### PR TITLE
Wave 1: secret guards and shell injection elimination

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -1,0 +1,28 @@
+# Copy this file to .env.dev and fill in real values before starting Goldilocks.
+# Example secret generation:
+#   openssl rand -hex 32
+#   python3 - <<'PY'
+#   import secrets
+#   print(secrets.token_hex(32))
+#   PY
+
+# Server
+PORT=3000
+NODE_ENV=development
+CORS_ORIGIN=http://localhost:5173
+
+# State
+DATA_DIR=.dev
+WORKSPACE_ROOT=.dev/workspaces
+
+# Required secrets
+JWT_SECRET=replace-with-a-random-secret
+ENCRYPTION_KEY=replace-with-a-random-secret
+AGENT_SERVICE_SHARED_SECRET=replace-with-a-random-secret
+
+# Runtime / k8s
+K8S_NAMESPACE=goldilocks
+AGENT_IMAGE=goldilocks-agent:latest
+AGENT_SERVICE_URL=http://agent-service:3001
+AGENT_SERVICE_WS_URL=ws://agent-service:3001/ws
+AGENT_IDLE_TIMEOUT_MS=1800000

--- a/.env.example
+++ b/.env.example
@@ -1,13 +1,16 @@
 # Server
 PORT=3000
 NODE_ENV=development
+CORS_ORIGIN=http://localhost:5173
 
-# Database
-DATA_DIR=./data
+# State
+DATA_DIR=.dev
+WORKSPACE_ROOT=.dev/workspaces
 
-# Auth
-JWT_SECRET=change-me-in-production-use-a-long-random-string
-ENCRYPTION_KEY=change-me-32-bytes-for-aes-256
+# Required secrets
+JWT_SECRET=replace-with-a-random-secret
+ENCRYPTION_KEY=replace-with-a-random-secret
+AGENT_SERVICE_SHARED_SECRET=replace-with-a-random-secret
 
 # API Keys (optional - users can provide their own)
 ANTHROPIC_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ build/
 # Environment
 .env
 .env.local
+.env.dev
 .env.*.local
 
 # Data

--- a/apps/agent-service/src/index.ts
+++ b/apps/agent-service/src/index.ts
@@ -17,6 +17,8 @@ import {
   websocketErrored,
 } from './metrics.js';
 
+CONFIG.validateRequiredSecrets();
+
 interface InternalAuthRequest extends express.Request {
   internalUserId?: string;
 }

--- a/apps/gateway/src/files/routes.ts
+++ b/apps/gateway/src/files/routes.ts
@@ -1,24 +1,32 @@
 /**
- * File routes -- workspace file operations via k8s exec into the user's pod.
+ * File routes -- workspace file operations via the user's pod-backed home directory.
  *
- * Files live on the user's PVC at /home/node/.
- * All operations exec into the pod to read/write the PVC.
+ * Files live on the user's mounted home at /home/node in the pod, backed by a host
+ * path managed by the pod manager. Read/raw/move/delete still use pod exec, while
+ * list/search/write now operate directly on the host-mounted path to avoid any shell
+ * interpolation with user-controlled input.
  *
  * Note: These routes are scoped per user (via auth), not per conversation.
  *
  * Route order matters (Express matches first):
- *   1. GET /          -- list (static)
- *   2. POST /upload   -- upload (static)
- *   3. POST /move     -- move (static)
- *   4. GET /<path>/raw -- raw download (specific, before catch-all)
- *   5. GET /<path>     -- read file (regex catch-all, also used for PUT/DELETE)
+ *   1. GET /           -- list (static)
+ *   2. POST /upload    -- upload (static)
+ *   3. POST /move      -- move (static)
+ *   4. POST /mkdir     -- mkdir (static)
+ *   5. GET /<path>/raw -- raw download (specific, before catch-all)
+ *   6. GET /<path>     -- read file (regex catch-all, also used for PUT/DELETE)
  */
 
+import { promises as fs } from 'fs';
+import { dirname, relative, resolve, sep } from 'path';
 import { Router, Response } from 'express';
-import { verifyToken, AuthRequest } from '../auth/middleware.js';
+import { CONFIG } from '@goldilocks/config';
 import { sessionManager } from '@goldilocks/runtime';
+import { verifyToken, AuthRequest } from '../auth/middleware.js';
 
 const router = Router();
+const SEARCH_LIMIT = 50;
+const SEARCH_MAX_DEPTH = 2;
 
 router.use(verifyToken);
 
@@ -33,12 +41,19 @@ interface FileEntry {
   modified?: number;
 }
 
