### PR TITLE
P3: harden runtime readiness and observability

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -69,7 +69,7 @@ docker_build(
     ],
 )
 
-k8s_yaml(['k8s/web-app.yaml', 'k8s/agent-service.yaml'])
+k8s_yaml(['k8s/web-app.yaml', 'k8s/agent-service.yaml', 'k8s/web-app-hpa.yaml', 'k8s/agent-service-hpa.yaml'])
 k8s_resource(
     'web-app',
     port_forwards=['3000:3000', '5173:5173'],

--- a/agent-service/src/index.ts
+++ b/agent-service/src/index.ts
@@ -6,6 +6,15 @@ import { CONFIG } from '../../server/src/config.js';
 import { getDb, runMigrations, closeDb } from '../../server/src/db.js';
 import { sessionManager, type SessionEvent } from '../../server/src/agent/sessions.js';
 import type { ClientMessage, HistoryMessage, ServerMessage } from '../../server/src/shared/types.js';
+import {
+  gatewayConnectionClosed,
+  gatewayConnectionOpened,
+  getMetrics,
+  internalAuthFailed,
+  promptFinished,
+  promptStarted,
+  websocketErrored,
+} from './metrics.js';
 
 interface InternalAuthRequest extends express.Request {
   internalUserId?: string;
@@ -204,6 +213,7 @@ function verifyInternalRequest(req: InternalAuthRequest, res: Response, next: ex
   const userId = req.header('x-goldilocks-user');
 
   if (sharedSecret !== CONFIG.agentServiceSharedSecret || !userId) {
+    internalAuthFailed();
     res.status(401).json({ error: 'Unauthorized internal request' });
     return;
   }
@@ -216,6 +226,22 @@ const app = express();
 app.use(express.json());
 app.get('/api/health', (_req, res) => {
   res.json({ status: 'ok', service: 'agent-service', timestamp: Date.now() });
+});
+
+app.get('/api/ready', (_req, res) => {
+  try {
+    getDb().prepare('SELECT 1').get();
+    res.json({ status: 'ready', dependencies: { db: 'ok' } });
+  } catch (err) {
+    res.status(503).json({
+      status: 'degraded',
+      error: err instanceof Error ? err.message : 'Readiness check failed',
+    });
+  }
+});
+
+app.get('/api/metrics', (_req, res) => {
+  res.json(getMetrics());
 });
 
 app.get('/internal/models', verifyInternalRequest, async (req: InternalAuthRequest, res: Response) => {
@@ -264,6 +290,7 @@ const server = createServer(app);
 const wss = new WebSocketServer({ server, path: '/ws' });
 
 wss.on('connection', (ws: WebSocket, _req: IncomingMessage) => {
+  gatewayConnectionOpened();
   const state: InternalWsState = {
     userId: null,
     conversationId: null,
@@ -294,6 +321,7 @@ wss.on('connection', (ws: WebSocket, _req: IncomingMessage) => {
     try {
       if (msg.type === 'auth' && 'gatewayToken' in msg) {
         if (msg.gatewayToken !== CONFIG.agentServiceSharedSecret) {
+          internalAuthFailed();
           send(ws, { type: 'auth_fail', error: 'Invalid gateway token' });
           return;
         }
@@ -348,6 +376,7 @@ wss.on('connection', (ws: WebSocket, _req: IncomingMessage) => {
           }
 
           state.isProcessing = true;
+          promptStarted();
           const db = getDb();
           const conv = db.prepare('SELECT title FROM conversations WHERE id = ?').get(state.conversationId) as { title: string } | undefined;
           if (conv?.title === 'New conversation' && msg.text.trim()) {
@@ -361,6 +390,7 @@ wss.on('connection', (ws: WebSocket, _req: IncomingMessage) => {
             await sessionManager.prompt(state.userId, state.conversationId, msg.text);
           } finally {
             state.isProcessing = false;
+            promptFinished();
           }
           break;
         }
@@ -379,25 +409,39 @@ wss.on('connection', (ws: WebSocket, _req: IncomingMessage) => {
     }
   });
 
-  ws.on('close', cleanup);
+  ws.on('close', () => {
+    gatewayConnectionClosed();
+    cleanup();
+  });
   ws.on('error', (err) => {
     console.error('Agent service websocket error:', err);
+    websocketErrored();
     cleanup();
   });
 });
 
-function shutdown() {
+let shuttingDown = false;
+async function shutdown() {
+  if (shuttingDown) return;
+  shuttingDown = true;
   console.log('\nShutting down agent service...');
-  sessionManager.shutdown();
+
+  wss.close();
+  await sessionManager.shutdown();
   closeDb();
-  server.close(() => {
-    console.log('Agent service closed');
-    process.exit(0);
+  await new Promise<void>((resolve, reject) => {
+    server.close((err) => {
+      if (err) reject(err);
+      else resolve();
+    });
   });
+
+  console.log('Agent service closed');
+  process.exit(0);
 }
 
-process.on('SIGINT', shutdown);
-process.on('SIGTERM', shutdown);
+process.on('SIGINT', () => { void shutdown(); });
+process.on('SIGTERM', () => { void shutdown(); });
 
 async function main() {
   runMigrations();

--- a/agent-service/src/index.ts
+++ b/agent-service/src/index.ts
@@ -13,6 +13,7 @@ import {
   internalAuthFailed,
   promptFinished,
   promptStarted,
+  recordTtft,
   websocketErrored,
 } from './metrics.js';
 
@@ -28,6 +29,7 @@ interface InternalWsState {
   receivedTextDelta: boolean;
   currentToolCallId: string | null;
   toolCallIdMap: Map<string, string>;
+  promptSentAt: number | null;
 }
 
 interface GatewayAuthMessage {
@@ -53,9 +55,17 @@ function mapSessionEvent(event: SessionEvent, ws: WebSocket, state: InternalWsSt
       if (!delta) break;
 
       if (delta.type === 'text_delta' && delta.delta) {
+        if (state.promptSentAt !== null) {
+          recordTtft(Date.now() - state.promptSentAt);
+          state.promptSentAt = null;
+        }
         state.receivedTextDelta = true;
         send(ws, { type: 'text_delta', delta: delta.delta });
       } else if (delta.type === 'thinking_delta' && delta.delta) {
+        if (state.promptSentAt !== null) {
+          recordTtft(Date.now() - state.promptSentAt);
+          state.promptSentAt = null;
+        }
         send(ws, { type: 'thinking_delta', delta: delta.delta });
       } else if (delta.type === 'toolcall_start') {
         const tc = delta.partial ?? delta.toolCall;
@@ -94,6 +104,11 @@ function mapSessionEvent(event: SessionEvent, ws: WebSocket, state: InternalWsSt
     }
 
     case 'message_end': {
+      if (state.promptSentAt !== null) {
+        recordTtft(Date.now() - state.promptSentAt);
+        state.promptSentAt = null;
+      }
+
       if (!state.receivedTextDelta) {
         const msg = event.message as {
           role?: string;
@@ -244,6 +259,35 @@ app.get('/api/metrics', (_req, res) => {
   res.json(getMetrics());
 });
 
+app.post('/internal/prewarm', verifyInternalRequest, async (req: InternalAuthRequest, res: Response) => {
+  const { conversationId } = req.body as { conversationId?: string };
+  if (!conversationId) {
+    res.status(400).json({ error: 'conversationId is required' });
+    return;
+  }
+
+  try {
+    const db = getDb();
+    const row = db.prepare(
+      'SELECT pi_session_id FROM conversations WHERE id = ? AND user_id = ?'
+    ).get(conversationId, req.internalUserId) as { pi_session_id: string | null } | undefined;
+
+    if (!row) {
+      res.status(404).json({ error: 'Conversation not found' });
+      return;
+    }
+
+    if (row.pi_session_id) {
+      await sessionManager.switchSession(req.internalUserId!, conversationId, row.pi_session_id);
+    }
+
+    res.json({ ok: true, conversationId });
+  } catch (err) {
+    console.error('Prewarm failed:', err);
+    res.status(500).json({ error: 'Prewarm failed' });
+  }
+});
+
 app.get('/internal/models', verifyInternalRequest, async (req: InternalAuthRequest, res: Response) => {
   try {
     const result = await sessionManager.getAvailableModels(req.internalUserId!);
@@ -299,6 +343,7 @@ wss.on('connection', (ws: WebSocket, _req: IncomingMessage) => {
     receivedTextDelta: false,
     currentToolCallId: null,
     toolCallIdMap: new Map(),
+    promptSentAt: null as number | null,
   };
 
   const cleanup = () => {
@@ -376,6 +421,7 @@ wss.on('connection', (ws: WebSocket, _req: IncomingMessage) => {
           }
 
           state.isProcessing = true;
+          state.promptSentAt = Date.now();
           promptStarted();
           const db = getDb();
           const conv = db.prepare('SELECT title FROM conversations WHERE id = ?').get(state.conversationId) as { title: string } | undefined;

--- a/agent-service/src/index.ts
+++ b/agent-service/src/index.ts
@@ -68,6 +68,11 @@ function mapSessionEvent(event: SessionEvent, ws: WebSocket, state: InternalWsSt
         }
         send(ws, { type: 'thinking_delta', delta: delta.delta });
       } else if (delta.type === 'toolcall_start') {
+        if (state.promptSentAt !== null) {
+          recordTtft(Date.now() - state.promptSentAt);
+          state.promptSentAt = null;
+        }
+
         const tc = delta.partial ?? delta.toolCall;
         const toolCallId = tc?.id ?? `tc_${Date.now()}`;
         state.currentToolCallId = toolCallId;

--- a/agent-service/src/metrics.ts
+++ b/agent-service/src/metrics.ts
@@ -5,7 +5,10 @@ const metrics = {
   promptCount: 0,
   internalAuthFailures: 0,
   websocketErrors: 0,
+  ttftSamples: [] as number[],
 };
+
+const TTFT_MAX_SAMPLES = 1000;
 
 export function gatewayConnectionOpened(): void {
   metrics.gatewayConnections += 1;
@@ -25,6 +28,13 @@ export function promptFinished(): void {
   metrics.activePrompts = Math.max(0, metrics.activePrompts - 1);
 }
 
+export function recordTtft(durationMs: number): void {
+  metrics.ttftSamples.push(durationMs);
+  if (metrics.ttftSamples.length > TTFT_MAX_SAMPLES) {
+    metrics.ttftSamples.shift();
+  }
+}
+
 export function internalAuthFailed(): void {
   metrics.internalAuthFailures += 1;
 }
@@ -34,5 +44,22 @@ export function websocketErrored(): void {
 }
 
 export function getMetrics() {
-  return { ...metrics };
+  const samples = metrics.ttftSamples;
+  const sorted = [...samples].sort((a, b) => a - b);
+  const p50 = sorted.length > 0 ? sorted[Math.floor(sorted.length / 2)] : 0;
+  const p95 = sorted.length > 0 ? sorted[Math.floor(sorted.length * 0.95)] : 0;
+  const p99 = sorted.length > 0 ? sorted[Math.floor(sorted.length * 0.99)] : 0;
+
+  return {
+    gatewayConnections: metrics.gatewayConnections,
+    activeGatewayConnections: metrics.activeGatewayConnections,
+    activePrompts: metrics.activePrompts,
+    promptCount: metrics.promptCount,
+    internalAuthFailures: metrics.internalAuthFailures,
+    websocketErrors: metrics.websocketErrors,
+    ttftCount: samples.length,
+    ttftP50Ms: p50,
+    ttftP95Ms: p95,
+    ttftP99Ms: p99,
+  };
 }

--- a/agent-service/src/metrics.ts
+++ b/agent-service/src/metrics.ts
@@ -1,0 +1,38 @@
+const metrics = {
+  gatewayConnections: 0,
+  activeGatewayConnections: 0,
+  activePrompts: 0,
+  promptCount: 0,
+  internalAuthFailures: 0,
+  websocketErrors: 0,
+};
+
+export function gatewayConnectionOpened(): void {
+  metrics.gatewayConnections += 1;
+  metrics.activeGatewayConnections += 1;
+}
+
+export function gatewayConnectionClosed(): void {
+  metrics.activeGatewayConnections = Math.max(0, metrics.activeGatewayConnections - 1);
+}
+
+export function promptStarted(): void {
+  metrics.promptCount += 1;
+  metrics.activePrompts += 1;
+}
+
+export function promptFinished(): void {
+  metrics.activePrompts = Math.max(0, metrics.activePrompts - 1);
+}
+
+export function internalAuthFailed(): void {
+  metrics.internalAuthFailures += 1;
+}
+
+export function websocketErrored(): void {
+  metrics.websocketErrors += 1;
+}
+
+export function getMetrics() {
+  return { ...metrics };
+}

--- a/k8s/agent-service-hpa.yaml
+++ b/k8s/agent-service-hpa.yaml
@@ -1,3 +1,8 @@
+# NOTE: The active_prompts custom metric requires a Prometheus adapter
+# (e.g. prometheus-adapter) configured to scrape /api/metrics from
+# agent-service pods. Without it, k8s cannot discover this metric
+# and the HPA will report MissingMetrics. Either deploy the adapter
+# or remove the Pods metric and rely on CPU/memory alone.
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/k8s/agent-service-hpa.yaml
+++ b/k8s/agent-service-hpa.yaml
@@ -1,0 +1,26 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: agent-service-hpa
+  namespace: goldilocks
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: agent-service
+  minReplicas: 1
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+    - type: Pods
+      pods:
+        metric:
+          name: active_prompts
+        target:
+          type: AverageValue
+          averageValue: "10"

--- a/k8s/agent-service.yaml
+++ b/k8s/agent-service.yaml
@@ -74,9 +74,9 @@ spec:
             periodSeconds: 30
           lifecycle:
             preStop:
-              httpGet:
-                path: /api/health
-                port: http
+              exec:
+                command: ['sh', '-c', 'sleep 5']
+          terminationGracePeriodSeconds: 30
 
       volumes:
         - name: data

--- a/k8s/agent-service.yaml
+++ b/k8s/agent-service.yaml
@@ -60,10 +60,24 @@ spec:
               memory: 2Gi
           readinessProbe:
             httpGet:
+              path: /api/ready
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
               path: /api/health
               port: http
-            initialDelaySeconds: 5
-            periodSeconds: 10
+            initialDelaySeconds: 15
+            periodSeconds: 30
+          lifecycle:
+            preStop:
+              httpGet:
+                path: /api/health
+                port: http
+
       volumes:
         - name: data
           hostPath:
@@ -75,6 +89,11 @@ kind: Service
 metadata:
   name: agent-service
   namespace: goldilocks
+  annotations:
+    # Sticky routing ensures gateway connections land on the same agent-service pod
+    # for the lifetime of a WS session.
+    nginx.ingress.kubernetes.io/affinity: cookie
+    nginx.ingress.kubernetes.io/affinity-mode: persistent
 spec:
   selector:
     app: agent-service
@@ -82,3 +101,20 @@ spec:
     - port: 3001
       targetPort: 3001
       name: http
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: agent-service-ws
+  namespace: goldilocks
+spec:
+  selector:
+    app: agent-service
+  ports:
+    - port: 3001
+      targetPort: 3001
+      name: ws
+  sessionAffinity: ClientIP
+  sessionAffinityConfig:
+    clientIP:
+      timeoutSeconds: 3600

--- a/k8s/web-app-hpa.yaml
+++ b/k8s/web-app-hpa.yaml
@@ -1,0 +1,25 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: web-app-hpa
+  namespace: goldilocks
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: web-app
+  minReplicas: 2
+  maxReplicas: 10
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80

--- a/k8s/web-app.yaml
+++ b/k8s/web-app.yaml
@@ -83,9 +83,9 @@ spec:
             periodSeconds: 30
           lifecycle:
             preStop:
-              httpGet:
-                path: /api/health
-                port: http
+              exec:
+                command: ['sh', '-c', 'sleep 5']
+          terminationGracePeriodSeconds: 30
 
       volumes:
         - name: data

--- a/k8s/web-app.yaml
+++ b/k8s/web-app.yaml
@@ -69,16 +69,24 @@ spec:
               memory: 2Gi
           readinessProbe:
             httpGet:
-              path: /api/health
+              path: /api/ready
               port: http
-            initialDelaySeconds: 5
+            initialDelaySeconds: 10
             periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
           livenessProbe:
             httpGet:
               path: /api/health
               port: http
             initialDelaySeconds: 15
             periodSeconds: 30
+          lifecycle:
+            preStop:
+              httpGet:
+                path: /api/health
+                port: http
+
       volumes:
         - name: data
           hostPath:

--- a/server/src/agent/relay-metrics.ts
+++ b/server/src/agent/relay-metrics.ts
@@ -1,0 +1,42 @@
+const relayMetrics = {
+  browserConnections: 0,
+  activeBrowserConnections: 0,
+  agentConnections: 0,
+  activeAgentConnections: 0,
+  authAttempts: 0,
+  authFailures: 0,
+  relayErrors: 0,
+};
+
+export function recordBrowserConnectionOpened(): void {
+  relayMetrics.browserConnections += 1;
+  relayMetrics.activeBrowserConnections += 1;
+}
+
+export function recordBrowserConnectionClosed(): void {
+  relayMetrics.activeBrowserConnections = Math.max(0, relayMetrics.activeBrowserConnections - 1);
+}
+
+export function recordAgentConnectionOpened(): void {
+  relayMetrics.agentConnections += 1;
+  relayMetrics.activeAgentConnections += 1;
+}
+
+export function recordAgentConnectionClosed(): void {
+  relayMetrics.activeAgentConnections = Math.max(0, relayMetrics.activeAgentConnections - 1);
+}
+
+export function recordAuthAttempt(success: boolean): void {
+  relayMetrics.authAttempts += 1;
+  if (!success) {
+    relayMetrics.authFailures += 1;
+  }
+}
+
+export function recordRelayError(): void {
+  relayMetrics.relayErrors += 1;
+}
+
+export function getRelayMetrics() {
+  return { ...relayMetrics };
+}

--- a/server/src/agent/relay-metrics.ts
+++ b/server/src/agent/relay-metrics.ts
@@ -6,7 +6,10 @@ const relayMetrics = {
   authAttempts: 0,
   authFailures: 0,
   relayErrors: 0,
+  ttftSamples: [] as number[],
 };
+
+const TTFT_MAX_SAMPLES = 1000;
 
 export function recordBrowserConnectionOpened(): void {
   relayMetrics.browserConnections += 1;
@@ -37,6 +40,26 @@ export function recordRelayError(): void {
   relayMetrics.relayErrors += 1;
 }
 
+export function recordTtft(durationMs: number): void {
+  relayMetrics.ttftSamples.push(durationMs);
+  if (relayMetrics.ttftSamples.length > TTFT_MAX_SAMPLES) {
+    relayMetrics.ttftSamples.shift();
+  }
+}
+
 export function getRelayMetrics() {
-  return { ...relayMetrics };
+  const samples = relayMetrics.ttftSamples;
+  const sorted = [...samples].sort((a, b) => a - b);
+  const p50 = sorted.length > 0 ? sorted[Math.floor(sorted.length / 2)] : 0;
+  const p95 = sorted.length > 0 ? sorted[Math.floor(sorted.length * 0.95)] : 0;
+  const p99 = sorted.length > 0 ? sorted[Math.floor(sorted.length * 0.99)] : 0;
+
+  return {
+    ...relayMetrics,
+    ttftSamples: undefined,
+    ttftCount: samples.length,
+    ttftP50Ms: p50,
+    ttftP95Ms: p95,
+    ttftP99Ms: p99,
+  };
 }

--- a/server/src/agent/websocket.ts
+++ b/server/src/agent/websocket.ts
@@ -9,6 +9,7 @@ import {
   recordBrowserConnectionClosed,
   recordBrowserConnectionOpened,
   recordRelayError,
+  recordTtft,
 } from './relay-metrics.js';
 import type { ClientMessage, ServerMessage } from '../shared/types.js';
 
@@ -22,6 +23,9 @@ interface GatewayToAgentMessage {
   userId: string;
   gatewayToken: string;
 }
+
+const HEARTBEAT_INTERVAL_MS = 30_000;
+const HEARTBEAT_TIMEOUT_MS = 60_000;
 
 function send(ws: WebSocket, msg: ServerMessage): void {
   if (ws.readyState !== WebSocket.OPEN) return;
@@ -40,11 +44,27 @@ export function setupWebSocket(wss: WebSocketServer): void {
     let agentReady = false;
     let agentGeneration = 0;
     const pendingMessages: ClientMessage[] = [];
+    let promptSentAt: number | null = null;
+
+    // Browser keepalive
+    let browserAlive = true;
+    const browserHeartbeat = setInterval(() => {
+      if (browserWs.readyState !== WebSocket.OPEN) {
+        clearInterval(browserHeartbeat);
+        return;
+      }
+      browserWs.ping();
+    }, HEARTBEAT_INTERVAL_MS);
+
+    browserWs.on('pong', () => {
+      browserAlive = true;
+    });
 
     const cleanupAgentConnection = () => {
       agentGeneration += 1;
       agentReady = false;
       pendingMessages.length = 0;
+      promptSentAt = null;
       if (agentWs) {
         const ws = agentWs;
         agentWs = null;
@@ -84,6 +104,20 @@ export function setupWebSocket(wss: WebSocketServer): void {
           agentWs = nextAgentWs;
           recordAgentConnectionOpened();
 
+          // Agent keepalive
+          const agentHeartbeat = setInterval(() => {
+            if (nextAgentWs.readyState !== WebSocket.OPEN) {
+              clearInterval(agentHeartbeat);
+              return;
+            }
+            nextAgentWs.ping();
+          }, HEARTBEAT_INTERVAL_MS);
+
+          let agentAlive = true;
+          nextAgentWs.on('pong', () => {
+            agentAlive = true;
+          });
+
           nextAgentWs.on('open', () => {
             if (connectionGeneration !== agentGeneration) return;
             const authMessage: GatewayToAgentMessage = {
@@ -118,11 +152,25 @@ export function setupWebSocket(wss: WebSocketServer): void {
               return;
             }
 
+            // TTFT: record time from prompt send to first content delta
+            if (promptSentAt !== null) {
+              if (agentMsg.type === 'text_delta' || agentMsg.type === 'thinking_delta' || agentMsg.type === 'message_end') {
+                recordTtft(Date.now() - promptSentAt);
+                promptSentAt = null;
+              }
+            }
+
             send(browserWs, agentMsg);
           });
 
           nextAgentWs.on('close', () => {
-            if (connectionGeneration !== agentGeneration) return;
+            clearInterval(agentHeartbeat);
+            if (connectionGeneration !== agentGeneration) {
+              // Stale socket — counter already decremented by cleanupAgentConnection()
+              return;
+            }
+            // Spontaneous disconnect — counter was not decremented yet
+            recordAgentConnectionClosed();
             agentReady = false;
             agentWs = null;
             if (browserWs.readyState === WebSocket.OPEN) {
@@ -148,6 +196,11 @@ export function setupWebSocket(wss: WebSocketServer): void {
         return;
       }
 
+      // Track prompt send time for TTFT
+      if (msg.type === 'prompt') {
+        promptSentAt = Date.now();
+      }
+
       if (!agentWs || agentWs.readyState !== WebSocket.OPEN || !agentReady) {
         pendingMessages.push(msg);
         return;
@@ -157,10 +210,12 @@ export function setupWebSocket(wss: WebSocketServer): void {
     });
 
     browserWs.on('close', () => {
+      clearInterval(browserHeartbeat);
       recordBrowserConnectionClosed();
       cleanupAgentConnection();
     });
     browserWs.on('error', (err) => {
+      clearInterval(browserHeartbeat);
       console.error('Browser WebSocket error:', err);
       recordRelayError();
       cleanupAgentConnection();

--- a/server/src/agent/websocket.ts
+++ b/server/src/agent/websocket.ts
@@ -27,6 +27,11 @@ interface GatewayToAgentMessage {
 const HEARTBEAT_INTERVAL_MS = 30_000;
 const HEARTBEAT_TIMEOUT_MS = 60_000;
 
+// Events that count as "first meaningful output" for TTFT.
+// Includes toolcall_start so a model that immediately calls a tool
+// doesn't inflate TTFT to the full turn time.
+const TTFT_CLEAR_TYPES = new Set(['text_delta', 'thinking_delta', 'tool_start', 'message_end']);
+
 function send(ws: WebSocket, msg: ServerMessage): void {
   if (ws.readyState !== WebSocket.OPEN) return;
   try {
@@ -43,21 +48,30 @@ export function setupWebSocket(wss: WebSocketServer): void {
     let agentWs: WebSocket | null = null;
     let agentReady = false;
     let agentGeneration = 0;
+    let currentAgentHeartbeat: ReturnType<typeof setInterval> | null = null;
     const pendingMessages: ClientMessage[] = [];
     let promptSentAt: number | null = null;
 
-    // Browser keepalive
-    let browserAlive = true;
+    // ── Browser keepalive ──
+    // Ping every HEARTBEAT_INTERVAL_MS. If no pong arrives within
+    // HEARTBEAT_TIMEOUT_MS since the last pong, terminate the connection.
+    let browserLastPong = Date.now();
     const browserHeartbeat = setInterval(() => {
       if (browserWs.readyState !== WebSocket.OPEN) {
         clearInterval(browserHeartbeat);
         return;
       }
       browserWs.ping();
+
+      if (Date.now() - browserLastPong > HEARTBEAT_TIMEOUT_MS) {
+        console.warn('Browser WebSocket pong timeout — terminating connection');
+        browserWs.terminate();
+        clearInterval(browserHeartbeat);
+      }
     }, HEARTBEAT_INTERVAL_MS);
 
     browserWs.on('pong', () => {
-      browserAlive = true;
+      browserLastPong = Date.now();
     });
 
     const cleanupAgentConnection = () => {
@@ -65,6 +79,10 @@ export function setupWebSocket(wss: WebSocketServer): void {
       agentReady = false;
       pendingMessages.length = 0;
       promptSentAt = null;
+      if (currentAgentHeartbeat) {
+        clearInterval(currentAgentHeartbeat);
+        currentAgentHeartbeat = null;
+      }
       if (agentWs) {
         const ws = agentWs;
         agentWs = null;
@@ -104,18 +122,26 @@ export function setupWebSocket(wss: WebSocketServer): void {
           agentWs = nextAgentWs;
           recordAgentConnectionOpened();
 
-          // Agent keepalive
+          // ── Agent keepalive ──
+          // Same pattern: ping at interval, enforce pong timeout.
+          let agentLastPong = Date.now();
           const agentHeartbeat = setInterval(() => {
             if (nextAgentWs.readyState !== WebSocket.OPEN) {
               clearInterval(agentHeartbeat);
               return;
             }
             nextAgentWs.ping();
-          }, HEARTBEAT_INTERVAL_MS);
 
-          let agentAlive = true;
+            if (Date.now() - agentLastPong > HEARTBEAT_TIMEOUT_MS) {
+              console.warn('Agent service WebSocket pong timeout — closing connection');
+              nextAgentWs.terminate();
+              clearInterval(agentHeartbeat);
+            }
+          }, HEARTBEAT_INTERVAL_MS);
+          currentAgentHeartbeat = agentHeartbeat;
+
           nextAgentWs.on('pong', () => {
-            agentAlive = true;
+            agentLastPong = Date.now();
           });
 
           nextAgentWs.on('open', () => {
@@ -152,12 +178,10 @@ export function setupWebSocket(wss: WebSocketServer): void {
               return;
             }
 
-            // TTFT: record time from prompt send to first content delta
-            if (promptSentAt !== null) {
-              if (agentMsg.type === 'text_delta' || agentMsg.type === 'thinking_delta' || agentMsg.type === 'message_end') {
-                recordTtft(Date.now() - promptSentAt);
-                promptSentAt = null;
-              }
+            // TTFT: record time from prompt send to first meaningful output
+            if (promptSentAt !== null && TTFT_CLEAR_TYPES.has(agentMsg.type)) {
+              recordTtft(Date.now() - promptSentAt);
+              promptSentAt = null;
             }
 
             send(browserWs, agentMsg);
@@ -165,6 +189,9 @@ export function setupWebSocket(wss: WebSocketServer): void {
 
           nextAgentWs.on('close', () => {
             clearInterval(agentHeartbeat);
+            if (currentAgentHeartbeat === agentHeartbeat) {
+              currentAgentHeartbeat = null;
+            }
             if (connectionGeneration !== agentGeneration) {
               // Stale socket — counter already decremented by cleanupAgentConnection()
               return;

--- a/server/src/agent/websocket.ts
+++ b/server/src/agent/websocket.ts
@@ -2,6 +2,14 @@ import { IncomingMessage } from 'http';
 import jwt from 'jsonwebtoken';
 import { WebSocket, WebSocketServer } from 'ws';
 import { CONFIG } from '../config.js';
+import {
+  recordAgentConnectionClosed,
+  recordAgentConnectionOpened,
+  recordAuthAttempt,
+  recordBrowserConnectionClosed,
+  recordBrowserConnectionOpened,
+  recordRelayError,
+} from './relay-metrics.js';
 import type { ClientMessage, ServerMessage } from '../shared/types.js';
 
 interface AuthUser {
@@ -26,6 +34,7 @@ function send(ws: WebSocket, msg: ServerMessage): void {
 
 export function setupWebSocket(wss: WebSocketServer): void {
   wss.on('connection', (browserWs: WebSocket, _req: IncomingMessage) => {
+    recordBrowserConnectionOpened();
     let browserUser: AuthUser | null = null;
     let agentWs: WebSocket | null = null;
     let agentReady = false;
@@ -40,6 +49,7 @@ export function setupWebSocket(wss: WebSocketServer): void {
         const ws = agentWs;
         agentWs = null;
         ws.removeAllListeners();
+        recordAgentConnectionClosed();
         if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) {
           ws.close();
         }
@@ -67,10 +77,12 @@ export function setupWebSocket(wss: WebSocketServer): void {
 
         try {
           const payload = jwt.verify(msg.token, CONFIG.jwtSecret) as AuthUser;
+          recordAuthAttempt(true);
           browserUser = payload;
           const connectionGeneration = agentGeneration;
           const nextAgentWs = new WebSocket(CONFIG.agentServiceWsUrl);
           agentWs = nextAgentWs;
+          recordAgentConnectionOpened();
 
           nextAgentWs.on('open', () => {
             if (connectionGeneration !== agentGeneration) return;
@@ -121,9 +133,11 @@ export function setupWebSocket(wss: WebSocketServer): void {
           nextAgentWs.on('error', (err) => {
             if (connectionGeneration !== agentGeneration) return;
             console.error('Agent service WebSocket error:', err);
+            recordRelayError();
             send(browserWs, { type: 'error', error: 'Agent service connection error' });
           });
         } catch {
+          recordAuthAttempt(false);
           send(browserWs, { type: 'auth_fail', error: 'Invalid or expired token' });
         }
         return;
@@ -142,9 +156,13 @@ export function setupWebSocket(wss: WebSocketServer): void {
       agentWs.send(JSON.stringify(msg));
     });
 
-    browserWs.on('close', cleanupAgentConnection);
+    browserWs.on('close', () => {
+      recordBrowserConnectionClosed();
+      cleanupAgentConnection();
+    });
     browserWs.on('error', (err) => {
       console.error('Browser WebSocket error:', err);
+      recordRelayError();
       cleanupAgentConnection();
     });
   });

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -13,6 +13,9 @@ import { existsSync } from 'fs';
 import { resolve } from 'path';
 
 import { CONFIG } from './config.js';
+import { getDb } from './db.js';
+import { agentServiceFetch } from './agent/agent-service-client.js';
+import { getRelayMetrics } from './agent/relay-metrics.js';
 import authRoutes from './auth/routes.js';
 import conversationRoutes from './conversations/routes.js';
 import fileRoutes from './files/routes.js';
@@ -50,7 +53,32 @@ export function createApp() {
 
   // Health check
   app.get('/api/health', (_req, res) => {
-    res.json({ status: 'ok', timestamp: Date.now(), version: '0.1.0' });
+    res.json({ status: 'ok', timestamp: Date.now(), version: '0.1.0', service: 'gateway' });
+  });
+
+  app.get('/api/ready', async (_req, res) => {
+    try {
+      getDb().prepare('SELECT 1').get();
+      const response = await agentServiceFetch('/api/health', {
+        method: 'GET',
+        userId: 'system',
+        signal: AbortSignal.timeout(1_000),
+      });
+      if (!response.ok) {
+        res.status(503).json({ status: 'degraded', dependency: 'agent-service' });
+        return;
+      }
+      res.json({ status: 'ready', dependencies: { db: 'ok', agentService: 'ok' } });
+    } catch (err) {
+      res.status(503).json({
+        status: 'degraded',
+        error: err instanceof Error ? err.message : 'Readiness check failed',
+      });
+    }
+  });
+
+  app.get('/api/metrics', (_req, res) => {
+    res.json({ relay: getRelayMetrics() });
   });
 
   // Routes

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -27,18 +27,29 @@ const wss = new WebSocketServer({ server, path: '/ws' });
 setupWebSocket(wss);
 
 // Graceful shutdown
-function shutdown() {
+let shuttingDown = false;
+async function shutdown() {
+  if (shuttingDown) return;
+  shuttingDown = true;
   console.log('\nShutting down...');
-  sessionManager.shutdown();
+
+  wss.close();
+  await sessionManager.shutdown();
   closeDb();
-  server.close(() => {
-    console.log('Server closed');
-    process.exit(0);
+
+  await new Promise<void>((resolve, reject) => {
+    server.close((err) => {
+      if (err) reject(err);
+      else resolve();
+    });
   });
+
+  console.log('Server closed');
+  process.exit(0);
 }
 
-process.on('SIGINT', shutdown);
-process.on('SIGTERM', shutdown);
+process.on('SIGINT', () => { void shutdown(); });
+process.on('SIGTERM', () => { void shutdown(); });
 
 // Start
 async function main() {

--- a/test/server/config.test.ts
+++ b/test/server/config.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const originalEnv = { ...process.env };
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+  vi.resetModules();
+});
+
+describe('CONFIG.agentServiceSharedSecret', () => {
+  it('uses the dev default outside production', async () => {
+    delete process.env.AGENT_SERVICE_SHARED_SECRET;
+    process.env.NODE_ENV = 'development';
+
+    const { CONFIG } = await import('../../server/src/config');
+    expect(CONFIG.agentServiceSharedSecret).toBe('dev-agent-service-secret');
+  });
+
+  it('throws in production when unset', async () => {
+    delete process.env.AGENT_SERVICE_SHARED_SECRET;
+    process.env.NODE_ENV = 'production';
+
+    const { CONFIG } = await import('../../server/src/config');
+    expect(() => CONFIG.agentServiceSharedSecret).toThrow('AGENT_SERVICE_SHARED_SECRET must be set in production');
+  });
+});


### PR DESCRIPTION
## Summary
- add readiness and metrics endpoints to both gateway and agent-service
- instrument the gateway relay and agent-service websocket paths with lightweight runtime counters
- make shutdown paths drain websockets/session state cleanly before exit

## Testing
- nix develop -c npm run typecheck
- nix develop -c npm test
- nix develop -c npm run build
