### PR TITLE
refactor: align pod tool backend with Pi tool surface

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -22,7 +22,7 @@ graph TD
 
 1. **One architecture.** k8s for dev (kind + Tilt) and prod. No local-mode alternative.
 2. **Pi owns the agent.** Sessions, conversations, models — managed by Pi's SDK inside the agent-service. The gateway doesn't reimplement any agent logic.
-3. **Brain outside the sandbox.** The agent (reasoning, auth, session state) lives in the agent-service. The pod runs only tool commands: bash, read, write, edit, find, grep, ls.
+3. **Brain outside the sandbox.** The agent (reasoning, auth, session state) lives in the agent-service. The pod runs only the controlled tool surface: bash, read, write, and edit.
 4. **Credentials stay outside the pod.** Provider API keys are never injected into sandbox environment variables. They live only in `AuthStorage` inside the agent-service.
 5. **Pod per user, not per session.** One long-lived pod per user. Pi switches sessions via the SDK, not by restarting the process.
 6. **Sessions survive harness restarts.** Session files are stored durably outside the pod. If the agent-service restarts, it reopens sessions from disk.
@@ -83,13 +83,14 @@ Key file: `apps/agent-service/src/index.ts`
 
 ### Pod Tool Operations
 
-Rather than the Pi SDK running tools locally, Goldilocks provides pluggable operations backends that execute inside the user's pod via k8s exec:
+Rather than the Pi SDK running tools locally, Goldilocks provides pluggable operations backends that execute inside the user's pod via k8s exec. Pi still owns the tool semantics; Goldilocks only swaps the transport layer:
 
 - `BashOperations.exec()` → `k8s exec` with shell command
-- `ReadOperations.readFile()` → `k8s exec cat`
-- `WriteOperations.writeFile()` → `k8s exec` with base64 pipe
-- `EditOperations.readFile/writeFile()` → same as read/write
-- `FindOperations`, `GrepOperations`, `LsOperations` → shell commands in the pod
+- `ReadOperations.readFile()` → `k8s exec` running a dedicated Python helper script in the pod
+- `WriteOperations.writeFile()` / `mkdir()` → `k8s exec` running dedicated Python helper scripts in the pod
+- `EditOperations.readFile()/writeFile()` → same remote read/write transport as the standalone tools
+
+Only `read`, `write`, `edit`, and `bash` are exposed to the agent. `find`, `grep`, and `ls` are intentionally not part of the Goldilocks tool surface; the agent can use `bash` when it needs shell-level search/list behavior.
 
 **Key file:** `packages/runtime/src/pod-tool-operations.ts`
 

