### PR TITLE
P2: extract agent-service behind the gateway

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -69,7 +69,7 @@ docker_build(
     ],
 )
 
-k8s_yaml(['k8s/web-app.yaml', 'k8s/agent-service.yaml'])
+k8s_yaml(['k8s/web-app.yaml', 'k8s/agent-service.yaml', 'k8s/web-app-hpa.yaml', 'k8s/agent-service-hpa.yaml'])
 k8s_resource(
     'web-app',
     port_forwards=['3000:3000', '5173:5173'],

--- a/Tiltfile
+++ b/Tiltfile
@@ -15,6 +15,7 @@ type: Opaque
 stringData:
   jwt-secret: dev-jwt-secret-not-for-production
   encryption-key: dev-encryption-key-not-for-prod
+  agent-service-shared-secret: dev-agent-service-secret
 """))
 
 # ── k8s Infrastructure ──
@@ -52,10 +53,31 @@ docker_build(
     ],
 )
 
-k8s_yaml('k8s/web-app.yaml')
+docker_build(
+    'goldilocks-agent-service',
+    '.',
+    dockerfile='deploy/docker/Dockerfile.agent-service.dev',
+    live_update=[
+        fall_back_on([
+            './package.json',
+            './server/package.json',
+            './agent-service/package.json',
+            './package-lock.json',
+        ]),
+        sync('./agent-service/src', '/app/agent-service/src'),
+        sync('./server/src', '/app/server/src'),
+    ],
+)
+
+k8s_yaml(['k8s/web-app.yaml', 'k8s/agent-service.yaml'])
 k8s_resource(
     'web-app',
     port_forwards=['3000:3000', '5173:5173'],
+    labels=['app'],
+)
+k8s_resource(
+    'agent-service',
+    port_forwards=['3001:3001'],
     labels=['app'],
 )
 

--- a/agent-service/package.json
+++ b/agent-service/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "goldilocks-agent-service",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/agent-service/src/index.js",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc",
+    "start": "node dist/agent-service/src/index.js",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint src/"
+  },
+  "dependencies": {
+    "@kubernetes/client-node": "^1.4.0",
+    "@mariozechner/pi-coding-agent": "^0.64.0",
+    "better-sqlite3": "^11.9.1",
+    "dotenv": "^16.5.0",
+    "express": "^5.1.0",
+    "ws": "^8.18.2"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.12",
+    "@types/express": "^5.0.2",
+    "@types/node": "^22.15.3",
+    "@types/ws": "^8.18.1",
+    "tsx": "^4.19.4",
+    "typescript": "^5.8.3"
+  }
+}

--- a/agent-service/src/index.ts
+++ b/agent-service/src/index.ts
@@ -6,6 +6,15 @@ import { CONFIG } from '../../server/src/config.js';
 import { getDb, runMigrations, closeDb } from '../../server/src/db.js';
 import { sessionManager, type SessionEvent } from '../../server/src/agent/sessions.js';
 import type { ClientMessage, HistoryMessage, ServerMessage } from '../../server/src/shared/types.js';
+import {
+  gatewayConnectionClosed,
+  gatewayConnectionOpened,
+  getMetrics,
+  internalAuthFailed,
+  promptFinished,
+  promptStarted,
+  websocketErrored,
+} from './metrics.js';
 
 interface InternalAuthRequest extends express.Request {
   internalUserId?: string;
@@ -204,6 +213,7 @@ function verifyInternalRequest(req: InternalAuthRequest, res: Response, next: ex
   const userId = req.header('x-goldilocks-user');
 
   if (sharedSecret !== CONFIG.agentServiceSharedSecret || !userId) {
+    internalAuthFailed();
     res.status(401).json({ error: 'Unauthorized internal request' });
     return;
   }
@@ -216,6 +226,22 @@ const app = express();
 app.use(express.json());
 app.get('/api/health', (_req, res) => {
   res.json({ status: 'ok', service: 'agent-service', timestamp: Date.now() });
+});
+
+app.get('/api/ready', (_req, res) => {
+  try {
+    getDb().prepare('SELECT 1').get();
+    res.json({ status: 'ready', dependencies: { db: 'ok' } });
+  } catch (err) {
+    res.status(503).json({
+      status: 'degraded',
+      error: err instanceof Error ? err.message : 'Readiness check failed',
+    });
+  }
+});
+
+app.get('/api/metrics', (_req, res) => {
+  res.json(getMetrics());
 });
 
 app.get('/internal/models', verifyInternalRequest, async (req: InternalAuthRequest, res: Response) => {
@@ -264,6 +290,7 @@ const server = createServer(app);
 const wss = new WebSocketServer({ server, path: '/ws' });
 
 wss.on('connection', (ws: WebSocket, _req: IncomingMessage) => {
+  gatewayConnectionOpened();
   const state: InternalWsState = {
     userId: null,
     conversationId: null,
@@ -294,6 +321,7 @@ wss.on('connection', (ws: WebSocket, _req: IncomingMessage) => {
     try {
       if (msg.type === 'auth' && 'gatewayToken' in msg) {
         if (msg.gatewayToken !== CONFIG.agentServiceSharedSecret) {
+          internalAuthFailed();
           send(ws, { type: 'auth_fail', error: 'Invalid gateway token' });
           return;
         }
@@ -348,6 +376,7 @@ wss.on('connection', (ws: WebSocket, _req: IncomingMessage) => {
           }
 
           state.isProcessing = true;
+          promptStarted();
           const db = getDb();
           const conv = db.prepare('SELECT title FROM conversations WHERE id = ?').get(state.conversationId) as { title: string } | undefined;
           if (conv?.title === 'New conversation' && msg.text.trim()) {
@@ -361,6 +390,7 @@ wss.on('connection', (ws: WebSocket, _req: IncomingMessage) => {
             await sessionManager.prompt(state.userId, state.conversationId, msg.text);
           } finally {
             state.isProcessing = false;
+            promptFinished();
           }
           break;
         }
@@ -379,25 +409,39 @@ wss.on('connection', (ws: WebSocket, _req: IncomingMessage) => {
     }
   });
 
-  ws.on('close', cleanup);
+  ws.on('close', () => {
+    gatewayConnectionClosed();
+    cleanup();
+  });
   ws.on('error', (err) => {
     console.error('Agent service websocket error:', err);
+    websocketErrored();
     cleanup();
   });
 });
 
-function shutdown() {
+let shuttingDown = false;
+async function shutdown() {
+  if (shuttingDown) return;
+  shuttingDown = true;
   console.log('\nShutting down agent service...');
-  sessionManager.shutdown();
+
+  wss.close();
+  await sessionManager.shutdown();
   closeDb();
-  server.close(() => {
-    console.log('Agent service closed');
-    process.exit(0);
+  await new Promise<void>((resolve, reject) => {
+    server.close((err) => {
+      if (err) reject(err);
+      else resolve();
+    });
   });
+
+  console.log('Agent service closed');
+  process.exit(0);
 }
 
-process.on('SIGINT', shutdown);
-process.on('SIGTERM', shutdown);
+process.on('SIGINT', () => { void shutdown(); });
+process.on('SIGTERM', () => { void shutdown(); });
 
 async function main() {
   runMigrations();

--- a/agent-service/src/index.ts
+++ b/agent-service/src/index.ts
@@ -1,0 +1,412 @@
+import express, { Response } from 'express';
+import { createServer } from 'http';
+import { IncomingMessage } from 'http';
+import { WebSocket, WebSocketServer } from 'ws';
+import { CONFIG } from '../../server/src/config.js';
+import { getDb, runMigrations, closeDb } from '../../server/src/db.js';
+import { sessionManager, type SessionEvent } from '../../server/src/agent/sessions.js';
+import type { ClientMessage, HistoryMessage, ServerMessage } from '../../server/src/shared/types.js';
+
+interface InternalAuthRequest extends express.Request {
+  internalUserId?: string;
+}
+
+interface InternalWsState {
+  userId: string | null;
+  conversationId: string | null;
+  unsubscribe: (() => void) | null;
+  isProcessing: boolean;
+  receivedTextDelta: boolean;
+  currentToolCallId: string | null;
+  toolCallIdMap: Map<string, string>;
+}
+
+interface GatewayAuthMessage {
+  type: 'auth';
+  userId: string;
+  gatewayToken: string;
+}
+
+function send(ws: WebSocket, msg: ServerMessage): void {
+  if (ws.readyState !== WebSocket.OPEN) return;
+  ws.send(JSON.stringify(msg));
+}
+
+function mapSessionEvent(event: SessionEvent, ws: WebSocket, state: InternalWsState): void {
+  switch (event.type) {
+    case 'message_update': {
+      const delta = event.assistantMessageEvent as {
+        type?: string;
+        delta?: string;
+        toolCall?: { id?: string; name?: string; arguments?: string };
+        partial?: { id?: string; name?: string; arguments?: string };
+      } | undefined;
+      if (!delta) break;
+
+      if (delta.type === 'text_delta' && delta.delta) {
+        state.receivedTextDelta = true;
+        send(ws, { type: 'text_delta', delta: delta.delta });
+      } else if (delta.type === 'thinking_delta' && delta.delta) {
+        send(ws, { type: 'thinking_delta', delta: delta.delta });
+      } else if (delta.type === 'toolcall_start') {
+        const tc = delta.partial ?? delta.toolCall;
+        const toolCallId = tc?.id ?? `tc_${Date.now()}`;
+        state.currentToolCallId = toolCallId;
+        send(ws, {
+          type: 'tool_start',
+          toolName: tc?.name ?? 'unknown',
+          toolCallId,
+          args: {},
+        });
+      } else if (delta.type === 'toolcall_delta' && delta.delta && state.currentToolCallId) {
+        send(ws, {
+          type: 'tool_update',
+          toolCallId: state.currentToolCallId,
+          content: delta.delta,
+        });
+      } else if (delta.type === 'toolcall_end') {
+        const tc = delta.toolCall;
+        if (tc && state.currentToolCallId) {
+          let args: unknown = {};
+          try {
+            args = tc.arguments ? JSON.parse(tc.arguments) : {};
+          } catch {
+            args = { raw: tc.arguments };
+          }
+          send(ws, {
+            type: 'tool_start',
+            toolName: tc.name ?? 'tool',
+            toolCallId: state.currentToolCallId,
+            args,
+          });
+        }
+      }
+      break;
+    }
+
+    case 'message_end': {
+      if (!state.receivedTextDelta) {
+        const msg = event.message as {
+          role?: string;
+          content?: Array<{ type: string; text?: string }>;
+        } | undefined;
+        if (msg?.role === 'assistant' && Array.isArray(msg.content)) {
+          const fullText = msg.content
+            .filter((block) => block.type === 'text')
+            .map((block) => block.text ?? '')
+            .join('');
+          if (fullText) {
+            send(ws, { type: 'text_delta', delta: fullText });
+          }
+        }
+      }
+      state.receivedTextDelta = false;
+      send(ws, { type: 'message_end' });
+      break;
+    }
+
+    case 'tool_execution_start': {
+      const execId = event.toolCallId as string;
+      if (state.currentToolCallId && execId) {
+        state.toolCallIdMap.set(execId, state.currentToolCallId);
+        state.currentToolCallId = null;
+      }
+      break;
+    }
+
+    case 'tool_execution_end': {
+      const execId = event.toolCallId as string;
+      const mappedId = state.toolCallIdMap.get(execId) ?? execId;
+      state.toolCallIdMap.delete(execId);
+
+      let result = event.result;
+      if (result && typeof result === 'object' && Array.isArray((result as { content?: unknown[] }).content)) {
+        result = (result as { content: Array<{ type: string; text?: string }> }).content
+          .filter((block) => block.type === 'text')
+          .map((block) => block.text ?? '')
+          .join('');
+      }
+
+      send(ws, {
+        type: 'tool_end',
+        toolName: event.toolName as string,
+        toolCallId: mappedId,
+        result,
+        isError: (event.isError as boolean) ?? false,
+      });
+      break;
+    }
+
+    case 'agent_end':
+      send(ws, { type: 'agent_end' });
+      break;
+  }
+}
+
+function normalizeMessages(history: unknown[]): HistoryMessage[] {
+  const messages: HistoryMessage[] = [];
+
+  for (const entry of history as any[]) {
+    if (entry.role === 'user') {
+      const text = typeof entry.content === 'string'
+        ? entry.content
+        : Array.isArray(entry.content)
+          ? entry.content.filter((b: any) => b.type === 'text').map((b: any) => b.text ?? '').join('')
+          : '';
+      if (text) messages.push({ role: 'user', text });
+      continue;
+    }
+
+    if (entry.role === 'assistant' && Array.isArray(entry.content)) {
+      const text = entry.content
+        .filter((b: any) => b.type === 'text')
+        .map((b: any) => b.text ?? '')
+        .join('');
+      const toolCalls = entry.content
+        .filter((b: any) => b.type === 'toolCall')
+        .map((b: any) => ({
+          toolCallId: b.id ?? '',
+          toolName: b.name ?? 'tool',
+          args: b.arguments
+            ? typeof b.arguments === 'string'
+              ? (() => { try { return JSON.parse(b.arguments); } catch { return { raw: b.arguments }; } })()
+              : b.arguments
+            : {},
+        }));
+
+      if (text || toolCalls.length > 0) {
+        messages.push({ role: 'assistant', text, toolCalls });
+      }
+      continue;
+    }
+
+    if (entry.role === 'toolResult') {
+      const prev = messages[messages.length - 1];
+      if (prev?.role === 'assistant' && prev.toolCalls) {
+        const toolCall = prev.toolCalls.find((candidate) => candidate.toolCallId === entry.toolCallId);
+        if (toolCall) {
+          toolCall.result = Array.isArray(entry.content)
+            ? entry.content.filter((b: any) => b.type === 'text').map((b: any) => b.text ?? '').join('')
+            : typeof entry.content === 'string'
+              ? entry.content
+              : '';
+          toolCall.isError = entry.isError ?? false;
+        }
+      }
+    }
+  }
+
+  return messages;
+}
+
+function verifyInternalRequest(req: InternalAuthRequest, res: Response, next: express.NextFunction): void {
+  const sharedSecret = req.header('x-goldilocks-shared-secret');
+  const userId = req.header('x-goldilocks-user');
+
+  if (sharedSecret !== CONFIG.agentServiceSharedSecret || !userId) {
+    res.status(401).json({ error: 'Unauthorized internal request' });
+    return;
+  }
+
+  req.internalUserId = userId;
+  next();
+}
+
+const app = express();
+app.use(express.json());
+app.get('/api/health', (_req, res) => {
+  res.json({ status: 'ok', service: 'agent-service', timestamp: Date.now() });
+});
+
+app.get('/internal/models', verifyInternalRequest, async (req: InternalAuthRequest, res: Response) => {
+  try {
+    const result = await sessionManager.getAvailableModels(req.internalUserId!);
+    res.json(result);
+  } catch (err) {
+    console.error('Internal models fetch failed:', err);
+    res.status(500).json({ error: 'Failed to fetch models' });
+  }
+});
+
+app.post('/internal/models/select', verifyInternalRequest, async (req: InternalAuthRequest, res: Response) => {
+  const { modelId } = req.body as { modelId?: string };
+  if (!modelId) {
+    res.status(400).json({ error: 'modelId is required' });
+    return;
+  }
+
+  try {
+    await sessionManager.setModel(req.internalUserId!, modelId);
+    res.json({ ok: true, modelId });
+  } catch (err) {
+    console.error('Internal set model failed:', err);
+    res.status(500).json({ error: 'Failed to set model' });
+  }
+});
+
+app.post('/internal/sessions/delete', verifyInternalRequest, async (req: InternalAuthRequest, res: Response) => {
+  const { sessionPath } = req.body as { sessionPath?: string };
+  if (!sessionPath) {
+    res.status(400).json({ error: 'sessionPath is required' });
+    return;
+  }
+
+  try {
+    await sessionManager.deleteConversation(req.internalUserId!, sessionPath);
+    res.json({ ok: true });
+  } catch (err) {
+    console.error('Internal delete session failed:', err);
+    res.status(500).json({ error: 'Failed to delete session' });
+  }
+});
+
+const server = createServer(app);
+const wss = new WebSocketServer({ server, path: '/ws' });
+
+wss.on('connection', (ws: WebSocket, _req: IncomingMessage) => {
+  const state: InternalWsState = {
+    userId: null,
+    conversationId: null,
+    unsubscribe: null,
+    isProcessing: false,
+    receivedTextDelta: false,
+    currentToolCallId: null,
+    toolCallIdMap: new Map(),
+  };
+
+  const cleanup = () => {
+    if (state.unsubscribe) {
+      state.unsubscribe();
+      state.unsubscribe = null;
+    }
+    state.conversationId = null;
+  };
+
+  ws.on('message', async (raw) => {
+    let msg: ClientMessage | GatewayAuthMessage;
+    try {
+      msg = JSON.parse(raw.toString()) as ClientMessage | GatewayAuthMessage;
+    } catch {
+      send(ws, { type: 'error', error: 'Invalid JSON' });
+      return;
+    }
+
+    try {
+      if (msg.type === 'auth' && 'gatewayToken' in msg) {
+        if (msg.gatewayToken !== CONFIG.agentServiceSharedSecret) {
+          send(ws, { type: 'auth_fail', error: 'Invalid gateway token' });
+          return;
+        }
+        state.userId = msg.userId;
+        send(ws, { type: 'auth_ok', userId: msg.userId });
+        return;
+      }
+
+      if (!state.userId) {
+        send(ws, { type: 'error', error: 'Not authenticated' });
+        return;
+      }
+
+      switch (msg.type) {
+        case 'open': {
+          cleanup();
+          state.conversationId = msg.conversationId;
+
+          const db = getDb();
+          const row = db.prepare(
+            'SELECT pi_session_id FROM conversations WHERE id = ? AND user_id = ?'
+          ).get(msg.conversationId, state.userId) as { pi_session_id: string | null } | undefined;
+
+          if (!row) {
+            send(ws, { type: 'error', error: 'Conversation not found' });
+            return;
+          }
+
+          const unsubscribe = await sessionManager.subscribe(state.userId, (event: SessionEvent) => {
+            mapSessionEvent(event, ws, state);
+          });
+          state.unsubscribe = unsubscribe;
+
+          const sessionPath = await sessionManager.switchSession(state.userId, row.pi_session_id);
+          if (!row.pi_session_id && sessionPath) {
+            db.prepare('UPDATE conversations SET pi_session_id = ? WHERE id = ?').run(sessionPath, msg.conversationId);
+          }
+
+          const history = await sessionManager.getMessages(state.userId);
+          send(ws, { type: 'ready', conversationId: msg.conversationId, messages: normalizeMessages(history) });
+          break;
+        }
+
+        case 'prompt': {
+          if (!state.conversationId) {
+            send(ws, { type: 'error', error: 'No active session' });
+            return;
+          }
+          if (state.isProcessing) {
+            send(ws, { type: 'error', error: 'Already processing a prompt' });
+            return;
+          }
+
+          state.isProcessing = true;
+          const db = getDb();
+          const conv = db.prepare('SELECT title FROM conversations WHERE id = ?').get(state.conversationId) as { title: string } | undefined;
+          if (conv?.title === 'New conversation' && msg.text.trim()) {
+            const title = msg.text.trim().slice(0, 50).replace(/\s+/g, ' ');
+            db.prepare('UPDATE conversations SET title = ?, updated_at = ? WHERE id = ?').run(title, Date.now(), state.conversationId);
+          } else {
+            db.prepare('UPDATE conversations SET updated_at = ? WHERE id = ?').run(Date.now(), state.conversationId);
+          }
+
+          try {
+            await sessionManager.prompt(state.userId, msg.text);
+          } finally {
+            state.isProcessing = false;
+          }
+          break;
+        }
+
+        case 'abort': {
+          if (state.isProcessing) {
+            await sessionManager.abort(state.userId);
+            state.isProcessing = false;
+          }
+          break;
+        }
+      }
+    } catch (err) {
+      console.error('Agent service WebSocket handler error:', err);
+      send(ws, { type: 'error', error: err instanceof Error ? err.message : 'Internal agent-service error' });
+    }
+  });
+
+  ws.on('close', cleanup);
+  ws.on('error', (err) => {
+    console.error('Agent service websocket error:', err);
+    cleanup();
+  });
+});
+
+function shutdown() {
+  console.log('\nShutting down agent service...');
+  sessionManager.shutdown();
+  closeDb();
+  server.close(() => {
+    console.log('Agent service closed');
+    process.exit(0);
+  });
+}
+
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);
+
+async function main() {
+  runMigrations();
+  server.listen(3001, () => {
+    console.log('🕸️  Goldilocks agent service running on http://localhost:3001');
+  });
+}
+
+main().catch((err) => {
+  console.error('Failed to start agent service:', err);
+  process.exit(1);
+});

--- a/agent-service/src/index.ts
+++ b/agent-service/src/index.ts
@@ -13,6 +13,7 @@ import {
   internalAuthFailed,
   promptFinished,
   promptStarted,
+  recordTtft,
   websocketErrored,
 } from './metrics.js';
 
@@ -28,6 +29,7 @@ interface InternalWsState {
   receivedTextDelta: boolean;
   currentToolCallId: string | null;
   toolCallIdMap: Map<string, string>;
+  promptSentAt: number | null;
 }
 
 interface GatewayAuthMessage {
@@ -53,9 +55,17 @@ function mapSessionEvent(event: SessionEvent, ws: WebSocket, state: InternalWsSt
       if (!delta) break;
 
       if (delta.type === 'text_delta' && delta.delta) {
+        if (state.promptSentAt !== null) {
+          recordTtft(Date.now() - state.promptSentAt);
+          state.promptSentAt = null;
+        }
         state.receivedTextDelta = true;
         send(ws, { type: 'text_delta', delta: delta.delta });
       } else if (delta.type === 'thinking_delta' && delta.delta) {
+        if (state.promptSentAt !== null) {
+          recordTtft(Date.now() - state.promptSentAt);
+          state.promptSentAt = null;
+        }
         send(ws, { type: 'thinking_delta', delta: delta.delta });
       } else if (delta.type === 'toolcall_start') {
         const tc = delta.partial ?? delta.toolCall;
@@ -94,6 +104,11 @@ function mapSessionEvent(event: SessionEvent, ws: WebSocket, state: InternalWsSt
     }
 
     case 'message_end': {
+      if (state.promptSentAt !== null) {
+        recordTtft(Date.now() - state.promptSentAt);
+        state.promptSentAt = null;
+      }
+
       if (!state.receivedTextDelta) {
         const msg = event.message as {
           role?: string;
@@ -244,6 +259,35 @@ app.get('/api/metrics', (_req, res) => {
   res.json(getMetrics());
 });
 
+app.post('/internal/prewarm', verifyInternalRequest, async (req: InternalAuthRequest, res: Response) => {
+  const { conversationId } = req.body as { conversationId?: string };
+  if (!conversationId) {
+    res.status(400).json({ error: 'conversationId is required' });
+    return;
+  }
+
+  try {
+    const db = getDb();
+    const row = db.prepare(
+      'SELECT pi_session_id FROM conversations WHERE id = ? AND user_id = ?'
+    ).get(conversationId, req.internalUserId) as { pi_session_id: string | null } | undefined;
+
+    if (!row) {
+      res.status(404).json({ error: 'Conversation not found' });
+      return;
+    }
+
+    if (row.pi_session_id) {
+      await sessionManager.switchSession(req.internalUserId!, conversationId, row.pi_session_id);
+    }
+
+    res.json({ ok: true, conversationId });
+  } catch (err) {
+    console.error('Prewarm failed:', err);
+    res.status(500).json({ error: 'Prewarm failed' });
+  }
+});
+
 app.get('/internal/models', verifyInternalRequest, async (req: InternalAuthRequest, res: Response) => {
   try {
     const result = await sessionManager.getAvailableModels(req.internalUserId!);
@@ -299,6 +343,7 @@ wss.on('connection', (ws: WebSocket, _req: IncomingMessage) => {
     receivedTextDelta: false,
     currentToolCallId: null,
     toolCallIdMap: new Map(),
+    promptSentAt: null as number | null,
   };
 
   const cleanup = () => {
@@ -376,6 +421,7 @@ wss.on('connection', (ws: WebSocket, _req: IncomingMessage) => {
           }
 
           state.isProcessing = true;
+          state.promptSentAt = Date.now();
           promptStarted();
           const db = getDb();
           const conv = db.prepare('SELECT title FROM conversations WHERE id = ?').get(state.conversationId) as { title: string } | undefined;

--- a/agent-service/src/index.ts
+++ b/agent-service/src/index.ts
@@ -68,6 +68,11 @@ function mapSessionEvent(event: SessionEvent, ws: WebSocket, state: InternalWsSt
         }
         send(ws, { type: 'thinking_delta', delta: delta.delta });
       } else if (delta.type === 'toolcall_start') {
+        if (state.promptSentAt !== null) {
+          recordTtft(Date.now() - state.promptSentAt);
+          state.promptSentAt = null;
+        }
+
         const tc = delta.partial ?? delta.toolCall;
         const toolCallId = tc?.id ?? `tc_${Date.now()}`;
         state.currentToolCallId = toolCallId;

--- a/agent-service/src/metrics.ts
+++ b/agent-service/src/metrics.ts
@@ -5,7 +5,10 @@ const metrics = {
   promptCount: 0,
   internalAuthFailures: 0,
   websocketErrors: 0,
+  ttftSamples: [] as number[],
 };
+
+const TTFT_MAX_SAMPLES = 1000;
 
 export function gatewayConnectionOpened(): void {
   metrics.gatewayConnections += 1;
@@ -25,6 +28,13 @@ export function promptFinished(): void {
   metrics.activePrompts = Math.max(0, metrics.activePrompts - 1);
 }
 
+export function recordTtft(durationMs: number): void {
+  metrics.ttftSamples.push(durationMs);
+  if (metrics.ttftSamples.length > TTFT_MAX_SAMPLES) {
+    metrics.ttftSamples.shift();
+  }
+}
+
 export function internalAuthFailed(): void {
   metrics.internalAuthFailures += 1;
 }
@@ -34,5 +44,22 @@ export function websocketErrored(): void {
 }
 
 export function getMetrics() {
-  return { ...metrics };
+  const samples = metrics.ttftSamples;
+  const sorted = [...samples].sort((a, b) => a - b);
+  const p50 = sorted.length > 0 ? sorted[Math.floor(sorted.length / 2)] : 0;
+  const p95 = sorted.length > 0 ? sorted[Math.floor(sorted.length * 0.95)] : 0;
+  const p99 = sorted.length > 0 ? sorted[Math.floor(sorted.length * 0.99)] : 0;
+
+  return {
+    gatewayConnections: metrics.gatewayConnections,
+    activeGatewayConnections: metrics.activeGatewayConnections,
+    activePrompts: metrics.activePrompts,
+    promptCount: metrics.promptCount,
+    internalAuthFailures: metrics.internalAuthFailures,
+    websocketErrors: metrics.websocketErrors,
+    ttftCount: samples.length,
+    ttftP50Ms: p50,
+    ttftP95Ms: p95,
+    ttftP99Ms: p99,
+  };
 }

--- a/agent-service/src/metrics.ts
+++ b/agent-service/src/metrics.ts
@@ -1,0 +1,38 @@
+const metrics = {
+  gatewayConnections: 0,
+  activeGatewayConnections: 0,
+  activePrompts: 0,
+  promptCount: 0,
+  internalAuthFailures: 0,
+  websocketErrors: 0,
+};
+
+export function gatewayConnectionOpened(): void {
+  metrics.gatewayConnections += 1;
+  metrics.activeGatewayConnections += 1;
+}
+
+export function gatewayConnectionClosed(): void {
+  metrics.activeGatewayConnections = Math.max(0, metrics.activeGatewayConnections - 1);
+}
+
+export function promptStarted(): void {
+  metrics.promptCount += 1;
+  metrics.activePrompts += 1;
+}
+
+export function promptFinished(): void {
+  metrics.activePrompts = Math.max(0, metrics.activePrompts - 1);
+}
+
+export function internalAuthFailed(): void {
+  metrics.internalAuthFailures += 1;
+}
+
+export function websocketErrored(): void {
+  metrics.websocketErrors += 1;
+}
+
+export function getMetrics() {
+  return { ...metrics };
+}

--- a/agent-service/tsconfig.json
+++ b/agent-service/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": ".."
+  },
+  "include": ["src/**/*", "../server/src/**/*"]
+}

--- a/deploy/docker/Dockerfile.agent-service.dev
+++ b/deploy/docker/Dockerfile.agent-service.dev
@@ -1,0 +1,17 @@
+FROM node:22-alpine
+
+RUN apk add --no-cache python3 make g++
+
+WORKDIR /app
+
+COPY package*.json ./
+COPY server/package*.json ./server/
+COPY agent-service/package*.json ./agent-service/
+COPY frontend/package*.json ./frontend/
+RUN npm install
+
+COPY . .
+
+ENV NODE_ENV=development
+WORKDIR /app
+CMD ["npm", "run", "dev", "-w", "agent-service"]

--- a/k8s/agent-service-hpa.yaml
+++ b/k8s/agent-service-hpa.yaml
@@ -1,3 +1,8 @@
+# NOTE: The active_prompts custom metric requires a Prometheus adapter
+# (e.g. prometheus-adapter) configured to scrape /api/metrics from
+# agent-service pods. Without it, k8s cannot discover this metric
+# and the HPA will report MissingMetrics. Either deploy the adapter
+# or remove the Pods metric and rely on CPU/memory alone.
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/k8s/agent-service-hpa.yaml
+++ b/k8s/agent-service-hpa.yaml
@@ -1,0 +1,26 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: agent-service-hpa
+  namespace: goldilocks
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: agent-service
+  minReplicas: 1
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+    - type: Pods
+      pods:
+        metric:
+          name: active_prompts
+        target:
+          type: AverageValue
+          averageValue: "10"

--- a/k8s/agent-service.yaml
+++ b/k8s/agent-service.yaml
@@ -74,9 +74,9 @@ spec:
             periodSeconds: 30
           lifecycle:
             preStop:
-              httpGet:
-                path: /api/health
-                port: http
+              exec:
+                command: ['sh', '-c', 'sleep 5']
+          terminationGracePeriodSeconds: 30
 
       volumes:
         - name: data

--- a/k8s/agent-service.yaml
+++ b/k8s/agent-service.yaml
@@ -1,46 +1,38 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: web-app
+  name: agent-service
   namespace: goldilocks
   labels:
-    app.kubernetes.io/name: web-app
-    app.kubernetes.io/component: frontend
+    app.kubernetes.io/name: agent-service
+    app.kubernetes.io/component: agent
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: web-app
+      app: agent-service
   template:
     metadata:
       labels:
-        app: web-app
-        role: frontend
+        app: agent-service
+        role: agent-service
     spec:
       serviceAccountName: agent-manager
       containers:
-        - name: web-app
-          image: goldilocks-web
+        - name: agent-service
+          image: goldilocks-agent-service
           ports:
-            - containerPort: 3000
+            - containerPort: 3001
               name: http
-            - containerPort: 5173
-              name: vite
           env:
             - name: NODE_ENV
               value: development
-            - name: PORT
-              value: "3000"
-            - name: K8S_NAMESPACE
-              value: goldilocks
             - name: DATA_DIR
               value: /data
+            - name: K8S_NAMESPACE
+              value: goldilocks
             - name: AGENT_IMAGE
               value: goldilocks-agent:latest
-            - name: AGENT_SERVICE_URL
-              value: http://agent-service:3001
-            - name: AGENT_SERVICE_WS_URL
-              value: ws://agent-service:3001/ws
             - name: AGENT_SERVICE_SHARED_SECRET
               valueFrom:
                 secretKeyRef:
@@ -56,7 +48,6 @@ spec:
                 secretKeyRef:
                   name: app-secrets
                   key: encryption-key
-
           volumeMounts:
             - name: data
               mountPath: /data
@@ -73,12 +64,6 @@ spec:
               port: http
             initialDelaySeconds: 5
             periodSeconds: 10
-          livenessProbe:
-            httpGet:
-              path: /api/health
-              port: http
-            initialDelaySeconds: 15
-            periodSeconds: 30
       volumes:
         - name: data
           hostPath:
@@ -88,15 +73,12 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: web-app
+  name: agent-service
   namespace: goldilocks
 spec:
   selector:
-    app: web-app
+    app: agent-service
   ports:
-    - port: 3000
-      targetPort: 3000
+    - port: 3001
+      targetPort: 3001
       name: http
-    - port: 5173
-      targetPort: 5173
-      name: vite

--- a/k8s/agent-service.yaml
+++ b/k8s/agent-service.yaml
@@ -60,10 +60,24 @@ spec:
               memory: 2Gi
           readinessProbe:
             httpGet:
+              path: /api/ready
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
               path: /api/health
               port: http
-            initialDelaySeconds: 5
-            periodSeconds: 10
+            initialDelaySeconds: 15
+            periodSeconds: 30
+          lifecycle:
+            preStop:
+              httpGet:
+                path: /api/health
+                port: http
+
       volumes:
         - name: data
           hostPath:
@@ -75,6 +89,11 @@ kind: Service
 metadata:
   name: agent-service
   namespace: goldilocks
+  annotations:
+    # Sticky routing ensures gateway connections land on the same agent-service pod
+    # for the lifetime of a WS session.
+    nginx.ingress.kubernetes.io/affinity: cookie
+    nginx.ingress.kubernetes.io/affinity-mode: persistent
 spec:
   selector:
     app: agent-service
@@ -82,3 +101,20 @@ spec:
     - port: 3001
       targetPort: 3001
       name: http
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: agent-service-ws
+  namespace: goldilocks
+spec:
+  selector:
+    app: agent-service
+  ports:
+    - port: 3001
+      targetPort: 3001
+      name: ws
+  sessionAffinity: ClientIP
+  sessionAffinityConfig:
+    clientIP:
+      timeoutSeconds: 3600

--- a/k8s/web-app-hpa.yaml
+++ b/k8s/web-app-hpa.yaml
@@ -1,0 +1,25 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: web-app-hpa
+  namespace: goldilocks
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: web-app
+  minReplicas: 2
+  maxReplicas: 10
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80

--- a/k8s/web-app.yaml
+++ b/k8s/web-app.yaml
@@ -83,9 +83,9 @@ spec:
             periodSeconds: 30
           lifecycle:
             preStop:
-              httpGet:
-                path: /api/health
-                port: http
+              exec:
+                command: ['sh', '-c', 'sleep 5']
+          terminationGracePeriodSeconds: 30
 
       volumes:
         - name: data

--- a/k8s/web-app.yaml
+++ b/k8s/web-app.yaml
@@ -69,16 +69,24 @@ spec:
               memory: 2Gi
           readinessProbe:
             httpGet:
-              path: /api/health
+              path: /api/ready
               port: http
-            initialDelaySeconds: 5
+            initialDelaySeconds: 10
             periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
           livenessProbe:
             httpGet:
               path: /api/health
               port: http
             initialDelaySeconds: 15
             periodSeconds: 30
+          lifecycle:
+            preStop:
+              httpGet:
+                path: /api/health
+                port: http
+
       volumes:
         - name: data
           hostPath:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "workspaces": [
         "server",
+        "agent-service",
         "frontend"
       ],
       "devDependencies": {
@@ -19,6 +20,26 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "agent-service": {
+      "name": "goldilocks-agent-service",
+      "version": "0.1.0",
+      "dependencies": {
+        "@kubernetes/client-node": "^1.4.0",
+        "@mariozechner/pi-coding-agent": "^0.64.0",
+        "better-sqlite3": "^11.9.1",
+        "dotenv": "^16.5.0",
+        "express": "^5.1.0",
+        "ws": "^8.18.2"
+      },
+      "devDependencies": {
+        "@types/better-sqlite3": "^7.6.12",
+        "@types/express": "^5.0.2",
+        "@types/node": "^22.15.3",
+        "@types/ws": "^8.18.1",
+        "tsx": "^4.19.4",
+        "typescript": "^5.8.3"
       }
     },
     "frontend": {
@@ -8427,6 +8448,10 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/goldilocks-agent-service": {
+      "resolved": "agent-service",
+      "link": true
     },
     "node_modules/goldilocks-frontend": {
       "resolved": "frontend",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "React web app with embedded pi agent for DFT input file generation",
   "workspaces": [
     "server",
+    "agent-service",
     "frontend"
   ],
   "scripts": {
@@ -13,12 +14,13 @@
     "dev:setup": "kind get clusters | grep -q goldilocks || kind create cluster --name goldilocks --config deploy/kind-config.yaml",
     "dev:reset": "kind delete cluster --name goldilocks",
     "dev:server": "npm run dev -w server",
+    "dev:agent-service": "npm run dev -w agent-service",
     "dev:frontend": "npm run dev -w frontend",
-    "dev:both": "concurrently \"PORT=3000 npm run dev -w server\" \"npm run dev -w frontend -- --host 0.0.0.0\"",
-    "build": "npm run build -w server && npm run build -w frontend",
+    "dev:both": "concurrently \"PORT=3000 npm run dev -w server\" \"npm run dev -w agent-service\" \"npm run dev -w frontend -- --host 0.0.0.0\"",
+    "build": "npm run build -w server && npm run build -w agent-service && npm run build -w frontend",
     "start": "npm run start -w server",
-    "lint": "npm run lint -w server && npm run lint -w frontend",
-    "typecheck": "npm run typecheck -w server && npm run typecheck -w frontend",
+    "lint": "npm run lint -w server && npm run lint -w agent-service && npm run lint -w frontend",
+    "typecheck": "npm run typecheck -w server && npm run typecheck -w agent-service && npm run typecheck -w frontend",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:ui": "vitest --ui",

--- a/server/src/agent/agent-service-client.ts
+++ b/server/src/agent/agent-service-client.ts
@@ -1,0 +1,15 @@
+import { CONFIG } from '../config.js';
+
+export async function agentServiceFetch(
+  path: string,
+  options: RequestInit & { userId: string },
+): Promise<Response> {
+  const headers = new Headers(options.headers ?? {});
+  headers.set('x-goldilocks-user', options.userId);
+  headers.set('x-goldilocks-shared-secret', CONFIG.agentServiceSharedSecret);
+
+  return fetch(`${CONFIG.agentServiceUrl}${path}`, {
+    ...options,
+    headers,
+  });
+}

--- a/server/src/agent/relay-metrics.ts
+++ b/server/src/agent/relay-metrics.ts
@@ -1,0 +1,42 @@
+const relayMetrics = {
+  browserConnections: 0,
+  activeBrowserConnections: 0,
+  agentConnections: 0,
+  activeAgentConnections: 0,
+  authAttempts: 0,
+  authFailures: 0,
+  relayErrors: 0,
+};
+
+export function recordBrowserConnectionOpened(): void {
+  relayMetrics.browserConnections += 1;
+  relayMetrics.activeBrowserConnections += 1;
+}
+
+export function recordBrowserConnectionClosed(): void {
+  relayMetrics.activeBrowserConnections = Math.max(0, relayMetrics.activeBrowserConnections - 1);
+}
+
+export function recordAgentConnectionOpened(): void {
+  relayMetrics.agentConnections += 1;
+  relayMetrics.activeAgentConnections += 1;
+}
+
+export function recordAgentConnectionClosed(): void {
+  relayMetrics.activeAgentConnections = Math.max(0, relayMetrics.activeAgentConnections - 1);
+}
+
+export function recordAuthAttempt(success: boolean): void {
+  relayMetrics.authAttempts += 1;
+  if (!success) {
+    relayMetrics.authFailures += 1;
+  }
+}
+
+export function recordRelayError(): void {
+  relayMetrics.relayErrors += 1;
+}
+
+export function getRelayMetrics() {
+  return { ...relayMetrics };
+}

--- a/server/src/agent/relay-metrics.ts
+++ b/server/src/agent/relay-metrics.ts
@@ -6,7 +6,10 @@ const relayMetrics = {
   authAttempts: 0,
   authFailures: 0,
   relayErrors: 0,
+  ttftSamples: [] as number[],
 };
+
+const TTFT_MAX_SAMPLES = 1000;
 
 export function recordBrowserConnectionOpened(): void {
   relayMetrics.browserConnections += 1;
@@ -37,6 +40,26 @@ export function recordRelayError(): void {
   relayMetrics.relayErrors += 1;
 }
 
+export function recordTtft(durationMs: number): void {
+  relayMetrics.ttftSamples.push(durationMs);
+  if (relayMetrics.ttftSamples.length > TTFT_MAX_SAMPLES) {
+    relayMetrics.ttftSamples.shift();
+  }
+}
+
 export function getRelayMetrics() {
-  return { ...relayMetrics };
+  const samples = relayMetrics.ttftSamples;
+  const sorted = [...samples].sort((a, b) => a - b);
+  const p50 = sorted.length > 0 ? sorted[Math.floor(sorted.length / 2)] : 0;
+  const p95 = sorted.length > 0 ? sorted[Math.floor(sorted.length * 0.95)] : 0;
+  const p99 = sorted.length > 0 ? sorted[Math.floor(sorted.length * 0.99)] : 0;
+
+  return {
+    ...relayMetrics,
+    ttftSamples: undefined,
+    ttftCount: samples.length,
+    ttftP50Ms: p50,
+    ttftP95Ms: p95,
+    ttftP99Ms: p99,
+  };
 }

--- a/server/src/agent/websocket.ts
+++ b/server/src/agent/websocket.ts
@@ -1,412 +1,133 @@
-/**
- * WebSocket handler — connects the React frontend to the in-process pi SDK session.
- *
- * Protocol (shared/types.ts):
- *   Client → Server: auth, open, prompt, abort
- *   Server → Client: auth_ok, auth_fail, ready, text_delta, thinking_delta,
- *                     tool_start, tool_update, tool_end, message_end, agent_end, error
- *
- * Each WebSocket connection maps to one user. Multiple tabs share the same SDK session.
- * Session events are fanned out to all connected WebSocket clients for that user.
- */
-
-import { WebSocket, WebSocketServer } from 'ws';
 import { IncomingMessage } from 'http';
 import jwt from 'jsonwebtoken';
+import { WebSocket, WebSocketServer } from 'ws';
 import { CONFIG } from '../config.js';
-import { sessionManager } from './sessions.js';
-import { getDb } from '../db.js';
-import type { SessionEvent } from './sessions.js';
-import type { ClientMessage, ServerMessage, HistoryMessage } from '../shared/types.js';
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
+import type { ClientMessage, ServerMessage } from '../shared/types.js';
 
 interface AuthUser {
   id: string;
   email: string;
 }
 
-interface ClientState {
-  user: AuthUser | null;
-  conversationId: string | null;
-  unsubscribe: (() => void) | null;
-  isProcessing: boolean;
-  /** Track whether text deltas were received for the current message. */
-  receivedTextDelta: boolean;
-  /** Track the current streaming tool call ID (from toolcall_start). */
-  currentToolCallId: string | null;
-  /** Map pi's execution toolCallId → our streaming toolCallId. */
-  toolCallIdMap: Map<string, string>;
+interface GatewayToAgentMessage {
+  type: 'auth';
+  userId: string;
+  gatewayToken: string;
 }
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
 
 function send(ws: WebSocket, msg: ServerMessage): void {
-  if (ws.readyState === WebSocket.OPEN) {
-    try {
-      ws.send(JSON.stringify(msg));
-    } catch (err) {
-      console.error('Failed to send WebSocket message:', err);
-    }
-  }
-}
-
-/**
- * Map an SDK session event to WebSocket messages for the frontend.
- *
- * Handles:
- *   - message_update (text_delta, thinking_delta)
- *   - message_end fallback (extracts text if no deltas were streamed)
- *   - tool_execution_start/update/end
- *   - message_end, agent_end
- */
-function mapBridgeEvent(event: SessionEvent, ws: WebSocket, state: ClientState): void {
+  if (ws.readyState !== WebSocket.OPEN) return;
   try {
-    switch (event.type) {
-      case 'message_update': {
-        const delta = event.assistantMessageEvent as {
-          type?: string;
-          delta?: string;
-          contentIndex?: number;
-          toolCall?: { id?: string; name?: string; arguments?: string };
-          partial?: { id?: string; name?: string; arguments?: string };
-        } | undefined;
-        if (!delta) break;
-
-        if (delta.type === 'text_delta' && delta.delta) {
-          state.receivedTextDelta = true;
-          send(ws, { type: 'text_delta', delta: delta.delta });
-        } else if (delta.type === 'thinking_delta' && delta.delta) {
-          send(ws, { type: 'thinking_delta', delta: delta.delta });
-        } else if (delta.type === 'toolcall_start') {
-          const tc = delta.partial ?? delta.toolCall;
-          const toolCallId = tc?.id ?? `tc_${Date.now()}`;
-          state.currentToolCallId = toolCallId;
-          send(ws, {
-            type: 'tool_start',
-            toolName: tc?.name ?? 'unknown',
-            toolCallId,
-            args: {},
-          });
-        } else if (delta.type === 'toolcall_delta' && delta.delta && state.currentToolCallId) {
-          send(ws, {
-            type: 'tool_update',
-            toolCallId: state.currentToolCallId,
-            content: delta.delta,
-          });
-        } else if (delta.type === 'toolcall_end') {
-          // Update the existing card with final parsed args and correct name
-          const tc = delta.toolCall;
-          if (tc && state.currentToolCallId) {
-            let args: unknown = {};
-            try {
-              args = tc.arguments ? JSON.parse(tc.arguments) : {};
-            } catch {
-              args = { raw: tc.arguments };
-            }
-            send(ws, {
-              type: 'tool_start',
-              toolName: tc.name ?? 'tool',
-              toolCallId: state.currentToolCallId,
-              args,
-            });
-          }
-          // Keep currentToolCallId alive for tool_execution_start to map it.
-        }
-        break;
-      }
-
-      case 'message_end': {
-        // Fallback: extract text from message_end ONLY if no deltas were streamed
-        if (!state.receivedTextDelta) {
-          const msg = event.message as {
-            role?: string;
-            content?: Array<{ type: string; text?: string }>;
-          } | undefined;
-          if (msg?.role === 'assistant' && Array.isArray(msg.content)) {
-            const textBlocks = msg.content.filter((b) => b.type === 'text');
-            const fullText = textBlocks.map((b) => b.text ?? '').join('');
-            if (fullText) {
-              send(ws, { type: 'text_delta', delta: fullText });
-            }
-          }
-        }
-        state.receivedTextDelta = false;
-        send(ws, { type: 'message_end' });
-        break;
-      }
-
-      case 'tool_execution_start': {
-        const execId = event.toolCallId as string;
-        if (state.currentToolCallId && execId) {
-          state.toolCallIdMap.set(execId, state.currentToolCallId);
-          state.currentToolCallId = null;
-        }
-        break;
-      }
-
-      case 'tool_execution_update':
-        // Skip — we already stream content via toolcall_delta during arg generation.
-        // tool_execution_update is the execution output, not the streamed args.
-        break;
-
-      case 'tool_execution_end': {
-        const execTcId = event.toolCallId as string;
-        const mappedId = state.toolCallIdMap.get(execTcId) ?? execTcId;
-        state.toolCallIdMap.delete(execTcId);
-
-        // Extract text from result (pi wraps it in {content: [{type: "text", text: "..."}]})
-        let result = event.result;
-        if (result && typeof result === 'object' && Array.isArray((result as any).content)) {
-          const textParts = (result as any).content
-            .filter((b: any) => b.type === 'text')
-            .map((b: any) => b.text ?? '');
-          result = textParts.join('');
-        }
-
-        send(ws, {
-          type: 'tool_end',
-          toolName: event.toolName as string,
-          toolCallId: mappedId,
-          result,
-          isError: event.isError as boolean ?? false,
-        });
-        break;
-      }
-
-      case 'agent_end':
-        send(ws, { type: 'agent_end' });
-        break;
-
-      // Ignore: agent_start, turn_start, turn_end, message_start — not needed by frontend
-    }
+    ws.send(JSON.stringify(msg));
   } catch (err) {
-    console.error('Error mapping bridge event:', err);
+    console.error('Failed to send WebSocket message:', err);
   }
 }
-
-// ---------------------------------------------------------------------------
-// WebSocket setup
-// ---------------------------------------------------------------------------
 
 export function setupWebSocket(wss: WebSocketServer): void {
-  wss.on('connection', (ws: WebSocket, _req: IncomingMessage) => {
-    console.log('WebSocket client connected');
+  wss.on('connection', (browserWs: WebSocket, _req: IncomingMessage) => {
+    let browserUser: AuthUser | null = null;
+    let agentWs: WebSocket | null = null;
+    let agentReady = false;
+    const pendingMessages: ClientMessage[] = [];
 
-    const state: ClientState = {
-      user: null,
-      conversationId: null,
-      unsubscribe: null,
-      isProcessing: false,
-      receivedTextDelta: false,
-      currentToolCallId: null,
-      toolCallIdMap: new Map(),
+    const flushPending = () => {
+      if (!agentWs || agentWs.readyState !== WebSocket.OPEN || !agentReady) return;
+      for (const msg of pendingMessages.splice(0)) {
+        agentWs.send(JSON.stringify(msg));
+      }
     };
 
     const cleanup = () => {
-      if (state.unsubscribe) {
-        try { state.unsubscribe(); } catch (err) {
-          console.error('Error unsubscribing:', err);
-        }
-        state.unsubscribe = null;
+      if (agentWs && agentWs.readyState === WebSocket.OPEN) {
+        agentWs.close();
       }
-      state.conversationId = null;
+      agentWs = null;
+      agentReady = false;
     };
 
-    ws.on('message', async (data) => {
+    browserWs.on('message', (raw) => {
       let msg: ClientMessage;
       try {
-        msg = JSON.parse(data.toString());
+        msg = JSON.parse(raw.toString()) as ClientMessage;
       } catch {
-        send(ws, { type: 'error', error: 'Invalid JSON' });
+        send(browserWs, { type: 'error', error: 'Invalid JSON' });
         return;
       }
 
-      try {
-        switch (msg.type) {
-          case 'auth': {
+      if (msg.type === 'auth') {
+        try {
+          const payload = jwt.verify(msg.token, CONFIG.jwtSecret) as AuthUser;
+          browserUser = payload;
+          agentWs = new WebSocket(CONFIG.agentServiceWsUrl);
+
+          agentWs.on('open', () => {
+            const authMessage: GatewayToAgentMessage = {
+              type: 'auth',
+              userId: payload.id,
+              gatewayToken: CONFIG.agentServiceSharedSecret,
+            };
+            agentWs?.send(JSON.stringify(authMessage));
+          });
+
+          agentWs.on('message', (agentRaw) => {
+            let agentMsg: ServerMessage;
             try {
-              const payload = jwt.verify(msg.token, CONFIG.jwtSecret) as AuthUser;
-              state.user = payload;
-              send(ws, { type: 'auth_ok', userId: payload.id });
+              agentMsg = JSON.parse(agentRaw.toString()) as ServerMessage;
             } catch {
-              send(ws, { type: 'auth_fail', error: 'Invalid or expired token' });
-            }
-            break;
-          }
-
-          case 'open': {
-            if (!state.user) {
-              send(ws, { type: 'error', error: 'Not authenticated' });
+              send(browserWs, { type: 'error', error: 'Invalid agent-service message' });
               return;
             }
 
-            cleanup();
+            if (agentMsg.type === 'auth_ok') {
+              agentReady = true;
+              send(browserWs, { type: 'auth_ok', userId: payload.id });
+              flushPending();
+              return;
+            }
 
-            try {
-              state.conversationId = msg.conversationId;
-
-              // Look up pi_session_id from DB
-              const db = getDb();
-              const row = db.prepare(
-                'SELECT pi_session_id FROM conversations WHERE id = ? AND user_id = ?'
-              ).get(msg.conversationId, state.user.id) as { pi_session_id: string | null } | undefined;
-
-              if (!row) {
-                send(ws, { type: 'error', error: 'Conversation not found' });
-                return;
-              }
-
-              // Subscribe to session events BEFORE switching session
-              const unsubscribe = await sessionManager.subscribe(state.user.id, (event: SessionEvent) => {
-                mapBridgeEvent(event, ws, state);
-              });
-              state.unsubscribe = unsubscribe;
-
-              // Switch to the pi session (or create if no pi_session_id yet)
-              const sessionPath = await sessionManager.switchSession(
-                state.user.id,
-                row.pi_session_id, // null on first open → creates new session
-              );
-
-              // Store the session path if this is a new conversation
-              if (!row.pi_session_id && sessionPath) {
-                db.prepare(
-                  'UPDATE conversations SET pi_session_id = ? WHERE id = ?'
-                ).run(sessionPath, msg.conversationId);
-              }
-
-              // Fetch message history from pi
-              let messages: HistoryMessage[] = [];
-              try {
-                const history = await sessionManager.getMessages(state.user.id);
-                // Pi may return { messages: [...] } or bare array
-                const msgList = Array.isArray(history) ? history
-                  : (history as Record<string, unknown>)?.messages;
-                if (Array.isArray(msgList)) {
-                  for (const m of msgList as any[]) {
-                    if (m.role === 'user') {
-                      const text = typeof m.content === 'string'
-                        ? m.content
-                        : Array.isArray(m.content)
-                          ? m.content.filter((b: any) => b.type === 'text').map((b: any) => b.text ?? '').join('')
-                          : '';
-                      if (text) messages.push({ role: 'user', text });
-                    } else if (m.role === 'assistant' && Array.isArray(m.content)) {
-                      // Extract text blocks
-                      const textParts = m.content.filter((b: any) => b.type === 'text').map((b: any) => b.text ?? '');
-                      const text = textParts.join('');
-                      // Extract tool calls
-                      const toolCalls = m.content
-                        .filter((b: any) => b.type === 'toolCall')
-                        .map((b: any) => ({
-                          toolCallId: b.id ?? '',
-                          toolName: b.name ?? 'tool',
-                          args: b.arguments ? (typeof b.arguments === 'string' ? (() => { try { return JSON.parse(b.arguments); } catch { return { raw: b.arguments }; } })() : b.arguments) : {},
-                        }));
-                      if (text || toolCalls.length > 0) {
-                        messages.push({ role: 'assistant', text, toolCalls });
-                      }
-                    } else if (m.role === 'toolResult') {
-                      // Attach tool results to the previous assistant message's tool call
-                      const prev = messages[messages.length - 1];
-                      if (prev?.role === 'assistant' && prev.toolCalls) {
-                        const tc = prev.toolCalls.find((t: any) => t.toolCallId === m.toolCallId);
-                        if (tc) {
-                          tc.result = Array.isArray(m.content)
-                            ? m.content.filter((b: any) => b.type === 'text').map((b: any) => b.text ?? '').join('')
-                            : typeof m.content === 'string' ? m.content : '';
-                          tc.isError = m.isError ?? false;
-                        }
-                      }
-                    }
-                  }
-                }
-              } catch (err) {
-                console.error('Failed to fetch messages:', err);
-              }
-
-              send(ws, { type: 'ready', conversationId: msg.conversationId, messages });
-            } catch (err) {
-              console.error('Failed to open session:', err);
-              const errorMsg = err instanceof Error ? err.message : 'Failed to open session';
-              send(ws, { type: 'error', error: errorMsg });
+            if (agentMsg.type === 'auth_fail') {
+              send(browserWs, agentMsg);
               cleanup();
-            }
-            break;
-          }
-
-          case 'prompt': {
-            if (!state.user || !state.conversationId) {
-              send(ws, { type: 'error', error: 'No active session' });
               return;
             }
 
-            if (state.isProcessing) {
-              send(ws, { type: 'error', error: 'Already processing a prompt' });
-              return;
+            send(browserWs, agentMsg);
+          });
+
+          agentWs.on('close', () => {
+            agentReady = false;
+            if (browserWs.readyState === WebSocket.OPEN) {
+              send(browserWs, { type: 'error', error: 'Agent service disconnected' });
             }
+          });
 
-            try {
-              state.isProcessing = true;
-              sessionManager.touch(state.user.id);
-
-              // Update conversation title from first message
-              const db = getDb();
-              const conv = db.prepare(
-                'SELECT title FROM conversations WHERE id = ?'
-              ).get(state.conversationId) as { title: string } | undefined;
-              if (conv?.title === 'New conversation' && msg.text.trim()) {
-                const title = msg.text.trim().slice(0, 50).replace(/\s+/g, ' ');
-                db.prepare(
-                  'UPDATE conversations SET title = ?, updated_at = ? WHERE id = ?'
-                ).run(title, Date.now(), state.conversationId);
-              } else {
-                db.prepare(
-                  'UPDATE conversations SET updated_at = ? WHERE id = ?'
-                ).run(Date.now(), state.conversationId);
-              }
-
-              await sessionManager.prompt(state.user.id, msg.text);
-            } catch (err) {
-              console.error('Prompt error:', err);
-              const errorMsg = err instanceof Error ? err.message : 'Failed to process prompt';
-              send(ws, { type: 'error', error: errorMsg });
-            } finally {
-              state.isProcessing = false;
-            }
-            break;
-          }
-
-          case 'abort': {
-            if (state.user && state.isProcessing) {
-              try {
-                await sessionManager.abort(state.user.id);
-              } catch (err) {
-                console.error('Abort error:', err);
-              }
-              state.isProcessing = false;
-            }
-            break;
-          }
+          agentWs.on('error', (err) => {
+            console.error('Agent service WebSocket error:', err);
+            send(browserWs, { type: 'error', error: 'Agent service connection error' });
+          });
+        } catch {
+          send(browserWs, { type: 'auth_fail', error: 'Invalid or expired token' });
         }
-      } catch (err) {
-        console.error('WebSocket message handler error:', err);
-        send(ws, { type: 'error', error: 'Internal server error' });
+        return;
       }
+
+      if (!browserUser) {
+        send(browserWs, { type: 'error', error: 'Not authenticated' });
+        return;
+      }
+
+      if (!agentWs || agentWs.readyState !== WebSocket.OPEN || !agentReady) {
+        pendingMessages.push(msg);
+        return;
+      }
+
+      agentWs.send(JSON.stringify(msg));
     });
 
-    ws.on('close', () => {
-      console.log('WebSocket client disconnected');
-      cleanup();
-    });
-
-    ws.on('error', (err) => {
-      console.error('WebSocket error:', err);
+    browserWs.on('close', cleanup);
+    browserWs.on('error', (err) => {
+      console.error('Browser WebSocket error:', err);
       cleanup();
     });
   });

--- a/server/src/agent/websocket.ts
+++ b/server/src/agent/websocket.ts
@@ -9,6 +9,7 @@ import {
   recordBrowserConnectionClosed,
   recordBrowserConnectionOpened,
   recordRelayError,
+  recordTtft,
 } from './relay-metrics.js';
 import type { ClientMessage, ServerMessage } from '../shared/types.js';
 
@@ -22,6 +23,9 @@ interface GatewayToAgentMessage {
   userId: string;
   gatewayToken: string;
 }
+
+const HEARTBEAT_INTERVAL_MS = 30_000;
+const HEARTBEAT_TIMEOUT_MS = 60_000;
 
 function send(ws: WebSocket, msg: ServerMessage): void {
   if (ws.readyState !== WebSocket.OPEN) return;
@@ -40,11 +44,27 @@ export function setupWebSocket(wss: WebSocketServer): void {
     let agentReady = false;
     let agentGeneration = 0;
     const pendingMessages: ClientMessage[] = [];
+    let promptSentAt: number | null = null;
+
+    // Browser keepalive
+    let browserAlive = true;
+    const browserHeartbeat = setInterval(() => {
+      if (browserWs.readyState !== WebSocket.OPEN) {
+        clearInterval(browserHeartbeat);
+        return;
+      }
+      browserWs.ping();
+    }, HEARTBEAT_INTERVAL_MS);
+
+    browserWs.on('pong', () => {
+      browserAlive = true;
+    });
 
     const cleanupAgentConnection = () => {
       agentGeneration += 1;
       agentReady = false;
       pendingMessages.length = 0;
+      promptSentAt = null;
       if (agentWs) {
         const ws = agentWs;
         agentWs = null;
@@ -84,6 +104,20 @@ export function setupWebSocket(wss: WebSocketServer): void {
           agentWs = nextAgentWs;
           recordAgentConnectionOpened();
 
+          // Agent keepalive
+          const agentHeartbeat = setInterval(() => {
+            if (nextAgentWs.readyState !== WebSocket.OPEN) {
+              clearInterval(agentHeartbeat);
+              return;
+            }
+            nextAgentWs.ping();
+          }, HEARTBEAT_INTERVAL_MS);
+
+          let agentAlive = true;
+          nextAgentWs.on('pong', () => {
+            agentAlive = true;
+          });
+
           nextAgentWs.on('open', () => {
             if (connectionGeneration !== agentGeneration) return;
             const authMessage: GatewayToAgentMessage = {
@@ -118,11 +152,25 @@ export function setupWebSocket(wss: WebSocketServer): void {
               return;
             }
 
+            // TTFT: record time from prompt send to first content delta
+            if (promptSentAt !== null) {
+              if (agentMsg.type === 'text_delta' || agentMsg.type === 'thinking_delta' || agentMsg.type === 'message_end') {
+                recordTtft(Date.now() - promptSentAt);
+                promptSentAt = null;
+              }
+            }
+
             send(browserWs, agentMsg);
           });
 
           nextAgentWs.on('close', () => {
-            if (connectionGeneration !== agentGeneration) return;
+            clearInterval(agentHeartbeat);
+            if (connectionGeneration !== agentGeneration) {
+              // Stale socket — counter already decremented by cleanupAgentConnection()
+              return;
+            }
+            // Spontaneous disconnect — counter was not decremented yet
+            recordAgentConnectionClosed();
             agentReady = false;
             agentWs = null;
             if (browserWs.readyState === WebSocket.OPEN) {
@@ -148,6 +196,11 @@ export function setupWebSocket(wss: WebSocketServer): void {
         return;
       }
 
+      // Track prompt send time for TTFT
+      if (msg.type === 'prompt') {
+        promptSentAt = Date.now();
+      }
+
       if (!agentWs || agentWs.readyState !== WebSocket.OPEN || !agentReady) {
         pendingMessages.push(msg);
         return;
@@ -157,10 +210,12 @@ export function setupWebSocket(wss: WebSocketServer): void {
     });
 
     browserWs.on('close', () => {
+      clearInterval(browserHeartbeat);
       recordBrowserConnectionClosed();
       cleanupAgentConnection();
     });
     browserWs.on('error', (err) => {
+      clearInterval(browserHeartbeat);
       console.error('Browser WebSocket error:', err);
       recordRelayError();
       cleanupAgentConnection();

--- a/server/src/agent/websocket.ts
+++ b/server/src/agent/websocket.ts
@@ -27,6 +27,11 @@ interface GatewayToAgentMessage {
 const HEARTBEAT_INTERVAL_MS = 30_000;
 const HEARTBEAT_TIMEOUT_MS = 60_000;
 
+// Events that count as "first meaningful output" for TTFT.
+// Includes toolcall_start so a model that immediately calls a tool
+// doesn't inflate TTFT to the full turn time.
+const TTFT_CLEAR_TYPES = new Set(['text_delta', 'thinking_delta', 'tool_start', 'message_end']);
+
 function send(ws: WebSocket, msg: ServerMessage): void {
   if (ws.readyState !== WebSocket.OPEN) return;
   try {
@@ -43,21 +48,30 @@ export function setupWebSocket(wss: WebSocketServer): void {
     let agentWs: WebSocket | null = null;
     let agentReady = false;
     let agentGeneration = 0;
+    let currentAgentHeartbeat: ReturnType<typeof setInterval> | null = null;
     const pendingMessages: ClientMessage[] = [];
     let promptSentAt: number | null = null;
 
-    // Browser keepalive
-    let browserAlive = true;
+    // ── Browser keepalive ──
+    // Ping every HEARTBEAT_INTERVAL_MS. If no pong arrives within
+    // HEARTBEAT_TIMEOUT_MS since the last pong, terminate the connection.
+    let browserLastPong = Date.now();
     const browserHeartbeat = setInterval(() => {
       if (browserWs.readyState !== WebSocket.OPEN) {
         clearInterval(browserHeartbeat);
         return;
       }
       browserWs.ping();
+
+      if (Date.now() - browserLastPong > HEARTBEAT_TIMEOUT_MS) {
+        console.warn('Browser WebSocket pong timeout — terminating connection');
+        browserWs.terminate();
+        clearInterval(browserHeartbeat);
+      }
     }, HEARTBEAT_INTERVAL_MS);
 
     browserWs.on('pong', () => {
-      browserAlive = true;
+      browserLastPong = Date.now();
     });
 
     const cleanupAgentConnection = () => {
@@ -65,6 +79,10 @@ export function setupWebSocket(wss: WebSocketServer): void {
       agentReady = false;
       pendingMessages.length = 0;
       promptSentAt = null;
+      if (currentAgentHeartbeat) {
+        clearInterval(currentAgentHeartbeat);
+        currentAgentHeartbeat = null;
+      }
       if (agentWs) {
         const ws = agentWs;
         agentWs = null;
@@ -104,18 +122,26 @@ export function setupWebSocket(wss: WebSocketServer): void {
           agentWs = nextAgentWs;
           recordAgentConnectionOpened();
 
-          // Agent keepalive
+          // ── Agent keepalive ──
+          // Same pattern: ping at interval, enforce pong timeout.
+          let agentLastPong = Date.now();
           const agentHeartbeat = setInterval(() => {
             if (nextAgentWs.readyState !== WebSocket.OPEN) {
               clearInterval(agentHeartbeat);
               return;
             }
             nextAgentWs.ping();
-          }, HEARTBEAT_INTERVAL_MS);
 
-          let agentAlive = true;
+            if (Date.now() - agentLastPong > HEARTBEAT_TIMEOUT_MS) {
+              console.warn('Agent service WebSocket pong timeout — closing connection');
+              nextAgentWs.terminate();
+              clearInterval(agentHeartbeat);
+            }
+          }, HEARTBEAT_INTERVAL_MS);
+          currentAgentHeartbeat = agentHeartbeat;
+
           nextAgentWs.on('pong', () => {
-            agentAlive = true;
+            agentLastPong = Date.now();
           });
 
           nextAgentWs.on('open', () => {
@@ -152,12 +178,10 @@ export function setupWebSocket(wss: WebSocketServer): void {
               return;
             }
 
-            // TTFT: record time from prompt send to first content delta
-            if (promptSentAt !== null) {
-              if (agentMsg.type === 'text_delta' || agentMsg.type === 'thinking_delta' || agentMsg.type === 'message_end') {
-                recordTtft(Date.now() - promptSentAt);
-                promptSentAt = null;
-              }
+            // TTFT: record time from prompt send to first meaningful output
+            if (promptSentAt !== null && TTFT_CLEAR_TYPES.has(agentMsg.type)) {
+              recordTtft(Date.now() - promptSentAt);
+              promptSentAt = null;
             }
 
             send(browserWs, agentMsg);
@@ -165,6 +189,9 @@ export function setupWebSocket(wss: WebSocketServer): void {
 
           nextAgentWs.on('close', () => {
             clearInterval(agentHeartbeat);
+            if (currentAgentHeartbeat === agentHeartbeat) {
+              currentAgentHeartbeat = null;
+            }
             if (connectionGeneration !== agentGeneration) {
               // Stale socket — counter already decremented by cleanupAgentConnection()
               return;

--- a/server/src/agent/websocket.ts
+++ b/server/src/agent/websocket.ts
@@ -2,6 +2,14 @@ import { IncomingMessage } from 'http';
 import jwt from 'jsonwebtoken';
 import { WebSocket, WebSocketServer } from 'ws';
 import { CONFIG } from '../config.js';
+import {
+  recordAgentConnectionClosed,
+  recordAgentConnectionOpened,
+  recordAuthAttempt,
+  recordBrowserConnectionClosed,
+  recordBrowserConnectionOpened,
+  recordRelayError,
+} from './relay-metrics.js';
 import type { ClientMessage, ServerMessage } from '../shared/types.js';
 
 interface AuthUser {
@@ -26,6 +34,7 @@ function send(ws: WebSocket, msg: ServerMessage): void {
 
 export function setupWebSocket(wss: WebSocketServer): void {
   wss.on('connection', (browserWs: WebSocket, _req: IncomingMessage) => {
+    recordBrowserConnectionOpened();
     let browserUser: AuthUser | null = null;
     let agentWs: WebSocket | null = null;
     let agentReady = false;
@@ -40,6 +49,7 @@ export function setupWebSocket(wss: WebSocketServer): void {
         const ws = agentWs;
         agentWs = null;
         ws.removeAllListeners();
+        recordAgentConnectionClosed();
         if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) {
           ws.close();
         }
@@ -67,10 +77,12 @@ export function setupWebSocket(wss: WebSocketServer): void {
 
         try {
           const payload = jwt.verify(msg.token, CONFIG.jwtSecret) as AuthUser;
+          recordAuthAttempt(true);
           browserUser = payload;
           const connectionGeneration = agentGeneration;
           const nextAgentWs = new WebSocket(CONFIG.agentServiceWsUrl);
           agentWs = nextAgentWs;
+          recordAgentConnectionOpened();
 
           nextAgentWs.on('open', () => {
             if (connectionGeneration !== agentGeneration) return;
@@ -121,9 +133,11 @@ export function setupWebSocket(wss: WebSocketServer): void {
           nextAgentWs.on('error', (err) => {
             if (connectionGeneration !== agentGeneration) return;
             console.error('Agent service WebSocket error:', err);
+            recordRelayError();
             send(browserWs, { type: 'error', error: 'Agent service connection error' });
           });
         } catch {
+          recordAuthAttempt(false);
           send(browserWs, { type: 'auth_fail', error: 'Invalid or expired token' });
         }
         return;
@@ -142,9 +156,13 @@ export function setupWebSocket(wss: WebSocketServer): void {
       agentWs.send(JSON.stringify(msg));
     });
 
-    browserWs.on('close', cleanupAgentConnection);
+    browserWs.on('close', () => {
+      recordBrowserConnectionClosed();
+      cleanupAgentConnection();
+    });
     browserWs.on('error', (err) => {
       console.error('Browser WebSocket error:', err);
+      recordRelayError();
       cleanupAgentConnection();
     });
   });

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -13,6 +13,9 @@ import { existsSync } from 'fs';
 import { resolve } from 'path';
 
 import { CONFIG } from './config.js';
+import { getDb } from './db.js';
+import { agentServiceFetch } from './agent/agent-service-client.js';
+import { getRelayMetrics } from './agent/relay-metrics.js';
 import authRoutes from './auth/routes.js';
 import conversationRoutes from './conversations/routes.js';
 import fileRoutes from './files/routes.js';
@@ -50,7 +53,32 @@ export function createApp() {
 
   // Health check
   app.get('/api/health', (_req, res) => {
-    res.json({ status: 'ok', timestamp: Date.now(), version: '0.1.0' });
+    res.json({ status: 'ok', timestamp: Date.now(), version: '0.1.0', service: 'gateway' });
+  });
+
+  app.get('/api/ready', async (_req, res) => {
+    try {
+      getDb().prepare('SELECT 1').get();
+      const response = await agentServiceFetch('/api/health', {
+        method: 'GET',
+        userId: 'system',
+        signal: AbortSignal.timeout(1_000),
+      });
+      if (!response.ok) {
+        res.status(503).json({ status: 'degraded', dependency: 'agent-service' });
+        return;
+      }
+      res.json({ status: 'ready', dependencies: { db: 'ok', agentService: 'ok' } });
+    } catch (err) {
+      res.status(503).json({
+        status: 'degraded',
+        error: err instanceof Error ? err.message : 'Readiness check failed',
+      });
+    }
+  });
+
+  app.get('/api/metrics', (_req, res) => {
+    res.json({ relay: getRelayMetrics() });
   });
 
   // Routes

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -32,10 +32,10 @@ export const CONFIG = {
   k8sNamespace: process.env.K8S_NAMESPACE ?? 'goldilocks',
   agentImage: process.env.AGENT_IMAGE ?? 'goldilocks-agent:latest',
   agentIdleTimeoutMs: parseInt(process.env.AGENT_IDLE_TIMEOUT_MS ?? '1800000', 10), // 30min
+  agentServiceUrl: process.env.AGENT_SERVICE_URL ?? 'http://agent-service:3001',
+  agentServiceWsUrl: process.env.AGENT_SERVICE_WS_URL ?? 'ws://agent-service:3001/ws',
+  agentServiceSharedSecret: process.env.AGENT_SERVICE_SHARED_SECRET ?? 'dev-agent-service-secret',
 
-  
-
-  
   get isDev() {
     return this.nodeEnv === 'development';
   },

--- a/server/src/conversations/routes.ts
+++ b/server/src/conversations/routes.ts
@@ -9,7 +9,7 @@ import { Router, Response } from 'express';
 import { v4 as uuid } from 'uuid';
 import { getDb } from '../db.js';
 import { verifyToken, AuthRequest } from '../auth/middleware.js';
-import { sessionManager } from '../agent/sessions.js';
+import { agentServiceFetch } from '../agent/agent-service-client.js';
 
 const router = Router();
 
@@ -191,10 +191,15 @@ router.delete('/:id', async (req: AuthRequest, res: Response) => {
 
   db.prepare(`DELETE FROM conversations WHERE id = ?`).run(req.params.id);
 
-  // Clean up pi session files on the PVC
+  // Clean up session files via the agent service
   if (row.pi_session_id) {
     try {
-      await sessionManager.deleteConversation(req.user.id, row.pi_session_id);
+      await agentServiceFetch('/internal/sessions/delete', {
+        method: 'POST',
+        userId: req.user.id,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessionPath: row.pi_session_id }),
+      });
     } catch (err) {
       console.error('Failed to clean up pi session:', err);
     }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -27,18 +27,29 @@ const wss = new WebSocketServer({ server, path: '/ws' });
 setupWebSocket(wss);
 
 // Graceful shutdown
-function shutdown() {
+let shuttingDown = false;
+async function shutdown() {
+  if (shuttingDown) return;
+  shuttingDown = true;
   console.log('\nShutting down...');
-  sessionManager.shutdown();
+
+  wss.close();
+  await sessionManager.shutdown();
   closeDb();
-  server.close(() => {
-    console.log('Server closed');
-    process.exit(0);
+
+  await new Promise<void>((resolve, reject) => {
+    server.close((err) => {
+      if (err) reject(err);
+      else resolve();
+    });
   });
+
+  console.log('Server closed');
+  process.exit(0);
 }
 
-process.on('SIGINT', shutdown);
-process.on('SIGTERM', shutdown);
+process.on('SIGINT', () => { void shutdown(); });
+process.on('SIGTERM', () => { void shutdown(); });
 
 // Start
 async function main() {

--- a/server/src/models/routes.ts
+++ b/server/src/models/routes.ts
@@ -1,17 +1,9 @@
-/**
- * Models route — get available models from the in-process pi SDK.
- *
- * The SDK model registry knows which API keys are configured and which models
- * are available for the current user session.
- */
-
 import { Router, Response } from 'express';
 import { verifyToken, AuthRequest } from '../auth/middleware.js';
-import { sessionManager } from '../agent/sessions.js';
+import { agentServiceFetch } from '../agent/agent-service-client.js';
 
 const router = Router();
 
-// GET /api/models - List available models from pi
 router.get('/', verifyToken, async (req: AuthRequest, res: Response) => {
   if (!req.user) {
     res.status(401).json({ error: 'Unauthorized' });
@@ -19,40 +11,36 @@ router.get('/', verifyToken, async (req: AuthRequest, res: Response) => {
   }
 
   try {
-    const result = await sessionManager.getAvailableModels(req.user.id) as Record<string, unknown> | unknown[];
-    
-    // Pi returns { models: [...] }
-    const models = Array.isArray(result) ? result
-      : Array.isArray((result as Record<string, unknown>)?.models) ? (result as Record<string, unknown>).models as unknown[]
-      : [];
-    const providers = [...new Set((models as Array<Record<string, unknown>>).map((m) => m.provider as string))];
-
-    res.json({ models, providers });
+    const response = await agentServiceFetch('/internal/models', {
+      method: 'GET',
+      userId: req.user.id,
+    });
+    const json = await response.json();
+    res.status(response.status).json(json);
   } catch (err) {
-    console.error('Error fetching models:', err);
-    res.status(500).json({ error: 'Failed to fetch available models' });
+    console.error('Error fetching models from agent service:', err);
+    res.status(502).json({ error: 'Failed to fetch available models' });
   }
 });
 
-// POST /api/models/select - Set the active model
 router.post('/select', verifyToken, async (req: AuthRequest, res: Response) => {
   if (!req.user) {
     res.status(401).json({ error: 'Unauthorized' });
     return;
   }
 
-  const { modelId } = req.body;
-  if (!modelId) {
-    res.status(400).json({ error: 'modelId is required' });
-    return;
-  }
-
   try {
-    await sessionManager.setModel(req.user.id, modelId);
-    res.json({ ok: true, modelId });
+    const response = await agentServiceFetch('/internal/models/select', {
+      method: 'POST',
+      userId: req.user.id,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(req.body ?? {}),
+    });
+    const json = await response.json();
+    res.status(response.status).json(json);
   } catch (err) {
-    console.error('Error setting model:', err);
-    res.status(500).json({ error: 'Failed to set model' });
+    console.error('Error setting model via agent service:', err);
+    res.status(502).json({ error: 'Failed to set model' });
   }
 });
 

--- a/test/server/config.test.ts
+++ b/test/server/config.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const originalEnv = { ...process.env };
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+  vi.resetModules();
+});
+
+describe('CONFIG.agentServiceSharedSecret', () => {
+  it('uses the dev default outside production', async () => {
+    delete process.env.AGENT_SERVICE_SHARED_SECRET;
+    process.env.NODE_ENV = 'development';
+
+    const { CONFIG } = await import('../../server/src/config');
+    expect(CONFIG.agentServiceSharedSecret).toBe('dev-agent-service-secret');
+  });
+
+  it('throws in production when unset', async () => {
+    delete process.env.AGENT_SERVICE_SHARED_SECRET;
+    process.env.NODE_ENV = 'production';
+
+    const { CONFIG } = await import('../../server/src/config');
+    expect(() => CONFIG.agentServiceSharedSecret).toThrow('AGENT_SERVICE_SHARED_SECRET must be set in production');
+  });
+});


### PR DESCRIPTION
## Summary
- add a dedicated `agent-service` workspace that owns WebSocket session orchestration on port 3001
- turn the browser-facing gateway websocket into a relay and proxy model/session cleanup calls to the agent service
- wire the service into the dev stack with a deployment, service, image build, and shared-secret auth

## Testing
- nix develop -c npm run typecheck
- nix develop -c npm test
- nix develop -c npm run build