+interface FlatFileEntry {
+  path: string;
+  type: 'file' | 'dir';
+  size: number;
+  modified: number;
+}
+
 async function execCommand(userId: string, command: string[]): Promise<string> {
   const podManager = sessionManager.getPodManager();
   await podManager.ensurePod(userId);
   const exec = await podManager.execInPod(userId, command);
 
-  return new Promise((resolve, reject) => {
+  return new Promise((resolveOutput, reject) => {
     const chunks: Buffer[] = [];
     const errChunks: Buffer[] = [];
     let settled = false;
@@ -54,7 +69,7 @@ async function execCommand(userId: string, command: string[]): Promise<string> {
       const output = Buffer.concat(chunks).toString();
       const errOutput = Buffer.concat(errChunks).toString().trim();
       if (errOutput) console.error(`exec stderr for user ${userId}: ${errOutput}`);
-      resolve(output);
+      resolveOutput(output);
     };
 
     exec.stdout.on('data', (chunk: Buffer) => chunks.push(chunk));
@@ -68,12 +83,6 @@ async function execCommand(userId: string, command: string[]): Promise<string> {
   });
 }
 
-async function writeFileViaExec(userId: string, path: string, base64Content: string): Promise<void> {
-  await execCommand(userId, [
-    'sh', '-c', `echo '${base64Content}' | base64 -d > /home/node/${path} && echo OK`
-  ]);
-}
-
 function sanitizePath(path: string): string {
   let decoded = path;
   try {
@@ -81,17 +90,111 @@ function sanitizePath(path: string): string {
   } catch {
     decoded = path;
   }
-  return decoded.replace(/\.\./g, '').replace(/^\/+/, '');
+  return decoded.replace(/\0/g, '').replace(/^\/+/, '');
 }
 
-function buildTree(
-  flat: { path: string; type: 'file' | 'dir'; size?: number; modified?: number }[]
-): FileEntry[] {
+function getUserHomeRoot(userId: string): string {
+  const podManager = sessionManager.getPodManager() as { getUserHomeHostPath?: (userId: string) => string };
+  if (typeof podManager.getUserHomeHostPath === 'function') {
+    return podManager.getUserHomeHostPath(userId);
+  }
+  if (CONFIG.nodeEnv === 'test') {
+    return resolve(CONFIG.workspaceRoot, userId);
+  }
+  throw new Error('PodManager does not expose a host user-home path');
+}
+
+function resolveUserPath(userId: string, path: string): { root: string; absolutePath: string; relativePath: string } {
+  const root = resolve(getUserHomeRoot(userId));
+  const sanitized = sanitizePath(path);
+  if (!sanitized) {
+    throw new Error('Invalid path');
+  }
+
+  const absolutePath = resolve(root, sanitized);
+  if (absolutePath !== root && !absolutePath.startsWith(`${root}${sep}`)) {
+    throw new Error('Invalid path');
+  }
+
+  return {
+    root,
+    absolutePath,
+    relativePath: relative(root, absolutePath),
+  };
+}
+
+async function ensureUserHome(userId: string): Promise<string> {
+  const root = getUserHomeRoot(userId);
+  await fs.mkdir(root, { recursive: true });
+  return root;
+}
+
+async function writeUserFile(userId: string, path: string, content: Buffer): Promise<void> {
+  const { absolutePath } = resolveUserPath(userId, path);
+  await fs.mkdir(dirname(absolutePath), { recursive: true });
+  await fs.writeFile(absolutePath, content);
+}
+
+async function collectWorkspaceEntries(
+  root: string,
+  options: { search?: string; maxDepth?: number; limit?: number } = {}
+): Promise<FlatFileEntry[]> {
+  await fs.mkdir(root, { recursive: true });
+
+  const results: FlatFileEntry[] = [];
+  const searchTerm = options.search?.toLowerCase();
+  const maxDepth = options.maxDepth ?? Number.POSITIVE_INFINITY;
+  const limit = options.limit ?? Number.POSITIVE_INFINITY;
+
+  const walk = async (currentRelativePath = ''): Promise<boolean> => {
+    const currentAbsolutePath = currentRelativePath ? resolve(root, currentRelativePath) : root;
+    const entries = await fs.readdir(currentAbsolutePath, { withFileTypes: true });
+    entries.sort((a, b) => a.name.localeCompare(b.name));
+
+    for (const entry of entries) {
+      if (entry.name.startsWith('.')) {
+        continue;
+      }
+
+      const entryRelativePath = currentRelativePath ? `${currentRelativePath}/${entry.name}` : entry.name;
+      const entryAbsolutePath = resolve(root, entryRelativePath);
+      const stats = await fs.stat(entryAbsolutePath);
+      const matchesSearch = !searchTerm || entry.name.toLowerCase().includes(searchTerm);
+
+      if (matchesSearch) {
+        results.push({
+          path: entryRelativePath,
+          type: entry.isDirectory() ? 'dir' : 'file',
+          size: stats.size,
+          modified: stats.mtimeMs,
+        });
+
+        if (results.length >= limit) {
+          return true;
+        }
+      }
+
+      const entryDepth = entryRelativePath.split('/').length;
+      if (entry.isDirectory() && entryDepth < maxDepth) {
+        const shouldStop = await walk(entryRelativePath);
+        if (shouldStop) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  };
+
+  await walk();
+  return results;
+}
+
+function buildTree(flat: FlatFileEntry[]): FileEntry[] {
   const root: FileEntry[] = [];
   const index: Map<string, FileEntry> = new Map();
 
   function ensureAncestors(path: string): FileEntry | null {
-    // Ensure all parent directories exist, return the direct parent entry
     const parts = path.split('/').filter(Boolean);
     let children: FileEntry[] = root;
     let currentPath = '';
@@ -114,7 +217,6 @@ function buildTree(
       children = dir.children!;
     }
 
-    // Return the parent's children array for the leaf entry
     return parts.length > 1 ? index.get(parts.slice(0, -1).join('/')) ?? null : null;
   }
 
@@ -140,7 +242,6 @@ function buildTree(
       if (parent?.children) {
         parent.children.push(fileEntry);
       } else {
-        // Shouldn't happen if the find output is consistent, but safe fallback
         root.push(fileEntry);
       }
     }
@@ -152,13 +253,17 @@ function buildTree(
       if (a.type === 'file' && b.type === 'dir') return 1;
       return a.name.localeCompare(b.name);
     });
-    for (const e of entries) {
-      if (e.children) sort(e.children);
+    for (const entry of entries) {
+      if (entry.children) sort(entry.children);
     }
   };
 
   sort(root);
   return root;
+}
+
+function invalidPathResponse(res: Response): void {
+  res.status(400).json({ error: 'Invalid path' });
 }
 
 // --- Route 1: GET / -- List workspace files as a tree ------------------------
@@ -169,38 +274,13 @@ router.get('/', async (req: AuthRequest, res: Response) => {
     return;
   }
 
-  const search = req.query.search as string | undefined;
+  const search = typeof req.query.search === 'string' ? req.query.search : undefined;
 
   try {
-    let output: string;
-
-    if (search) {
-      output = await execCommand(req.user.id, [
-        'sh', '-c',
-        `find /home/node -maxdepth 2 -name "*${search.replace(/'/g, "'\"'\"'")}*" ` +
-        `-not -path "/home/node/.*" -not -name ".*" | head -50 | while read f; do ` +
-        'printf "%s\t%s\t%s\t%s\n" "$f" "$(stat -c %s "$f" 2>/dev/null)" "$(stat -c %Y "$f" 2>/dev/null)" "$(stat -c %F "$f" 2>/dev/null)"; done'
-      ]);
-    } else {
-      output = await execCommand(req.user.id, [
-        'sh', '-c',
-        'find /home/node -not -path "/home/node" -not -path "/home/node/.*" -not -name ".*" | ' +
-        'while read f; do ' +
-        'printf "%s\t%s\t%s\t%s\n" "$f" "$(stat -c %s "$f" 2>/dev/null)" "$(stat -c %Y "$f" 2>/dev/null)" "$(stat -c %F "$f" 2>/dev/null)"; done'
-      ]);
-    }
-
-    const lines = output.split('\n').filter((l) => l.trim());
-
-    const flat = lines.map((line) => {
-      const [fullPath, size, mtime, type] = line.split('\t');
-      return {
-        path: fullPath.replace('/home/node/', ''),
-        type: (type?.trim() === 'directory' ? 'dir' : 'file') as 'file' | 'dir',
-        size: parseInt(size ?? '0', 10) || 0,
-        modified: (parseInt(mtime ?? '0', 10) || 0) * 1000,
-      };
-    });
+    const userHome = await ensureUserHome(req.user.id);
+    const flat = await collectWorkspaceEntries(userHome, search
+      ? { search, maxDepth: SEARCH_MAX_DEPTH, limit: SEARCH_LIMIT }
+      : undefined);
 
     res.json({ entries: buildTree(flat) });
   } catch (err) {
@@ -224,7 +304,7 @@ router.post('/upload', async (req: AuthRequest, res: Response) => {
     return;
   }
 
-  const safeName = filename.replace(/[^a-zA-Z0-9._-]/g, '_').replace(/\/+/g, '_');
+  const safeName = filename.replace(/[^a-zA-Z0-9._/-]/g, '_').replace(/\/+/g, '/');
   if (safeName.startsWith('.') || safeName.includes('..')) {
     res.status(400).json({ error: 'Invalid filename' });
     return;
@@ -232,12 +312,14 @@ router.post('/upload', async (req: AuthRequest, res: Response) => {
 
   try {
     const fileBuffer = Buffer.from(content, 'base64');
-    const base64Content = fileBuffer.toString('base64');
+    await writeUserFile(req.user.id, safeName, fileBuffer);
 
-    await writeFileViaExec(req.user.id, safeName, base64Content);
-
-    res.status(201).json({ ok: true, name: safeName, path: safeName, size: fileBuffer.length });
+    res.status(201).json({ ok: true, name: safeName.split('/').pop() ?? safeName, path: safeName, size: fileBuffer.length });
   } catch (err) {
+    if (err instanceof Error && err.message === 'Invalid path') {
+      invalidPathResponse(res);
+      return;
+    }
     console.error('Error uploading file:', err);
     res.status(500).json({ error: 'Failed to upload file' });
   }
@@ -258,8 +340,15 @@ router.post('/move', async (req: AuthRequest, res: Response) => {
     return;
   }
 
-  const safeFrom = sanitizePath(from);
-  const safeTo = sanitizePath(to);
+  let safeFrom: string;
+  let safeTo: string;
+  try {
+    safeFrom = resolveUserPath(req.user.id, from).relativePath;
+    safeTo = resolveUserPath(req.user.id, to).relativePath;
+  } catch {
+    invalidPathResponse(res);
+    return;
+  }
 
   if (!safeFrom || !safeTo || safeFrom === safeTo) {
     res.status(400).json({ error: 'Invalid from or to path' });
@@ -295,7 +384,14 @@ router.post('/mkdir', async (req: AuthRequest, res: Response) => {
     return;
   }
 
-  const safePath = sanitizePath(dirPath);
+  let safePath: string;
+  try {
+    safePath = resolveUserPath(req.user.id, dirPath).relativePath;
+  } catch {
+    invalidPathResponse(res);
+    return;
+  }
+
   if (!safePath || safePath.startsWith('.')) {
     res.status(400).json({ error: 'Invalid path' });
     return;
@@ -310,7 +406,7 @@ router.post('/mkdir', async (req: AuthRequest, res: Response) => {
   }
 });
 
-// --- Route 4: GET /<path>/raw -- Raw binary download --------------------------
+// --- Route 4: GET /<path>/raw -- Raw binary download -------------------------
 
 router.get(/^\/(.+)\/raw$/, async (req: AuthRequest, res: Response) => {
   if (!req.user) {
@@ -318,10 +414,11 @@ router.get(/^\/(.+)\/raw$/, async (req: AuthRequest, res: Response) => {
     return;
   }
 
-  const safePath = sanitizePath(req.params[0] as string);
-
-  if (!safePath) {
-    res.status(400).json({ error: 'Path is required' });
+  let safePath: string;
+  try {
+    safePath = resolveUserPath(req.user.id, req.params[0] as string).relativePath;
+  } catch {
+    invalidPathResponse(res);
     return;
   }
 
@@ -333,9 +430,9 @@ router.get(/^\/(.+)\/raw$/, async (req: AuthRequest, res: Response) => {
     const chunks: Buffer[] = [];
     exec.stdout.on('data', (chunk: Buffer) => chunks.push(chunk));
 
-    await new Promise<void>((resolve) => {
-      exec.stdout.on('end', () => { exec.close(); resolve(); });
-      setTimeout(() => { exec.close(); resolve(); }, 30_000);
+    await new Promise<void>((resolvePromise) => {
+      exec.stdout.on('end', () => { exec.close(); resolvePromise(); });
+      setTimeout(() => { exec.close(); resolvePromise(); }, 30_000);
     });
 
     const buffer = Buffer.concat(chunks);
@@ -350,7 +447,7 @@ router.get(/^\/(.+)\/raw$/, async (req: AuthRequest, res: Response) => {
   }
 });
 
-// --- Route 5: GET /<path> -- Read file content --------------------------------
+// --- Route 5: GET /<path> -- Read file content -------------------------------
 
 router.get(/^\/(.+)$/, async (req: AuthRequest, res: Response) => {
   if (!req.user) {
@@ -363,10 +460,11 @@ router.get(/^\/(.+)$/, async (req: AuthRequest, res: Response) => {
     return;
   }
 
-  const safePath = sanitizePath(req.params[0] as string);
-
-  if (!safePath) {
-    res.status(400).json({ error: 'Path is required' });
+  let safePath: string;
+  try {
+    safePath = resolveUserPath(req.user.id, req.params[0] as string).relativePath;
+  } catch {
+    invalidPathResponse(res);
     return;
   }
 
@@ -379,7 +477,7 @@ router.get(/^\/(.+)$/, async (req: AuthRequest, res: Response) => {
   }
 });
 
-// --- Route 6: PUT /<path> -- Create or update a file -------------------------
+// --- Route 6: PUT /<path> -- Create or update a file ------------------------
 
 router.put(/^\/(.+)$/, async (req: AuthRequest, res: Response) => {
   if (!req.user) {
@@ -387,10 +485,11 @@ router.put(/^\/(.+)$/, async (req: AuthRequest, res: Response) => {
     return;
   }
 
-  const safePath = sanitizePath(req.params[0] as string);
-
-  if (!safePath) {
-    res.status(400).json({ error: 'Path is required' });
+  let safePath: string;
+  try {
+    safePath = resolveUserPath(req.user.id, req.params[0] as string).relativePath;
+  } catch {
+    invalidPathResponse(res);
     return;
   }
 
@@ -402,23 +501,20 @@ router.put(/^\/(.+)$/, async (req: AuthRequest, res: Response) => {
 
   try {
     const fileBuffer = Buffer.from(content, 'utf8');
-    const base64Content = fileBuffer.toString('base64');
-
-    const parentDir = safePath.split('/').slice(0, -1).join('/');
-    if (parentDir) {
-      await execCommand(req.user.id, ['mkdir', '-p', `/home/node/${parentDir}`]);
-    }
-
-    await writeFileViaExec(req.user.id, safePath, base64Content);
+    await writeUserFile(req.user.id, safePath, fileBuffer);
 
     res.status(200).json({ ok: true, path: safePath, size: fileBuffer.length });
   } catch (err) {
+    if (err instanceof Error && err.message === 'Invalid path') {
+      invalidPathResponse(res);
+      return;
+    }
     console.error('Error writing file:', err);
     res.status(500).json({ error: 'Failed to write file' });
   }
 });
 
-// --- Route 7: DELETE /<path> ------------------------------------------------
+// --- Route 7: DELETE /<path> -------------------------------------------------
 
 router.delete(/^\/(.+)$/, async (req: AuthRequest, res: Response) => {
   if (!req.user) {
@@ -426,10 +522,11 @@ router.delete(/^\/(.+)$/, async (req: AuthRequest, res: Response) => {
     return;
   }
 
-  const safePath = sanitizePath(req.params[0] as string);
-
-  if (!safePath) {
-    res.status(400).json({ error: 'Path is required' });
+  let safePath: string;
+  try {
+    safePath = resolveUserPath(req.user.id, req.params[0] as string).relativePath;
+  } catch {
+    invalidPathResponse(res);
     return;
   }
 

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -18,6 +18,8 @@ import { runMigrations, closeDb } from '@goldilocks/data';
 import { setupWebSocket } from './agent/websocket.js';
 import { sessionManager } from '@goldilocks/runtime';
 
+CONFIG.validateRequiredSecrets();
+
 // Create app and HTTP server
 export const app = createApp();
 const server = createServer(app);

--- a/apps/gateway/test/api/files.test.ts
+++ b/apps/gateway/test/api/files.test.ts
@@ -37,7 +37,6 @@ describe('Files', () => {
   });
 
   it('searches files by query — only matching files appear', async () => {
-    // Write two files with different names
     await fetch(`${server.baseUrl}/api/files/searchable-foo.txt`, {
       method: 'PUT', headers: authHeaders(user),
       body: JSON.stringify({ content: 'foo content' }),
@@ -53,12 +52,27 @@ describe('Files', () => {
 
     expect(res.status).toBe(200);
     const json = await res.json() as { entries: { name: string; path: string }[] };
-    // Should find only the -foo file, not the -bar file
     const paths = json.entries.map(e => e.path ?? e.name);
     const hasFoo = paths.some(p => p.includes('foo'));
     const hasBar = paths.some(p => p.includes('bar'));
     expect(hasFoo).toBe(true);
     expect(hasBar).toBe(false);
+  });
+
+  it('treats shell metacharacters in search literally', async () => {
+    await fetch(`${server.baseUrl}/api/files/literal-$(whoami).txt`, {
+      method: 'PUT', headers: authHeaders(user),
+      body: JSON.stringify({ content: 'literal search target' }),
+    });
+
+    const res = await fetch(`${server.baseUrl}/api/files?search=$(whoami)`, {
+      headers: { authorization: server.authHeader(user) },
+    });
+
+    expect(res.status).toBe(200);
+    const json = await res.json() as { entries: { path: string }[] };
+    const paths = json.entries.map((entry) => entry.path);
+    expect(paths).toContain('literal-$(whoami).txt');
   });
 
   // ── PUT /api/files/:path — create file ──────────────────────────────────
@@ -125,6 +139,24 @@ describe('Files', () => {
     expect(json.content).toBe('File content here');
   });
 
+  it('writes shell metacharacters literally via PUT', async () => {
+    const path = `literal-put-${Date.now()}.txt`;
+    const content = '$(whoami); `uname -a` | cat && echo haunted';
+
+    const writeRes = await fetch(`${server.baseUrl}/api/files/${path}`, {
+      method: 'PUT', headers: authHeaders(user),
+      body: JSON.stringify({ content }),
+    });
+    expect(writeRes.status).toBe(200);
+
+    const readRes = await fetch(`${server.baseUrl}/api/files/${path}`, {
+      headers: { authorization: server.authHeader(user) },
+    });
+    expect(readRes.status).toBe(200);
+    const json = await readRes.json() as { content: string };
+    expect(json.content).toBe(content);
+  });
+
   it('returns 404 for a non-existent file', async () => {
     const res = await fetch(`${server.baseUrl}/api/files/nonexistent-file.xyz`, {
       headers: { authorization: server.authHeader(user) },
@@ -176,6 +208,24 @@ describe('Files', () => {
     expect(json.ok).toBe(true);
     expect(json.name).toBe('uploaded.txt');
     expect(json.size).toBe(content.length);
+  });
+
+  it('uploads shell metacharacters literally', async () => {
+    const filename = 'uploaded-literal.txt';
+    const content = '$(whoami) ; `pwd` | cat';
+
+    const uploadRes = await fetch(`${server.baseUrl}/api/files/upload`, {
+      method: 'POST', headers: authHeaders(user),
+      body: JSON.stringify({ filename, content: Buffer.from(content).toString('base64') }),
+    });
+    expect(uploadRes.status).toBe(201);
+
+    const readRes = await fetch(`${server.baseUrl}/api/files/${filename}`, {
+      headers: { authorization: server.authHeader(user) },
+    });
+    expect(readRes.status).toBe(200);
+    const json = await readRes.json() as { content: string };
+    expect(json.content).toBe(content);
   });
 
   it('rejects upload without filename', async () => {

--- a/apps/gateway/test/api/helpers/test-server.ts
+++ b/apps/gateway/test/api/helpers/test-server.ts
@@ -237,11 +237,18 @@ async function createTestServer(): Promise<TestServer> {
   process.env.WORKSPACE_ROOT = workspaceRoot;
   process.env.JWT_SECRET = 'test-jwt-not-for-prod';
   process.env.ENCRYPTION_KEY = 'test-encryption-key-32bytes!!';
+  process.env.AGENT_SERVICE_SHARED_SECRET = 'test-agent-shared-secret';
   process.env.NODE_ENV = 'test';
 
   const { sessionManager } = await import('@goldilocks/runtime');
 
   const stubPodManager = {
+    getUserHomeHostPath(userId: string) {
+      const base = userDir(workspaceRoot, userId);
+      mkdirSync(base, { recursive: true });
+      return base;
+    },
+
     async ensurePod(_userId: string) { /* no-op */ },
 
     async execInPod(userId: string, command: string[]) {

--- a/apps/gateway/test/security-wave1.test.ts
+++ b/apps/gateway/test/security-wave1.test.ts
@@ -1,0 +1,59 @@
+import { readFileSync, readdirSync } from 'fs';
+import { join, resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { describe, expect, it } from 'vitest';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '../../..');
+const gatewayEntry = resolve(repoRoot, 'apps/gateway/src/index.ts');
+const agentServiceEntry = resolve(repoRoot, 'apps/agent-service/src/index.ts');
+const gatewaySourceRoot = resolve(repoRoot, 'apps/gateway/src');
+
+function readGatewaySourceFiles(dir: string): string[] {
+  const files: string[] = [];
+  const entries = readdirSync(dir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isSymbolicLink()) {
+      continue;
+    }
+    if (entry.isDirectory()) {
+      files.push(...readGatewaySourceFiles(fullPath));
+      continue;
+    }
+    if (fullPath.endsWith('.ts')) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+describe('Wave 1 startup secret guards', () => {
+  it('gateway validates required secrets at startup', () => {
+    const source = readFileSync(gatewayEntry, 'utf8');
+    expect(source).toContain('CONFIG.validateRequiredSecrets();');
+  });
+
+  it('agent-service validates required secrets at startup', () => {
+    const source = readFileSync(agentServiceEntry, 'utf8');
+    expect(source).toContain('CONFIG.validateRequiredSecrets();');
+  });
+});
+
+describe('Wave 1 shell interpolation regression guard', () => {
+  it('gateway source contains no sh -c command invocations', () => {
+    const files = readGatewaySourceFiles(gatewaySourceRoot);
+    const offenders: string[] = [];
+
+    for (const file of files) {
+      const source = readFileSync(file, 'utf8');
+      if (/['"]sh['"]\s*,\s*['"]-c['"]/.test(source)) {
+        offenders.push(file.replace(`${repoRoot}/`, ''));
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/apps/gateway/test/setup.ts
+++ b/apps/gateway/test/setup.ts
@@ -22,6 +22,7 @@ process.env.DATA_DIR = testDataDir;
 process.env.WORKSPACE_ROOT = workspaceRoot;
 process.env.JWT_SECRET = 'test-jwt-not-for-prod';
 process.env.ENCRYPTION_KEY = 'test-encryption-key-32bytes!!';
+process.env.AGENT_SERVICE_SHARED_SECRET = 'test-agent-shared-secret';
 process.env.NODE_ENV = 'test';
 
 afterAll(() => {

--- a/apps/gateway/test/smoke-test.sh
+++ b/apps/gateway/test/smoke-test.sh
@@ -71,6 +71,7 @@ mkdir -p "$DATA_DIR" "$WORKSPACE_ROOT"
 export PORT DATA_DIR WORKSPACE_ROOT
 export JWT_SECRET='test-secret-for-smoke-test'
 export ENCRYPTION_KEY='test-encryption-key-32bytes!!'
+export AGENT_SERVICE_SHARED_SECRET='test-agent-shared-secret'
 export NODE_ENV='test'
 export K8S_NAMESPACE='smoke-test'  # prevents real k8s lookups
 

--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -6,31 +6,31 @@ config();
 const defaultStateDir = resolve(process.cwd(), '.dev');
 const dataDir = process.env.DATA_DIR ?? (process.env.GOLDILOCKS_STATE_DIR ? resolve(process.env.GOLDILOCKS_STATE_DIR) : defaultStateDir);
 
+function requireEnv(name: 'JWT_SECRET' | 'ENCRYPTION_KEY' | 'AGENT_SERVICE_SHARED_SECRET'): string {
+  const value = process.env[name]?.trim();
+  if (!value) {
+    throw new Error(`FATAL: ${name} environment variable is required. Set it before starting the server.`);
+  }
+  return value;
+}
+
 export const CONFIG = {
   port: parseInt(process.env.PORT ?? '3000', 10),
   nodeEnv: process.env.NODE_ENV ?? 'development',
-  
+
   // Paths
   dataDir,
   workspaceRoot: process.env.WORKSPACE_ROOT ?? resolve(dataDir, 'workspaces'),
-  
+
   // Auth
   get jwtSecret(): string {
-    const secret = process.env.JWT_SECRET;
-    if (!secret && process.env.NODE_ENV === 'production') {
-      throw new Error('JWT_SECRET must be set in production');
-    }
-    return secret ?? 'dev-secret-change-in-production';
+    return requireEnv('JWT_SECRET');
   },
   jwtExpiresIn: '7d',
   get encryptionKey(): string {
-    const key = process.env.ENCRYPTION_KEY;
-    if (!key && process.env.NODE_ENV === 'production') {
-      throw new Error('ENCRYPTION_KEY must be set in production');
-    }
-    return key ?? 'dev-encryption-key-32-bytes!!!';
+    return requireEnv('ENCRYPTION_KEY');
   },
-  
+
   // k8s
   k8sNamespace: process.env.K8S_NAMESPACE ?? 'goldilocks',
   agentImage: process.env.AGENT_IMAGE ?? 'goldilocks-agent:latest',
@@ -38,21 +38,23 @@ export const CONFIG = {
   agentServiceUrl: process.env.AGENT_SERVICE_URL ?? 'http://agent-service:3001',
   agentServiceWsUrl: process.env.AGENT_SERVICE_WS_URL ?? 'ws://agent-service:3001/ws',
   get agentServiceSharedSecret(): string {
-    const secret = process.env.AGENT_SERVICE_SHARED_SECRET;
-    if (!secret && process.env.NODE_ENV === 'production') {
-      throw new Error('AGENT_SERVICE_SHARED_SECRET must be set in production');
-    }
-    return secret ?? 'dev-agent-service-secret';
+    return requireEnv('AGENT_SERVICE_SHARED_SECRET');
+  },
+
+  validateRequiredSecrets(): void {
+    void this.jwtSecret;
+    void this.encryptionKey;
+    void this.agentServiceSharedSecret;
   },
 
   get isDev() {
     return this.nodeEnv === 'development';
   },
-  
+
   get isProd() {
     return this.nodeEnv === 'production';
   },
-  
+
   get dbPath() {
     return resolve(this.dataDir, 'goldilocks.db');
   }

--- a/packages/config/test/config.test.ts
+++ b/packages/config/test/config.test.ts
@@ -2,25 +2,54 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const originalEnv = { ...process.env };
 
+async function loadConfig() {
+  vi.resetModules();
+  return import('../src/index');
+}
+
 afterEach(() => {
   process.env = { ...originalEnv };
   vi.resetModules();
 });
 
-describe('CONFIG.agentServiceSharedSecret', () => {
-  it('uses the dev default outside production', async () => {
-    delete process.env.AGENT_SERVICE_SHARED_SECRET;
+describe('CONFIG required secrets', () => {
+  it('throws when JWT_SECRET is unset', async () => {
     process.env.NODE_ENV = 'development';
+    delete process.env.JWT_SECRET;
+    process.env.ENCRYPTION_KEY = 'test-encryption-key-32bytes!!';
+    process.env.AGENT_SERVICE_SHARED_SECRET = 'test-agent-shared-secret';
 
-    const { CONFIG } = await import('../src/index');
-    expect(CONFIG.agentServiceSharedSecret).toBe('dev-agent-service-secret');
+    const { CONFIG } = await loadConfig();
+    expect(() => CONFIG.jwtSecret).toThrow('FATAL: JWT_SECRET environment variable is required. Set it before starting the server.');
   });
 
-  it('throws in production when unset', async () => {
-    delete process.env.AGENT_SERVICE_SHARED_SECRET;
-    process.env.NODE_ENV = 'production';
+  it('throws when ENCRYPTION_KEY is unset', async () => {
+    process.env.NODE_ENV = 'development';
+    process.env.JWT_SECRET = 'test-jwt-not-for-prod';
+    delete process.env.ENCRYPTION_KEY;
+    process.env.AGENT_SERVICE_SHARED_SECRET = 'test-agent-shared-secret';
 
-    const { CONFIG } = await import('../src/index');
-    expect(() => CONFIG.agentServiceSharedSecret).toThrow('AGENT_SERVICE_SHARED_SECRET must be set in production');
+    const { CONFIG } = await loadConfig();
+    expect(() => CONFIG.encryptionKey).toThrow('FATAL: ENCRYPTION_KEY environment variable is required. Set it before starting the server.');
+  });
+
+  it('throws when AGENT_SERVICE_SHARED_SECRET is unset', async () => {
+    process.env.NODE_ENV = 'development';
+    process.env.JWT_SECRET = 'test-jwt-not-for-prod';
+    process.env.ENCRYPTION_KEY = 'test-encryption-key-32bytes!!';
+    delete process.env.AGENT_SERVICE_SHARED_SECRET;
+
+    const { CONFIG } = await loadConfig();
+    expect(() => CONFIG.agentServiceSharedSecret).toThrow('FATAL: AGENT_SERVICE_SHARED_SECRET environment variable is required. Set it before starting the server.');
+  });
+
+  it('validates all required secrets together', async () => {
+    process.env.NODE_ENV = 'test';
+    process.env.JWT_SECRET = 'test-jwt-not-for-prod';
+    process.env.ENCRYPTION_KEY = 'test-encryption-key-32bytes!!';
+    process.env.AGENT_SERVICE_SHARED_SECRET = 'test-agent-shared-secret';
+
+    const { CONFIG } = await loadConfig();
+    expect(() => CONFIG.validateRequiredSecrets()).not.toThrow();
   });
 });

--- a/packages/runtime/src/pod-manager.ts
+++ b/packages/runtime/src/pod-manager.ts
@@ -109,6 +109,10 @@ export class PodManager {
   private ensuring = new Map<string, Promise<string>>();
   private idleTimer: ReturnType<typeof setInterval> | null = null;
 
+  getUserHomeHostPath(userId: string): string {
+    return resolve(HOMES_HOST_PATH, userId);
+  }
+
   constructor() {
     // Check for idle pods every 60s
     this.idleTimer = setInterval(() => this.evictIdle(), 60_000);
@@ -475,7 +479,7 @@ export class PodManager {
           {
             name: 'home',
             hostPath: {
-              path: `${HOMES_HOST_PATH}/${userId}`,
+              path: this.getUserHomeHostPath(userId),
               type: 'DirectoryOrCreate',
             },
           },


### PR DESCRIPTION
## Summary
- remove all secret fallback defaults and make gateway/agent-service fail fast on missing required secrets
- replace shell-interpolated file listing/search/write paths with host-path filesystem operations backed by the pod manager
- add regression coverage for literal shell metacharacters, startup secret guards, and future `sh -c` reintroductions in gateway source

## What changed
- added `CONFIG.validateRequiredSecrets()` and wired it into both service entrypoints
- added `.env.dev.example`, refreshed `.env.example`, and gitignored `.env.dev`
- exposed pod-manager host home paths so gateway file routes can use safe `fs` writes/searches instead of `sh -c`
- tightened file path resolution to reject traversal instead of rewriting inputs silently
- expanded config/file route tests and smoke setup for the new required shared secret

## Verification
- `npx vitest run packages/config/test/config.test.ts apps/gateway/test/api/files.test.ts apps/gateway/test/security-wave1.test.ts`
- `npx vitest run`
- `npm run typecheck -w @goldilocks/gateway && npm run typecheck -w @goldilocks/config && npm run typecheck -w @goldilocks/runtime`
- `npm run build`
- manual startup smoke checks:
  - gateway exits with `FATAL: JWT_SECRET environment variable is required...`
  - agent-service exits with `FATAL: AGENT_SERVICE_SHARED_SECRET environment variable is required...`

## Roadmap
Implements Wave 1 of `scratchpad/plans/2026-04-14-security-hardening`:
- P1: Secret startup guards
- P2: Shell injection elimination

Wave 2 should stack on this branch/PR.