--- a/docs/architecture/backend.md
+++ b/docs/architecture/backend.md
@@ -42,13 +42,14 @@ Creates and manages Pi SDK `AgentSession` instances, keyed by `userId:conversati
 
 ### Pod Tool Operations (`pod-tool-operations.ts`)
 
-Provides pluggable operations backends for the Pi SDK's built-in tools. Instead of running tools locally, all execution is routed through the user's sandbox pod via k8s exec:
+Provides pluggable operations backends for the Pi SDK's built-in tools. Instead of running tools locally, Goldilocks routes the supported tool surface through the user's sandbox pod via k8s exec while leaving the Pi SDK's tool semantics intact:
 
 - **Bash**: `execInPod(userId, command)` with stdout/stderr streaming and exit status
-- **Read**: `cat` the file from the pod, detect image mime types
-- **Write**: base64-encoded content piped to the pod filesystem
-- **Edit**: read-modify-write via pod exec
-- **Find/Grep/Ls**: shell commands in the pod
+- **Read**: dedicated Python helper script streamed to `python3 -` inside the pod, then decoded back into the SDK's read flow
+- **Write**: dedicated Python helper script streamed to `python3 -` inside the pod, with parent-directory creation handled remotely
+- **Edit**: the Pi SDK's normal read/modify/write logic, backed by the same remote read/write helper scripts
+
+Goldilocks intentionally exposes only **`read`**, **`write`**, **`edit`**, and **`bash`** to the agent. `find`, `grep`, and `ls` are not part of the runtime surface here; if the agent needs shell-style discovery, it can use `bash`.
 
 This keeps all tool execution in the pod (the "hands") while the SDK orchestrates reasoning in the agent-service (the "brain").
 

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -12,7 +12,7 @@
     }
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && node ./scripts/copy-pod-tool-scripts.mjs",
     "typecheck": "tsc --noEmit",
     "lint": "echo 'runtime: no lint configured'"
   },

--- a/packages/runtime/scripts/copy-pod-tool-scripts.mjs
+++ b/packages/runtime/scripts/copy-pod-tool-scripts.mjs
@@ -1,0 +1,12 @@
+import { cp, mkdir, rm } from 'fs/promises';
+import { resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+const scriptDir = fileURLToPath(new URL('.', import.meta.url));
+const packageDir = resolve(scriptDir, '..');
+const sourceDir = resolve(packageDir, 'src', 'pod-tool-scripts');
+const outputDir = resolve(packageDir, 'dist', 'pod-tool-scripts');
+
+await rm(outputDir, { recursive: true, force: true });
+await mkdir(resolve(packageDir, 'dist'), { recursive: true });
+await cp(sourceDir, outputDir, { recursive: true });

--- a/packages/runtime/src/pod-tool-operations.ts
+++ b/packages/runtime/src/pod-tool-operations.ts
@@ -1,5 +1,6 @@
-import { mkdir, rm } from 'fs/promises';
-import { resolve, relative } from 'path';
+import { mkdir, readFile as readLocalFile, rm } from 'fs/promises';
+import { dirname, resolve, relative } from 'path';
+import { fileURLToPath } from 'url';
 import { PodManager } from './pod-manager.js';
 
 interface BashOperations {
@@ -28,24 +29,9 @@ interface EditOperations {
   access: (absolutePath: string) => Promise<void>;
 }
 
-interface FindOperations {
-  exists: (absolutePath: string) => Promise<boolean>;
-  glob: (pattern: string, cwd: string, options: { ignore: string[]; limit: number }) => Promise<string[]>;
-}
-
-interface GrepOperations {
-  isDirectory: (absolutePath: string) => Promise<boolean>;
-  readFile: (absolutePath: string) => Promise<string>;
-}
-
-interface LsOperations {
-  exists: (absolutePath: string) => Promise<boolean>;
-  stat: (absolutePath: string) => Promise<{ isDirectory: () => boolean }>;
-  readdir: (absolutePath: string) => Promise<string[]>;
-}
-
 const REMOTE_CWD = '/home/node';
 const PYTHON = 'python3';
+const POD_TOOL_SCRIPTS_DIR = resolve(dirname(fileURLToPath(import.meta.url)), 'pod-tool-scripts');
 
 const MIME_BY_EXT: Record<string, string> = {
   '.png': 'image/png',
@@ -70,17 +56,22 @@ interface ExecResult {
   exitCode: number | null;
 }
 
+interface ExecCommandOptions {
+  stdinData?: string | Buffer;
+}
+
 async function execCommand(
   podManager: PodManager,
   userId: string,
   command: string[],
+  options: ExecCommandOptions = {},
 ): Promise<ExecResult> {
   await podManager.ensurePod(userId);
   podManager.touch(userId);
 
   const exec = await podManager.execInPod(userId, command);
 
-  return new Promise<ExecResult>((resolve, reject) => {
+  return new Promise<ExecResult>((resolveResult, reject) => {
     const stdoutChunks: Buffer[] = [];
     const stderrChunks: Buffer[] = [];
     let stdoutEnded = false;
@@ -93,7 +84,7 @@ async function execCommand(
       if (settled || !stdoutEnded || !stderrEnded || !doneResolved) return;
       settled = true;
       exec.close();
-      resolve({
+      resolveResult({
         stdout: Buffer.concat(stdoutChunks),
         stderr: Buffer.concat(stderrChunks),
         exitCode,
@@ -123,6 +114,7 @@ async function execCommand(
     });
     exec.stdout.on('error', (err) => fail(err instanceof Error ? err : new Error(String(err))));
     exec.stderr.on('error', (err) => fail(err instanceof Error ? err : new Error(String(err))));
+    exec.stdin.on('error', (err) => fail(err instanceof Error ? err : new Error(String(err))));
 
     if (exec.done) {
       exec.done.then((result) => {
@@ -133,6 +125,17 @@ async function execCommand(
         fail(err instanceof Error ? err : new Error(String(err)));
       });
     }
+
+    queueMicrotask(() => {
+      try {
+        if (options.stdinData !== undefined) {
+          exec.stdin.write(options.stdinData);
+        }
+        exec.stdin.end();
+      } catch (err) {
+        fail(err instanceof Error ? err : new Error(String(err)));
+      }
+    });
   });
 }
 
@@ -140,8 +143,9 @@ async function execText(
   podManager: PodManager,
   userId: string,
   command: string[],
+  options?: ExecCommandOptions,
 ): Promise<string> {
-  const result = await execCommand(podManager, userId, command);
+  const result = await execCommand(podManager, userId, command, options);
   if (result.exitCode !== 0) {
     const stderr = result.stderr.toString('utf8').trim();
     throw new Error(stderr || `Command failed with exit code ${result.exitCode ?? 'null'}`);
@@ -158,17 +162,38 @@ async function execBoolean(
   return result.exitCode === 0;
 }
 
+async function getPythonScript(scriptName: string): Promise<string> {
+  const scriptPath = resolve(POD_TOOL_SCRIPTS_DIR, `${scriptName}.py`);
+  return readLocalFile(scriptPath, 'utf8');
+}
+
+async function execPythonScript(
+  podManager: PodManager,
+  userId: string,
+  scriptName: string,
+  args: string[] = [],
+): Promise<string> {
+  const script = await getPythonScript(scriptName);
+
+  try {
+    return await execText(
+      podManager,
+      userId,
+      [PYTHON, '-', ...args],
+      { stdinData: script },
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`Python helper ${scriptName}.py failed: ${message}`);
+  }
+}
+
 async function readBinaryFile(
   podManager: PodManager,
   userId: string,
   absolutePath: string,
 ): Promise<Buffer> {
-  const encoded = await execText(podManager, userId, [
-    PYTHON,
-    '-c',
-    'import base64,sys; print(base64.b64encode(open(sys.argv[1],"rb").read()).decode("ascii"))',
-    absolutePath,
-  ]);
+  const encoded = await execPythonScript(podManager, userId, 'read-binary-file', [absolutePath]);
   return Buffer.from(encoded.trim(), 'base64');
 }
 
@@ -178,20 +203,9 @@ async function writeBinaryFile(
   absolutePath: string,
   content: Buffer,
 ): Promise<void> {
-  const encoded = content.toString('base64');
-  await execText(podManager, userId, [
-    PYTHON,
-    '-c',
-    [
-      'import base64, os, sys',
-      'path = sys.argv[1]',
-      'os.makedirs(os.path.dirname(path), exist_ok=True)',
-      'with open(path, "wb") as fh:',
-      '    fh.write(base64.b64decode(sys.argv[2]))',
-      'print("ok")',
-    ].join('; '),
+  await execPythonScript(podManager, userId, 'write-binary-file', [
     absolutePath,
-    encoded,
+    content.toString('base64'),
   ]);
 }
 
@@ -207,9 +221,6 @@ export function createPodToolOperations(deps: {
   read: ReadOperations;
   write: WriteOperations;
   edit: EditOperations;
-  find: FindOperations;
-  grep: GrepOperations;
-  ls: LsOperations;
 } {
   const { podManager, userId } = deps;
 
@@ -228,7 +239,7 @@ export function createPodToolOperations(deps: {
 
       const exec = await podManager.execInPod(userId, ['sh', '-lc', script]);
 
-      return new Promise<{ exitCode: number | null }>((resolve, reject) => {
+      return new Promise<{ exitCode: number | null }>((resolveResult, reject) => {
         let settled = false;
         let timer: NodeJS.Timeout | undefined;
 
@@ -242,7 +253,7 @@ export function createPodToolOperations(deps: {
           settled = true;
           cleanup();
           exec.close();
-          resolve({ exitCode });
+          resolveResult({ exitCode });
         };
 
         const fail = (err: Error) => {
@@ -303,7 +314,7 @@ export function createPodToolOperations(deps: {
       await writeBinaryFile(podManager, userId, absolutePath, Buffer.from(content, 'utf8'));
     },
     async mkdir(dir) {
-      await execText(podManager, userId, [PYTHON, '-c', 'import os,sys; os.makedirs(sys.argv[1], exist_ok=True); print("ok")', dir]);
+      await execPythonScript(podManager, userId, 'mkdir', [dir]);
     },
   };
 
@@ -320,71 +331,7 @@ export function createPodToolOperations(deps: {
     },
   };
 
-  const find: FindOperations = {
-    async exists(absolutePath) {
-      return execBoolean(podManager, userId, ['test', '-e', absolutePath]);
-    },
-    async glob(pattern, cwd, options) {
-      const output = await execText(podManager, userId, [
-        PYTHON,
-        '-c',
-        [
-          'import glob, json, os, sys',
-          'pattern = sys.argv[1]',
-          'cwd = sys.argv[2]',
-          'ignore = set(filter(None, sys.argv[3].split("\n")))',
-          'limit = int(sys.argv[4])',
-          'matches = []',
-          'for path in sorted(glob.glob(os.path.join(cwd, pattern), recursive=True)):',
-          '    rel = os.path.relpath(path, cwd)',
-          '    if rel == ".": continue',
-          '    parts = rel.split(os.sep)',
-          '    if any(part in ignore for part in parts): continue',
-          '    matches.append(rel.replace(os.sep, "/"))',
-          '    if len(matches) >= limit: break',
-          'print(json.dumps(matches))',
-        ].join('; '),
-        pattern,
-        cwd,
-        options.ignore.join('\n'),
-        String(options.limit),
-      ]);
-      return JSON.parse(output) as string[];
-    },
-  };
-
-  const grep: GrepOperations = {
-    async isDirectory(absolutePath) {
-      const exists = await execBoolean(podManager, userId, ['test', '-e', absolutePath]);
-      if (!exists) throw new Error(`Path not found: ${absolutePath}`);
-      return execBoolean(podManager, userId, ['test', '-d', absolutePath]);
-    },
-    async readFile(absolutePath) {
-      const buffer = await readBinaryFile(podManager, userId, absolutePath);
-      return buffer.toString('utf8');
-    },
-  };
-
-  const ls: LsOperations = {
-    async exists(absolutePath) {
-      return execBoolean(podManager, userId, ['test', '-e', absolutePath]);
-    },
-    async stat(absolutePath) {
-      const isDirectory = await execBoolean(podManager, userId, ['test', '-d', absolutePath]);
-      return { isDirectory: () => isDirectory };
-    },
-    async readdir(absolutePath) {
-      const output = await execText(podManager, userId, [
-        PYTHON,
-        '-c',
-        'import json, os, sys; print(json.dumps(sorted(os.listdir(sys.argv[1]))))',
-        absolutePath,
-      ]);
-      return JSON.parse(output) as string[];
-    },
-  };
-
-  return { bash, read, write, edit, find, grep, ls };
+  return { bash, read, write, edit };
 }
 
 export async function deleteSessionFile(sessionPath: string): Promise<void> {

--- a/packages/runtime/src/pod-tool-scripts/mkdir.py
+++ b/packages/runtime/src/pod-tool-scripts/mkdir.py
@@ -1,0 +1,5 @@
+import os
+import sys
+
+os.makedirs(sys.argv[1], exist_ok=True)
+print('ok')

--- a/packages/runtime/src/pod-tool-scripts/read-binary-file.py
+++ b/packages/runtime/src/pod-tool-scripts/read-binary-file.py
@@ -1,0 +1,6 @@
+import base64
+import sys
+
+path = sys.argv[1]
+with open(path, 'rb') as handle:
+    sys.stdout.write(base64.b64encode(handle.read()).decode('ascii'))

--- a/packages/runtime/src/pod-tool-scripts/write-binary-file.py
+++ b/packages/runtime/src/pod-tool-scripts/write-binary-file.py
@@ -1,0 +1,12 @@
+import base64
+import os
+import sys
+
+path = sys.argv[1]
+encoded = sys.argv[2]
+parent = os.path.dirname(path)
+if parent:
+    os.makedirs(parent, exist_ok=True)
+with open(path, 'wb') as handle:
+    handle.write(base64.b64decode(encoded))
+print('ok')

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -250,6 +250,7 @@ class SessionManager {
       edit: createEditTool(getRemoteWorkspaceCwd(), { operations: operations.edit }),
       write: createWriteTool(getRemoteWorkspaceCwd(), { operations: operations.write }),
     };
+    const activeToolNames = ['read', 'bash', 'edit', 'write'] as const;
 
     const { session } = await createAgentSession({
       cwd: getRemoteWorkspaceCwd(),
@@ -257,7 +258,7 @@ class SessionManager {
       authStorage,
       modelRegistry,
       sessionManager,
-      tools: Object.values(baseTools),
+      tools: activeToolNames.map((name) => baseTools[name]),
     });
 
     // pi SDK 0.64.0 only uses options.tools to pick active tool names; it still
@@ -267,7 +268,7 @@ class SessionManager {
     const sessionWithOverride = session as unknown as AgentSessionWithToolOverride;
     sessionWithOverride._baseToolsOverride = baseTools;
     sessionWithOverride._buildRuntime?.({
-      activeToolNames: Object.keys(baseTools),
+      activeToolNames: [...activeToolNames],
       includeAllExtensionTools: true,
     });
 

--- a/packages/runtime/test/pod-tool-operations.test.ts
+++ b/packages/runtime/test/pod-tool-operations.test.ts
@@ -1,35 +1,85 @@
 import { PassThrough } from 'stream';
 import { describe, expect, it, vi } from 'vitest';
+import { createEditTool, createWriteTool } from '@mariozechner/pi-coding-agent';
 import { createPodToolOperations } from '../src/pod-tool-operations';
 
-function createExecStreams() {
-  const stdout = new PassThrough();
-  const stderr = new PassThrough();
-  const stdin = new PassThrough();
-  return {
-    stdin,
-    stdout,
-    stderr,
-    done: Promise.resolve({ exitCode: 0 }),
-    close: vi.fn(() => {
-      stdin.end();
-      stdout.end();
-      stderr.end();
-    }),
-  };
+interface ExecStep {
+  stdout?: string;
+  stderr?: string;
+  exitCode?: number;
 }
 
-describe('pod-tool-operations bash env forwarding', () => {
-  it('does not forward host/service env vars into the sandbox shell', async () => {
-    const exec = createExecStreams();
-    let capturedCommand: string[] | null = null;
+function createScriptedPodManager(steps: ExecStep[]) {
+  const commands: string[][] = [];
+  const stdinPayloads: string[] = [];
 
+  const podManager = {
+    ensurePod: vi.fn(async () => {}),
+    touch: vi.fn(),
+    execInPod: vi.fn(async (_userId: string, command: string[]) => {
+      const step = steps.shift();
+      if (!step) {
+        throw new Error(`Unexpected exec call: ${command.join(' ')}`);
+      }
+
+      commands.push(command);
+
+      const stdout = new PassThrough();
+      const stderr = new PassThrough();
+      const stdin = new PassThrough();
+      const stdinChunks: Buffer[] = [];
+
+      stdin.on('data', (chunk: Buffer | string) => {
+        stdinChunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      });
+      stdin.on('end', () => {
+        stdinPayloads.push(Buffer.concat(stdinChunks).toString('utf8'));
+      });
+
+      queueMicrotask(() => {
+        if (step.stdout) stdout.write(step.stdout);
+        if (step.stderr) stderr.write(step.stderr);
+        stdout.end();
+        stderr.end();
+      });
+
+      return {
+        stdin,
+        stdout,
+        stderr,
+        done: Promise.resolve({ exitCode: step.exitCode ?? 0 }),
+        close: vi.fn(() => {
+          stdin.end();
+          stdout.end();
+          stderr.end();
+        }),
+      };
+    }),
+  };
+
+  return { podManager, commands, stdinPayloads };
+}
+
+describe('pod-tool-operations', () => {
+  it('does not forward host/service env vars into the sandbox shell', async () => {
+    const exec = {
+      stdin: new PassThrough(),
+      stdout: new PassThrough(),
+      stderr: new PassThrough(),
+      done: Promise.resolve({ exitCode: 0 }),
+      close: vi.fn(() => {
+        exec.stdin.end();
+        exec.stdout.end();
+        exec.stderr.end();
+      }),
+    };
+
+    let capturedCommand: string[] | null = null;
     const podManager = {
       ensurePod: vi.fn(async () => {}),
       touch: vi.fn(),
       execInPod: vi.fn(async (_userId: string, command: string[]) => {
         capturedCommand = command;
-        // End streams on next tick so the operation resolves.
         queueMicrotask(() => {
           exec.stdout.end();
           exec.stderr.end();
@@ -56,5 +106,119 @@ describe('pod-tool-operations bash env forwarding', () => {
     expect(capturedCommand?.join(' ')).not.toContain('JWT_SECRET');
     expect(capturedCommand?.join(' ')).not.toContain('ENCRYPTION_KEY');
     expect(capturedCommand?.join(' ')).not.toContain('export PATH=');
+  });
+
+  it('streams dedicated python helper scripts into the pod for write operations', async () => {
+    const { podManager, commands, stdinPayloads } = createScriptedPodManager([
+      { stdout: 'ok\n' },
+    ]);
+
+    const { write } = createPodToolOperations({
+      podManager: podManager as any,
+      userId: 'user-1',
+    });
+
+    await write.writeFile('/home/node/demo.txt', 'hello');
+
+    expect(commands).toEqual([
+      ['python3', '-', '/home/node/demo.txt', 'aGVsbG8='],
+    ]);
+    expect(stdinPayloads[0]).toContain("with open(path, 'wb') as handle:");
+    expect(stdinPayloads[0]).toContain('base64.b64decode(encoded)');
+    expect(commands[0]).not.toContain('-c');
+  });
+
+  it('reads binary files through a dedicated python helper script', async () => {
+    const { podManager, commands, stdinPayloads } = createScriptedPodManager([
+      { stdout: Buffer.from('hello', 'utf8').toString('base64') },
+    ]);
+
+    const { read } = createPodToolOperations({
+      podManager: podManager as any,
+      userId: 'user-1',
+    });
+
+    const content = await read.readFile('/home/node/demo.txt');
+
+    expect(content.toString('utf8')).toBe('hello');
+    expect(commands).toEqual([
+      ['python3', '-', '/home/node/demo.txt'],
+    ]);
+    expect(stdinPayloads[0]).toContain('base64.b64encode(handle.read())');
+    expect(commands[0]).not.toContain('-c');
+  });
+
+  it('supports write tool success path, including parent directory creation', async () => {
+    const { podManager, commands, stdinPayloads } = createScriptedPodManager([
+      { stdout: 'ok\n' },
+      { stdout: 'ok\n' },
+    ]);
+
+    const operations = createPodToolOperations({
+      podManager: podManager as any,
+      userId: 'user-1',
+    });
+    const writeTool = createWriteTool('/home/node', { operations: operations.write });
+
+    const result = await writeTool.execute('tool-1', {
+      path: 'nested/demo.txt',
+      content: 'hello',
+    });
+
+    expect(result.content).toEqual([
+      { type: 'text', text: 'Successfully wrote 5 bytes to nested/demo.txt' },
+    ]);
+    expect(commands).toEqual([
+      ['python3', '-', '/home/node/nested'],
+      ['python3', '-', '/home/node/nested/demo.txt', 'aGVsbG8='],
+    ]);
+    expect(stdinPayloads[0]).toContain('os.makedirs(sys.argv[1], exist_ok=True)');
+    expect(stdinPayloads[1]).toContain("with open(path, 'wb') as handle:");
+  });
+
+  it('supports edit tool success path through the same script-backed transport', async () => {
+    const originalContent = 'alpha\n';
+    const { podManager, commands, stdinPayloads } = createScriptedPodManager([
+      {},
+      { stdout: Buffer.from(originalContent, 'utf8').toString('base64') },
+      { stdout: 'ok\n' },
+    ]);
+
+    const operations = createPodToolOperations({
+      podManager: podManager as any,
+      userId: 'user-1',
+    });
+    const editTool = createEditTool('/home/node', { operations: operations.edit });
+
+    const result = await editTool.execute('tool-2', {
+      path: 'notes.txt',
+      edits: [{ oldText: 'alpha', newText: 'beta' }],
+    });
+
+    expect(result.content).toEqual([
+      { type: 'text', text: 'Successfully replaced 1 block(s) in notes.txt.' },
+    ]);
+    expect(commands).toEqual([
+      ['test', '-r', '/home/node/notes.txt'],
+      ['python3', '-', '/home/node/notes.txt'],
+      ['python3', '-', '/home/node/notes.txt', Buffer.from('beta\n', 'utf8').toString('base64')],
+    ]);
+    expect(stdinPayloads[1]).toContain('base64.b64encode(handle.read())');
+    expect(stdinPayloads[2]).toContain("with open(path, 'wb') as handle:");
+  });
+
+  it('surfaces python helper failures with the helper name', async () => {
+    const { podManager } = createScriptedPodManager([
+      { stderr: 'traceback misery\n', exitCode: 1 },
+    ]);
+
+    const { write } = createPodToolOperations({
+      podManager: podManager as any,
+      userId: 'user-1',
+    });
+
+    await expect(write.writeFile('/home/node/demo.txt', 'hello')).rejects.toThrow(
+      'Python helper write-binary-file.py failed: traceback misery',
+    );
   });
 });

--- a/packages/runtime/test/session-manager.test.ts
+++ b/packages/runtime/test/session-manager.test.ts
@@ -9,7 +9,47 @@ const createdSessions: Array<{
   subscribe: ReturnType<typeof vi.fn>;
   emit: (event: unknown) => void;
   listeners: Set<(event: unknown) => void>;
+  _baseToolsOverride?: Record<string, unknown>;
+  _buildRuntime: ReturnType<typeof vi.fn>;
 }> = [];
+
+const createAgentSessionMock = vi.fn(async ({ sessionManager }: { sessionManager: { sessionFile: string } }) => {
+  const listeners = new Set<(event: unknown) => void>();
+  const session = {
+    id: sessionManager.sessionFile,
+    sessionFile: sessionManager.sessionFile,
+    prompt: vi.fn(async () => {}),
+    abort: vi.fn(async () => {}),
+    setModel: vi.fn(async () => {}),
+    dispose: vi.fn(),
+    subscribe: vi.fn((listener: (event: unknown) => void) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    }),
+    emit: (event: unknown) => {
+      for (const listener of listeners) listener(event);
+    },
+    listeners,
+    messages: [],
+    thinkingLevel: 'medium',
+    model: null,
+    _buildRuntime: vi.fn(),
+    _baseToolsOverride: undefined as Record<string, unknown> | undefined,
+  };
+  createdSessions.push(session);
+  return { session };
+});
+
+const createReadToolMock = vi.fn(() => ({ name: 'read' }));
+const createBashToolMock = vi.fn(() => ({ name: 'bash' }));
+const createEditToolMock = vi.fn(() => ({ name: 'edit' }));
+const createWriteToolMock = vi.fn(() => ({ name: 'write' }));
+const createPodToolOperationsMock = vi.fn(() => ({
+  read: { transport: 'read' },
+  bash: { transport: 'bash' },
+  edit: { transport: 'edit' },
+  write: { transport: 'write' },
+}));
 
 vi.mock('@mariozechner/pi-coding-agent', () => {
   return {
@@ -24,45 +64,11 @@ vi.mock('@mariozechner/pi-coding-agent', () => {
       open: (sessionPath: string) => ({ sessionFile: sessionPath }),
     },
     getAgentDir: () => '/tmp/.pi/agent',
-    createAgentSession: vi.fn(async ({ sessionManager }: { sessionManager: { sessionFile: string } }) => {
-      const listeners = new Set<(event: unknown) => void>();
-      const session = {
-        id: sessionManager.sessionFile,
-        prompt: vi.fn(async () => {}),
-        abort: vi.fn(async () => {}),
-        setModel: vi.fn(async () => {}),
-        dispose: vi.fn(),
-        subscribe: vi.fn((listener: (event: unknown) => void) => {
-          listeners.add(listener);
-          return () => listeners.delete(listener);
-        }),
-        emit: (event: unknown) => {
-          for (const listener of listeners) listener(event);
-        },
-        listeners,
-      };
-      createdSessions.push(session);
-      return {
-        session: {
-          sessionFile: sessionManager.sessionFile,
-          prompt: session.prompt,
-          abort: session.abort,
-          setModel: session.setModel,
-          subscribe: session.subscribe,
-          dispose: session.dispose,
-          messages: [],
-          thinkingLevel: 'medium',
-          model: null,
-        },
-      };
-    }),
-    createReadTool: vi.fn(() => ({})),
-    createBashTool: vi.fn(() => ({})),
-    createEditTool: vi.fn(() => ({})),
-    createWriteTool: vi.fn(() => ({})),
-    createGrepTool: vi.fn(() => ({})),
-    createFindTool: vi.fn(() => ({})),
-    createLsTool: vi.fn(() => ({})),
+    createAgentSession: createAgentSessionMock,
+    createReadTool: createReadToolMock,
+    createBashTool: createBashToolMock,
+    createEditTool: createEditToolMock,
+    createWriteTool: createWriteToolMock,
   };
 });
 
@@ -87,24 +93,23 @@ vi.mock('../src/pod-manager.js', () => ({
   },
 }));
 vi.mock('../src/pod-tool-operations.js', () => ({
-  createPodToolOperations: () => ({
-    read: {},
-    bash: {},
-    edit: {},
-    write: {},
-    grep: {},
-    find: {},
-    ls: {},
-  }),
+  createPodToolOperations: createPodToolOperationsMock,
   deleteSessionFile: vi.fn(async () => {}),
   ensureSessionDir: vi.fn(async () => {}),
   getRemoteWorkspaceCwd: () => '/home/node',
   isSessionPathInside: () => true,
 }));
 
-describe('sessionManager conversation isolation', () => {
+describe('sessionManager', () => {
   beforeEach(() => {
     createdSessions.length = 0;
+    createAgentSessionMock.mockClear();
+    createReadToolMock.mockClear();
+    createBashToolMock.mockClear();
+    createEditToolMock.mockClear();
+    createWriteToolMock.mockClear();
+    createPodToolOperationsMock.mockClear();
+    vi.resetModules();
   });
 
   it('keeps separate session instances per conversation', async () => {
@@ -131,5 +136,44 @@ describe('sessionManager conversation isolation', () => {
 
     expect(eventsA).toEqual([{ type: 'message_end', source: 'a' }]);
     expect(eventsB).toEqual([{ type: 'message_end', source: 'b' }]);
+
+    await sessionManager.shutdown();
+  });
+
+  it('limits the runtime tool surface to read, bash, edit, and write', async () => {
+    const { sessionManager } = await import('../src/session-manager');
+
+    await sessionManager.switchSession('user-1', 'conv-a', null);
+
+    expect(createPodToolOperationsMock).toHaveBeenCalledWith({
+      podManager: expect.any(Object),
+      userId: 'user-1',
+    });
+    expect(createReadToolMock).toHaveBeenCalledWith('/home/node', { operations: { transport: 'read' } });
+    expect(createBashToolMock).toHaveBeenCalledWith('/home/node', { operations: { transport: 'bash' } });
+    expect(createEditToolMock).toHaveBeenCalledWith('/home/node', { operations: { transport: 'edit' } });
+    expect(createWriteToolMock).toHaveBeenCalledWith('/home/node', { operations: { transport: 'write' } });
+
+    expect(createAgentSessionMock).toHaveBeenCalledTimes(1);
+    expect(createAgentSessionMock.mock.calls[0]?.[0]?.tools).toEqual([
+      { name: 'read' },
+      { name: 'bash' },
+      { name: 'edit' },
+      { name: 'write' },
+    ]);
+
+    expect(createdSessions).toHaveLength(1);
+    expect(createdSessions[0]._buildRuntime).toHaveBeenCalledWith({
+      activeToolNames: ['read', 'bash', 'edit', 'write'],
+      includeAllExtensionTools: true,
+    });
+    expect(createdSessions[0]._baseToolsOverride).toEqual({
+      read: { name: 'read' },
+      bash: { name: 'bash' },
+      edit: { name: 'edit' },
+      write: { name: 'write' },
+    });
+
+    await sessionManager.shutdown();
   });
 });


### PR DESCRIPTION
## What this PR does

This brings Goldilocks' pod-backed tool transport back into line with the intended Pi integration.

The main goals are to:
- keep the agent tool surface explicitly limited to `read`, `write`, `edit`, and `bash`
- remove backend drift from the pod transport layer
- fix the broken remote `write` path without teaching the agent to work around it with shell hacks

The important boundary stays the same: Pi owns tool semantics, while Goldilocks only swaps the execution backend so the agent's "hands" stay inside the sandbox pod.

## Key changes

### 1. Replace inline Python `-c` snippets with dedicated helper scripts
The old pod backend built Python helpers as flattened one-liners and passed them through `python3 -c`. That was brittle and is what broke `write` when compound statements like `with open(...)` were involved.

This PR replaces that path with dedicated helper scripts under `packages/runtime/src/pod-tool-scripts/`, executed through a shared `execPythonScript()` path using `python3 -`.

Added helpers:
- `read-binary-file.py`
- `write-binary-file.py`
- `mkdir.py`

### 2. Fix remote write/edit transport reliability
`writeBinaryFile()` and the edit writeback path now use the same script-backed transport, so they no longer depend on semicolon-flattened Python command strings.

This fixes the actual write failure while also making the read/write/edit backend path more predictable and easier to reason about.

### 3. Lock the runtime tool surface to four tools
Goldilocks is intentionally not exposing the full default Pi file/shell tool set here.

This PR keeps the runtime explicitly limited to:
- `read`
- `write`
- `edit`
- `bash`

`find`, `grep`, and `ls` are removed from the pod tool operations surface. If the agent needs shell-style discovery, it can use `bash`.

### 4. Add regression coverage for transport behavior and tool exposure
Added tests covering:
- no host/service env forwarding into sandbox `bash`
- script-backed remote read/write execution via `python3 -`
- write-tool parent directory creation
- edit success path over the same transport
- helper failure reporting with useful helper names
- session runtime wiring exposing only `read` / `write` / `edit` / `bash`

### 5. Update architecture docs to match the real contract
The backend docs now describe the pod tool layer as a transport compatibility layer for Pi's built-in tools, and they document the intentionally reduced four-tool surface.

## Testing
- `npx vitest run packages/runtime/test/pod-tool-operations.test.ts packages/runtime/test/session-manager.test.ts`
- `npx vitest run`
- `npm run build`
