### PR TITLE
Wave 2: cookie auth and websocket handshake hardening

### DIFF
--- a/apps/agent-service/package.json
+++ b/apps/agent-service/package.json
@@ -17,10 +17,12 @@
     "@goldilocks/data": "file:../../packages/data",
     "@goldilocks/runtime": "file:../../packages/runtime",
     "express": "^5.1.0",
+    "jsonwebtoken": "^9.0.3",
     "ws": "^8.18.2"
   },
   "devDependencies": {
     "@types/express": "^5.0.2",
+    "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^22.15.3",
     "@types/ws": "^8.18.1",
     "tsx": "^4.19.4",

--- a/apps/agent-service/src/index.ts
+++ b/apps/agent-service/src/index.ts
@@ -16,6 +16,10 @@ import {
   recordTtft,
   websocketErrored,
 } from './metrics.js';
+import {
+  authenticateInternalHttpRequest,
+  authenticateInternalWebSocketMessage,
+} from './internal-auth.js';
 
 CONFIG.validateRequiredSecrets();
 
@@ -36,11 +40,16 @@ interface InternalWsState {
 
 interface GatewayAuthMessage {
   type: 'auth';
-  userId: string;
   gatewayToken: string;
+  userToken: string;
 }
 
-function send(ws: WebSocket, msg: ServerMessage): void {
+type InternalServerMessage =
+  | ServerMessage
+  | { type: 'auth_ok'; userId: string }
+  | { type: 'auth_fail'; error: string };
+
+function send(ws: WebSocket, msg: InternalServerMessage): void {
   if (ws.readyState !== WebSocket.OPEN) return;
   ws.send(JSON.stringify(msg));
 }
@@ -245,17 +254,14 @@ function normalizeMessages(history: unknown[]): HistoryMessage[] {
 }
 
 function verifyInternalRequest(req: InternalAuthRequest, res: Response, next: express.NextFunction): void {
-  const sharedSecret = req.header('x-goldilocks-shared-secret');
-  const userId = req.header('x-goldilocks-user');
-
-  if (sharedSecret !== CONFIG.agentServiceSharedSecret || !userId) {
+  try {
+    const auth = authenticateInternalHttpRequest(req);
+    req.internalUserId = auth.userId;
+    next();
+  } catch {
     internalAuthFailed();
     res.status(401).json({ error: 'Unauthorized internal request' });
-    return;
   }
-
-  req.internalUserId = userId;
-  next();
 }
 
 const app = express();
@@ -386,13 +392,17 @@ wss.on('connection', (ws: WebSocket, _req: IncomingMessage) => {
 
     try {
       if (msg.type === 'auth' && 'gatewayToken' in msg) {
-        if (msg.gatewayToken !== CONFIG.agentServiceSharedSecret) {
+        try {
+          const auth = authenticateInternalWebSocketMessage(msg);
+          state.userId = auth.userId;
+          send(ws, { type: 'auth_ok', userId: auth.userId });
+        } catch (err) {
           internalAuthFailed();
-          send(ws, { type: 'auth_fail', error: 'Invalid gateway token' });
-          return;
+          send(ws, {
+            type: 'auth_fail',
+            error: err instanceof Error ? err.message : 'Unauthorized gateway websocket',
+          });
         }
-        state.userId = msg.userId;
-        send(ws, { type: 'auth_ok', userId: msg.userId });
         return;
       }
 

--- a/apps/agent-service/src/internal-auth.ts
+++ b/apps/agent-service/src/internal-auth.ts
@@ -1,0 +1,103 @@
+import type express from 'express';
+import jwt, { type JwtPayload } from 'jsonwebtoken';
+import { CONFIG } from '@goldilocks/config';
+import { getDb } from '@goldilocks/data';
+
+export interface InternalUserClaims extends JwtPayload {
+  id: string;
+  email: string;
+  jti: string;
+}
+
+export interface InternalHttpAuthResult {
+  ok: true;
+  userId: string;
+  claims: InternalUserClaims;
+}
+
+export interface InternalWsAuthResult extends InternalHttpAuthResult {}
+
+function assertValidClaims(payload: string | JwtPayload): InternalUserClaims {
+  if (typeof payload === 'string') {
+    throw new Error('Invalid token payload');
+  }
+
+  if (typeof payload.id !== 'string' || typeof payload.email !== 'string' || typeof payload.jti !== 'string') {
+    throw new Error('Invalid token payload');
+  }
+
+  if (typeof payload.exp !== 'number') {
+    throw new Error('Token missing expiry');
+  }
+
+  return payload as InternalUserClaims;
+}
+
+function pruneExpiredRevocations(): void {
+  getDb().prepare('DELETE FROM revoked_tokens WHERE expires_at <= ?').run(Date.now());
+}
+
+function isRevoked(jti: string): boolean {
+  pruneExpiredRevocations();
+  const row = getDb().prepare('SELECT 1 FROM revoked_tokens WHERE jti = ?').get(jti);
+  return Boolean(row);
+}
+
+function getBearerToken(authHeader?: string): string | null {
+  if (!authHeader?.startsWith('Bearer ')) {
+    return null;
+  }
+
+  const token = authHeader.slice(7).trim();
+  return token || null;
+}
+
+export function verifyInternalUserToken(token: string): InternalUserClaims {
+  const payload = jwt.verify(token, CONFIG.jwtSecret, {
+    issuer: CONFIG.jwtIssuer,
+    audience: CONFIG.jwtAudience,
+  });
+
+  const claims = assertValidClaims(payload);
+  if (isRevoked(claims.jti)) {
+    throw new Error('Token revoked');
+  }
+
+  return claims;
+}
+
+export function authenticateInternalHttpRequest(req: express.Request): InternalHttpAuthResult {
+  const sharedSecret = req.header('x-goldilocks-shared-secret');
+  if (sharedSecret !== CONFIG.agentServiceSharedSecret) {
+    throw new Error('Invalid shared secret');
+  }
+
+  const token = getBearerToken(req.header('authorization'));
+  if (!token) {
+    throw new Error('Missing bearer token');
+  }
+
+  const claims = verifyInternalUserToken(token);
+  return {
+    ok: true,
+    userId: claims.id,
+    claims,
+  };
+}
+
+export function authenticateInternalWebSocketMessage(message: { gatewayToken?: string; userToken?: string }): InternalWsAuthResult {
+  if (message.gatewayToken !== CONFIG.agentServiceSharedSecret) {
+    throw new Error('Invalid gateway token');
+  }
+
+  if (!message.userToken) {
+    throw new Error('Missing user token');
+  }
+
+  const claims = verifyInternalUserToken(message.userToken);
+  return {
+    ok: true,
+    userId: claims.id,
+    claims,
+  };
+}

--- a/apps/agent-service/test/internal-auth.test.ts
+++ b/apps/agent-service/test/internal-auth.test.ts
@@ -1,0 +1,71 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { closeDb, runMigrations } from '@goldilocks/data';
+import { CONFIG } from '@goldilocks/config';
+import { generateToken, revokeToken, verifySignedToken } from '../../gateway/src/auth/middleware.js';
+import {
+  authenticateInternalHttpRequest,
+  authenticateInternalWebSocketMessage,
+} from '../src/internal-auth.js';
+
+describe('agent-service internal auth', () => {
+  beforeAll(() => {
+    runMigrations();
+  });
+
+  afterAll(() => {
+    closeDb();
+  });
+
+  it('accepts internal HTTP requests with the shared secret and a verified JWT', () => {
+    const token = generateToken({ id: 'user-1', email: 'user@example.com' });
+    const req = {
+      header(name: string) {
+        if (name === 'x-goldilocks-shared-secret') {
+          return CONFIG.agentServiceSharedSecret;
+        }
+        if (name === 'authorization') {
+          return `Bearer ${token}`;
+        }
+        return undefined;
+      },
+    };
+
+    const auth = authenticateInternalHttpRequest(req as any);
+    expect(auth.userId).toBe('user-1');
+    expect(auth.claims.email).toBe('user@example.com');
+  });
+
+  it('rejects internal HTTP requests without a bearer token', () => {
+    const req = {
+      header(name: string) {
+        if (name === 'x-goldilocks-shared-secret') {
+          return CONFIG.agentServiceSharedSecret;
+        }
+        return undefined;
+      },
+    };
+
+    expect(() => authenticateInternalHttpRequest(req as any)).toThrow('Missing bearer token');
+  });
+
+  it('authenticates gateway websocket messages using the shared secret and JWT', () => {
+    const token = generateToken({ id: 'user-2', email: 'ws@example.com' });
+    const auth = authenticateInternalWebSocketMessage({
+      gatewayToken: CONFIG.agentServiceSharedSecret,
+      userToken: token,
+    });
+
+    expect(auth.userId).toBe('user-2');
+    expect(auth.claims.email).toBe('ws@example.com');
+  });
+
+  it('rejects revoked JWTs on internal websocket auth', () => {
+    const token = generateToken({ id: 'user-3', email: 'revoked@example.com' });
+    revokeToken(verifySignedToken(token));
+
+    expect(() => authenticateInternalWebSocketMessage({
+      gatewayToken: CONFIG.agentServiceSharedSecret,
+      userToken: token,
+    })).toThrow('Token revoked');
+  });
+});

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { Routes, Route, Navigate } from 'react-router-dom';
-import { lazy, Suspense } from 'react';
+import { lazy, Suspense, useEffect } from 'react';
 import { useAuthStore } from './store/auth';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import Login from './pages/Login';
@@ -9,26 +9,46 @@ import ToastContainer from './components/ui/Toast';
 
 const Settings = lazy(() => import('./pages/Settings'));
 
+function FullScreenLoading({ label = 'Loading…' }: { label?: string }) {
+  return <div className="flex items-center justify-center h-screen text-slate-400">{label}</div>;
+}
+
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
-  
+  const hasCheckedAuth = useAuthStore((s) => s.hasCheckedAuth);
+
+  if (!hasCheckedAuth) {
+    return <FullScreenLoading label="Checking session…" />;
+  }
+
   if (!isAuthenticated) {
     return <Navigate to="/login" replace />;
   }
-  
+
   return <>{children}</>;
 }
 
 export default function App() {
+  const checkAuth = useAuthStore((s) => s.checkAuth);
+  const hasCheckedAuth = useAuthStore((s) => s.hasCheckedAuth);
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+
+  useEffect(() => {
+    void checkAuth();
+  }, [checkAuth]);
+
   return (
     <ErrorBoundary>
       <Routes>
-        <Route path="/login" element={<Login />} />
+        <Route
+          path="/login"
+          element={hasCheckedAuth && isAuthenticated ? <Navigate to="/" replace /> : <Login />}
+        />
         <Route
           path="/settings"
           element={
             <ProtectedRoute>
-              <Suspense fallback={<div className="flex items-center justify-center h-screen text-slate-400">Loading…</div>}>
+              <Suspense fallback={<FullScreenLoading />}>
                 <Settings />
               </Suspense>
             </ProtectedRoute>

--- a/apps/frontend/src/api/client.ts
+++ b/apps/frontend/src/api/client.ts
@@ -1,5 +1,3 @@
-import { useAuthStore } from '../store/auth';
-
 const API_BASE = '/api';
 
 class ApiError extends Error {
@@ -18,32 +16,27 @@ async function request<T>(
   path: string,
   data?: unknown
 ): Promise<T> {
-  const token = useAuthStore.getState().token;
-  
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
   };
-  
-  if (token) {
-    headers['Authorization'] = `Bearer ${token}`;
-  }
-  
+
   const res = await fetch(`${API_BASE}${path}`, {
     method,
     headers,
+    credentials: 'include',
     body: data ? JSON.stringify(data) : undefined,
   });
-  
+
   const json = await res.json().catch(() => ({}));
-  
+
   if (!res.ok) {
     throw new ApiError(
-      json.error ?? `Request failed with status ${res.status}`,
+      (json as { error?: string }).error ?? `Request failed with status ${res.status}`,
       res.status,
       json
     );
   }
-  
+
   return json as T;
 }
 
@@ -97,13 +90,8 @@ export function rawFileUrl(path: string): string {
   return `/api/files/${encodeURIComponent(path)}/raw`;
 }
 
-export function getAuthHeaders(): Record<string, string> {
-  const token = useAuthStore.getState().token;
-  return token ? { Authorization: `Bearer ${token}` } : {};
-}
-
 export async function downloadWorkspaceFile(path: string): Promise<void> {
-  const res = await fetch(rawFileUrl(path), { headers: getAuthHeaders() });
+  const res = await fetch(rawFileUrl(path), { credentials: 'include' });
   if (!res.ok) {
     throw new ApiError(`Request failed with status ${res.status}`, res.status);
   }

--- a/apps/frontend/src/components/layout/Header.tsx
+++ b/apps/frontend/src/components/layout/Header.tsx
@@ -149,7 +149,7 @@ export default function Header({
                 Settings
               </button>
               <button
-                onClick={logout}
+                onClick={() => { void logout(); setMenuOpen(false); }}
                 className="w-full flex items-center gap-2 px-4 py-2 text-sm text-red-400 hover:bg-slate-600"
               >
                 <LogOut className="w-4 h-4" />

--- a/apps/frontend/src/components/workspace/ImageViewer.tsx
+++ b/apps/frontend/src/components/workspace/ImageViewer.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Maximize, ZoomIn, ZoomOut } from 'lucide-react';
-import { getAuthHeaders, rawFileUrl } from '../../api/client';
+import { rawFileUrl } from '../../api/client';
 import { useSettingsStore } from '../../store/settings';
 
 function backgroundStyle(background: 'checkered' | 'dark' | 'light') {
@@ -34,7 +34,7 @@ export default function ImageViewer({ path }: { path: string }) {
     let cancelled = false;
     setLoading(true);
 
-    fetch(rawFileUrl(path), { headers: getAuthHeaders() })
+    fetch(rawFileUrl(path), { credentials: 'include' })
       .then((response) => {
         if (!response.ok) throw new Error(`HTTP ${response.status}`);
         return response.blob();

--- a/apps/frontend/src/components/workspace/PdfViewer.tsx
+++ b/apps/frontend/src/components/workspace/PdfViewer.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { ZoomIn, ZoomOut } from 'lucide-react';
 import * as pdfjsLib from 'pdfjs-dist';
 import pdfjsWorker from 'pdfjs-dist/build/pdf.worker.min.mjs?url';
-import { getAuthHeaders, rawFileUrl } from '../../api/client';
+import { rawFileUrl } from '../../api/client';
 import { useSettingsStore } from '../../store/settings';
 
 pdfjsLib.GlobalWorkerOptions.workerSrc = pdfjsWorker;
@@ -36,7 +36,7 @@ export default function PdfViewer({ path }: { path: string }) {
 
     async function loadPdf() {
       try {
-        const response = await fetch(rawFileUrl(path), { headers: getAuthHeaders() });
+        const response = await fetch(rawFileUrl(path), { credentials: 'include' });
         if (!response.ok) {
           throw new Error(`HTTP ${response.status}`);
         }

--- a/apps/frontend/src/hooks/useAgent.ts
+++ b/apps/frontend/src/hooks/useAgent.ts
@@ -4,11 +4,11 @@ import { useChatStore } from '../store/chat';
 import { useFilesStore } from '../store/files';
 import type { ServerMessage } from '@goldilocks/contracts';
 
-export type AgentStatus = 'disconnected' | 'connecting' | 'authenticating' | 'opening' | 'ready';
+export type AgentStatus = 'disconnected' | 'connecting' | 'opening' | 'ready';
 
 export function useAgent(conversationId: string | null) {
   const ws = useRef<WebSocket | null>(null);
-  const token = useAuthStore((s) => s.token);
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
   const [status, setStatus] = useState<AgentStatus>('disconnected');
   const [error, setError] = useState<string | null>(null);
 
@@ -28,7 +28,7 @@ export function useAgent(conversationId: string | null) {
 
   useEffect(() => {
     const generation = ++generationRef.current;
-    if (!conversationId || !token) {
+    if (!conversationId || !isAuthenticated) {
       setStatus('disconnected');
       return;
     }
@@ -46,9 +46,9 @@ export function useAgent(conversationId: string | null) {
     const socket = new WebSocket(`${protocol}//${window.location.host}/ws`);
 
     socket.onopen = () => {
-      setStatus('authenticating');
+      setStatus('opening');
       setError(null);
-      socket.send(JSON.stringify({ type: 'auth', token }));
+      socket.send(JSON.stringify({ type: 'open', conversationId }));
     };
 
     socket.onmessage = (event) => {
@@ -66,48 +66,37 @@ export function useAgent(conversationId: string | null) {
       const store = useChatStore.getState();
 
       switch (msg.type) {
-        case 'auth_ok':
-          setStatus('opening');
-          socket.send(JSON.stringify({ type: 'open', conversationId }));
-          break;
-
-        case 'auth_fail':
-          setError(msg.error);
-          setStatus('disconnected');
-          break;
-
         case 'ready': {
-          // Load message history from pi if available
           if (msg.messages && msg.messages.length > 0) {
             const chatMessages = msg.messages.map((m) => {
               if (m.role === 'user') {
                 return { role: 'user' as const, text: m.text, timestamp: Date.now() };
-              } else {
-                const blocks: import('../store/chat').AssistantBlock[] = [];
-                if (m.text) {
-                  blocks.push({ type: 'text' as const, content: m.text });
-                }
-                if (m.toolCalls) {
-                  for (const tc of m.toolCalls) {
-                    blocks.push({
-                      type: 'tool_call' as const,
-                      data: {
-                        toolCallId: tc.toolCallId,
-                        toolName: tc.toolName,
-                        args: tc.args,
-                        result: tc.result,
-                        isError: tc.isError,
-                        status: 'done' as const,
-                      },
-                    });
-                  }
-                }
-                return {
-                  role: 'assistant' as const,
-                  blocks,
-                  timestamp: Date.now(),
-                };
               }
+
+              const blocks: import('../store/chat').AssistantBlock[] = [];
+              if (m.text) {
+                blocks.push({ type: 'text' as const, content: m.text });
+              }
+              if (m.toolCalls) {
+                for (const tc of m.toolCalls) {
+                  blocks.push({
+                    type: 'tool_call' as const,
+                    data: {
+                      toolCallId: tc.toolCallId,
+                      toolName: tc.toolName,
+                      args: tc.args,
+                      result: tc.result,
+                      isError: tc.isError,
+                      status: 'done' as const,
+                    },
+                  });
+                }
+              }
+              return {
+                role: 'assistant' as const,
+                blocks,
+                timestamp: Date.now(),
+              };
             });
             store.setMessages(chatMessages);
           }
@@ -173,7 +162,7 @@ export function useAgent(conversationId: string | null) {
         refreshWorkspaceTimerRef.current = null;
       }
     };
-  }, [conversationId, token, scheduleWorkspaceRefresh]);
+  }, [conversationId, isAuthenticated, scheduleWorkspaceRefresh]);
 
   const isReady = status === 'ready';
 

--- a/apps/frontend/src/store/auth.ts
+++ b/apps/frontend/src/store/auth.ts
@@ -1,10 +1,8 @@
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
 import { api } from '../api/client';
 import { resetUserScopedFrontendState } from './session-reset';
 
 interface AuthResponse {
-  token: string;
   user: User;
 }
 
@@ -17,98 +15,110 @@ export interface User {
   email: string;
   displayName: string | null;
   settings: Record<string, unknown>;
+  createdAt?: number;
 }
 
 interface AuthState {
   user: User | null;
-  token: string | null;
   isAuthenticated: boolean;
   isLoading: boolean;
+  hasCheckedAuth: boolean;
   error: string | null;
-  
+
   login: (email: string, password: string) => Promise<void>;
   register: (email: string, password: string, displayName?: string) => Promise<void>;
-  logout: () => void;
+  logout: () => Promise<void>;
   clearError: () => void;
   checkAuth: () => Promise<void>;
 }
 
-export const useAuthStore = create<AuthState>()(
-  persist(
-    (set, get) => ({
-      user: null,
-      token: null,
-      isAuthenticated: false,
-      isLoading: false,
-      error: null,
-      
-      login: async (email, password) => {
-        set({ isLoading: true, error: null });
-        try {
-          const res = await api.post<AuthResponse>('/auth/login', { email, password });
-          resetUserScopedFrontendState();
-          set({
-            user: res.user,
-            token: res.token,
-            isAuthenticated: true,
-            isLoading: false,
-          });
-        } catch (err: any) {
-          set({
-            error: err.message ?? 'Login failed',
-            isLoading: false,
-          });
-          throw err;
-        }
-      },
-      
-      register: async (email, password, displayName) => {
-        set({ isLoading: true, error: null });
-        try {
-          const res = await api.post<AuthResponse>('/auth/register', { email, password, displayName });
-          resetUserScopedFrontendState();
-          set({
-            user: res.user,
-            token: res.token,
-            isAuthenticated: true,
-            isLoading: false,
-          });
-        } catch (err: any) {
-          set({
-            error: err.message ?? 'Registration failed',
-            isLoading: false,
-          });
-          throw err;
-        }
-      },
-      
-      logout: () => {
-        resetUserScopedFrontendState();
-        set({
-          user: null,
-          token: null,
-          isAuthenticated: false,
-        });
-      },
-      
-      clearError: () => set({ error: null }),
-      
-      checkAuth: async () => {
-        const { token } = get();
-        if (!token) return;
-        
-        try {
-          const res = await api.get<MeResponse>('/auth/me');
-          set({ user: res.user, isAuthenticated: true });
-        } catch {
-          resetUserScopedFrontendState();
-          set({ user: null, token: null, isAuthenticated: false });
-        }
-      },
-    }),
-    {
-      name: 'goldilocks-auth',
-      partialize: (state) => ({ token: state.token }),
+export const useAuthStore = create<AuthState>()((set) => ({
+  user: null,
+  isAuthenticated: false,
+  isLoading: false,
+  hasCheckedAuth: false,
+  error: null,
+
+  login: async (email, password) => {
+    set({ isLoading: true, error: null });
+    try {
+      const res = await api.post<AuthResponse>('/auth/login', { email, password });
+      resetUserScopedFrontendState();
+      set({
+        user: res.user,
+        isAuthenticated: true,
+        isLoading: false,
+        hasCheckedAuth: true,
+      });
+    } catch (err: any) {
+      set({
+        error: err.message ?? 'Login failed',
+        isLoading: false,
+        hasCheckedAuth: true,
+      });
+      throw err;
     }
-  )
-);
+  },
+
+  register: async (email, password, displayName) => {
+    set({ isLoading: true, error: null });
+    try {
+      const res = await api.post<AuthResponse>('/auth/register', { email, password, displayName });
+      resetUserScopedFrontendState();
+      set({
+        user: res.user,
+        isAuthenticated: true,
+        isLoading: false,
+        hasCheckedAuth: true,
+      });
+    } catch (err: any) {
+      set({
+        error: err.message ?? 'Registration failed',
+        isLoading: false,
+        hasCheckedAuth: true,
+      });
+      throw err;
+    }
+  },
+
+  logout: async () => {
+    set({ isLoading: true });
+    try {
+      await api.post('/auth/logout');
+    } catch {
+      // If the cookie is already gone, local cleanup still matters.
+    } finally {
+      resetUserScopedFrontendState();
+      set({
+        user: null,
+        isAuthenticated: false,
+        isLoading: false,
+        hasCheckedAuth: true,
+        error: null,
+      });
+    }
+  },
+
+  clearError: () => set({ error: null }),
+
+  checkAuth: async () => {
+    set({ isLoading: true });
+    try {
+      const res = await api.get<MeResponse>('/auth/me');
+      set({
+        user: res.user,
+        isAuthenticated: true,
+        isLoading: false,
+        hasCheckedAuth: true,
+      });
+    } catch {
+      resetUserScopedFrontendState();
+      set({
+        user: null,
+        isAuthenticated: false,
+        isLoading: false,
+        hasCheckedAuth: true,
+      });
+    }
+  },
+}));

--- a/apps/gateway/package.json
+++ b/apps/gateway/package.json
@@ -16,17 +16,19 @@
     "@goldilocks/contracts": "file:../../packages/contracts",
     "@goldilocks/data": "file:../../packages/data",
     "@goldilocks/runtime": "file:../../packages/runtime",
+    "@mariozechner/pi-ai": "^0.64.0",
     "bcrypt": "^5.1.1",
+    "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "express": "^5.1.0",
     "express-rate-limit": "^8.3.2",
     "jsonwebtoken": "^9.0.2",
     "uuid": "^11.1.0",
-    "ws": "^8.18.2",
-    "@mariozechner/pi-ai": "^0.64.0"
+    "ws": "^8.18.2"
   },
   "devDependencies": {
     "@types/bcrypt": "^5.0.2",
+    "@types/cookie-parser": "^1.4.10",
     "@types/cors": "^2.8.17",
     "@types/express": "^5.0.2",
     "@types/jsonwebtoken": "^9.0.10",

--- a/apps/gateway/src/agent/agent-service-client.ts
+++ b/apps/gateway/src/agent/agent-service-client.ts
@@ -2,10 +2,10 @@ import { CONFIG } from '@goldilocks/config';
 
 export async function agentServiceFetch(
   path: string,
-  options: RequestInit & { userId: string },
+  options: RequestInit & { userToken: string },
 ): Promise<Response> {
   const headers = new Headers(options.headers ?? {});
-  headers.set('x-goldilocks-user', options.userId);
+  headers.set('authorization', `Bearer ${options.userToken}`);
   headers.set('x-goldilocks-shared-secret', CONFIG.agentServiceSharedSecret);
 
   return fetch(`${CONFIG.agentServiceUrl}${path}`, {

--- a/apps/gateway/src/agent/websocket.ts
+++ b/apps/gateway/src/agent/websocket.ts
@@ -1,7 +1,11 @@
-import { IncomingMessage } from 'http';
-import jwt from 'jsonwebtoken';
+import { IncomingMessage, Server as HttpServer } from 'http';
 import { WebSocket, WebSocketServer } from 'ws';
 import { CONFIG } from '@goldilocks/config';
+import {
+  getTokenFromCookieHeader,
+  verifySignedToken,
+  type AuthUser,
+} from '../auth/middleware.js';
 import {
   recordAgentConnectionClosed,
   recordAgentConnectionOpened,
@@ -13,16 +17,40 @@ import {
 } from './relay-metrics.js';
 import type { ClientMessage, ServerMessage } from '@goldilocks/contracts';
 
-interface AuthUser {
-  id: string;
-  email: string;
-}
-
 interface GatewayToAgentMessage {
   type: 'auth';
-  userId: string;
   gatewayToken: string;
+  userToken: string;
 }
+
+interface AgentAuthOkMessage {
+  type: 'auth_ok';
+  userId: string;
+}
+
+interface AgentAuthFailMessage {
+  type: 'auth_fail';
+  error: string;
+}
+
+interface AuthenticatedWebSocketRequest extends IncomingMessage {
+  authContext?: {
+    user: AuthUser;
+    token: string;
+  };
+}
+
+export type WebSocketUpgradeAuthResult =
+  | {
+      ok: true;
+      token: string;
+      user: AuthUser;
+    }
+  | {
+      ok: false;
+      status: 401 | 403;
+      error: string;
+    };
 
 const HEARTBEAT_INTERVAL_MS = 30_000;
 const HEARTBEAT_TIMEOUT_MS = 60_000;
@@ -41,10 +69,86 @@ function send(ws: WebSocket, msg: ServerMessage): void {
   }
 }
 
-export function setupWebSocket(wss: WebSocketServer): void {
-  wss.on('connection', (browserWs: WebSocket, _req: IncomingMessage) => {
+function rejectUpgrade(socket: import('stream').Duplex, status: 401 | 403, error: string): void {
+  const statusText = status === 403 ? 'Forbidden' : 'Unauthorized';
+  socket.write(
+    `HTTP/1.1 ${status} ${statusText}\r\n` +
+    'Connection: close\r\n' +
+    'Content-Type: text/plain\r\n' +
+    `Content-Length: ${Buffer.byteLength(error)}\r\n` +
+    '\r\n' +
+    error,
+  );
+  socket.destroy();
+}
+
+export function authenticateWebSocketUpgrade(req: IncomingMessage): WebSocketUpgradeAuthResult {
+  const origin = req.headers.origin;
+  if (!origin || !CONFIG.allowedWebSocketOrigins.includes(origin)) {
+    return { ok: false, status: 403, error: 'WebSocket origin not allowed' };
+  }
+
+  const token = getTokenFromCookieHeader(req.headers.cookie);
+  if (!token) {
+    return { ok: false, status: 401, error: 'Missing session cookie' };
+  }
+
+  try {
+    const claims = verifySignedToken(token);
+    return {
+      ok: true,
+      token,
+      user: {
+        id: claims.id,
+        email: claims.email,
+        jti: claims.jti,
+      },
+    };
+  } catch {
+    return { ok: false, status: 401, error: 'Invalid, expired, or revoked token' };
+  }
+}
+
+export function setupWebSocket(server: HttpServer): WebSocketServer {
+  const wss = new WebSocketServer({ noServer: true });
+
+  server.on('upgrade', (req, socket, head) => {
+    const pathname = new URL(req.url ?? '/', `http://${req.headers.host ?? 'localhost'}`).pathname;
+    if (pathname !== '/ws') {
+      socket.destroy();
+      return;
+    }
+
+    const authResult = authenticateWebSocketUpgrade(req);
+    recordAuthAttempt(authResult.ok);
+
+    if (!authResult.ok) {
+      rejectUpgrade(socket, authResult.status, authResult.error);
+      return;
+    }
+
+    const authReq = req as AuthenticatedWebSocketRequest;
+    authReq.authContext = {
+      user: authResult.user,
+      token: authResult.token,
+    };
+
+    wss.handleUpgrade(req, socket, head, (ws) => {
+      wss.emit('connection', ws, authReq);
+    });
+  });
+
+  wss.on('connection', (browserWs: WebSocket, req: IncomingMessage) => {
+    const authReq = req as AuthenticatedWebSocketRequest;
+    const authContext = authReq.authContext;
+    if (!authContext) {
+      browserWs.close();
+      return;
+    }
+
     recordBrowserConnectionOpened();
-    let browserUser: AuthUser | null = null;
+    const browserUser = authContext.user;
+    const browserToken = authContext.token;
     let agentWs: WebSocket | null = null;
     let agentReady = false;
     let agentGeneration = 0;
@@ -101,125 +205,112 @@ export function setupWebSocket(wss: WebSocketServer): void {
       }
     };
 
+    const connectToAgentService = () => {
+      cleanupAgentConnection();
+
+      const connectionGeneration = agentGeneration;
+      const nextAgentWs = new WebSocket(CONFIG.agentServiceWsUrl);
+      agentWs = nextAgentWs;
+      recordAgentConnectionOpened();
+
+      // ── Agent keepalive ──
+      // Same pattern: ping at interval, enforce pong timeout.
+      let agentLastPong = Date.now();
+      const agentHeartbeat = setInterval(() => {
+        if (nextAgentWs.readyState !== WebSocket.OPEN) {
+          clearInterval(agentHeartbeat);
+          return;
+        }
+        nextAgentWs.ping();
+
+        if (Date.now() - agentLastPong > HEARTBEAT_TIMEOUT_MS) {
+          console.warn('Agent service WebSocket pong timeout — closing connection');
+          nextAgentWs.terminate();
+          clearInterval(agentHeartbeat);
+        }
+      }, HEARTBEAT_INTERVAL_MS);
+      currentAgentHeartbeat = agentHeartbeat;
+
+      nextAgentWs.on('pong', () => {
+        agentLastPong = Date.now();
+      });
+
+      nextAgentWs.on('open', () => {
+        if (connectionGeneration !== agentGeneration) return;
+        const authMessage: GatewayToAgentMessage = {
+          type: 'auth',
+          gatewayToken: CONFIG.agentServiceSharedSecret,
+          userToken: browserToken,
+        };
+        nextAgentWs.send(JSON.stringify(authMessage));
+      });
+
+      nextAgentWs.on('message', (agentRaw) => {
+        if (connectionGeneration !== agentGeneration) return;
+
+        let agentMsg: ServerMessage | AgentAuthOkMessage | AgentAuthFailMessage;
+        try {
+          agentMsg = JSON.parse(agentRaw.toString()) as ServerMessage | AgentAuthOkMessage | AgentAuthFailMessage;
+        } catch {
+          send(browserWs, { type: 'error', error: 'Invalid agent-service message' });
+          return;
+        }
+
+        if (agentMsg.type === 'auth_ok') {
+          agentReady = true;
+          flushPending();
+          return;
+        }
+
+        if (agentMsg.type === 'auth_fail') {
+          send(browserWs, { type: 'error', error: agentMsg.error });
+          cleanupAgentConnection();
+          return;
+        }
+
+        // TTFT: record time from prompt send to first meaningful output
+        if (promptSentAt !== null && TTFT_CLEAR_TYPES.has(agentMsg.type)) {
+          recordTtft(Date.now() - promptSentAt);
+          promptSentAt = null;
+        }
+
+        send(browserWs, agentMsg);
+      });
+
+      nextAgentWs.on('close', () => {
+        clearInterval(agentHeartbeat);
+        if (currentAgentHeartbeat === agentHeartbeat) {
+          currentAgentHeartbeat = null;
+        }
+        if (connectionGeneration !== agentGeneration) {
+          // Stale socket — counter already decremented by cleanupAgentConnection()
+          return;
+        }
+        // Spontaneous disconnect — counter was not decremented yet
+        recordAgentConnectionClosed();
+        agentReady = false;
+        agentWs = null;
+        if (browserWs.readyState === WebSocket.OPEN) {
+          send(browserWs, { type: 'error', error: 'Agent service disconnected' });
+        }
+      });
+
+      nextAgentWs.on('error', (err) => {
+        if (connectionGeneration !== agentGeneration) return;
+        console.error('Agent service WebSocket error:', err);
+        recordRelayError();
+        send(browserWs, { type: 'error', error: 'Agent service connection error' });
+      });
+    };
+
+    connectToAgentService();
+
     browserWs.on('message', (raw) => {
       let msg: ClientMessage;
       try {
         msg = JSON.parse(raw.toString()) as ClientMessage;
       } catch {
         send(browserWs, { type: 'error', error: 'Invalid JSON' });
-        return;
-      }
-
-      if (msg.type === 'auth') {
-        cleanupAgentConnection();
-
-        try {
-          const payload = jwt.verify(msg.token, CONFIG.jwtSecret) as AuthUser;
-          recordAuthAttempt(true);
-          browserUser = payload;
-          const connectionGeneration = agentGeneration;
-          const nextAgentWs = new WebSocket(CONFIG.agentServiceWsUrl);
-          agentWs = nextAgentWs;
-          recordAgentConnectionOpened();
-
-          // ── Agent keepalive ──
-          // Same pattern: ping at interval, enforce pong timeout.
-          let agentLastPong = Date.now();
-          const agentHeartbeat = setInterval(() => {
-            if (nextAgentWs.readyState !== WebSocket.OPEN) {
-              clearInterval(agentHeartbeat);
-              return;
-            }
-            nextAgentWs.ping();
-
-            if (Date.now() - agentLastPong > HEARTBEAT_TIMEOUT_MS) {
-              console.warn('Agent service WebSocket pong timeout — closing connection');
-              nextAgentWs.terminate();
-              clearInterval(agentHeartbeat);
-            }
-          }, HEARTBEAT_INTERVAL_MS);
-          currentAgentHeartbeat = agentHeartbeat;
-
-          nextAgentWs.on('pong', () => {
-            agentLastPong = Date.now();
-          });
-
-          nextAgentWs.on('open', () => {
-            if (connectionGeneration !== agentGeneration) return;
-            const authMessage: GatewayToAgentMessage = {
-              type: 'auth',
-              userId: payload.id,
-              gatewayToken: CONFIG.agentServiceSharedSecret,
-            };
-            nextAgentWs.send(JSON.stringify(authMessage));
-          });
-
-          nextAgentWs.on('message', (agentRaw) => {
-            if (connectionGeneration !== agentGeneration) return;
-
-            let agentMsg: ServerMessage;
-            try {
-              agentMsg = JSON.parse(agentRaw.toString()) as ServerMessage;
-            } catch {
-              send(browserWs, { type: 'error', error: 'Invalid agent-service message' });
-              return;
-            }
-
-            if (agentMsg.type === 'auth_ok') {
-              agentReady = true;
-              send(browserWs, { type: 'auth_ok', userId: payload.id });
-              flushPending();
-              return;
-            }
-
-            if (agentMsg.type === 'auth_fail') {
-              send(browserWs, agentMsg);
-              cleanupAgentConnection();
-              return;
-            }
-
-            // TTFT: record time from prompt send to first meaningful output
-            if (promptSentAt !== null && TTFT_CLEAR_TYPES.has(agentMsg.type)) {
-              recordTtft(Date.now() - promptSentAt);
-              promptSentAt = null;
-            }
-
-            send(browserWs, agentMsg);
-          });
-
-          nextAgentWs.on('close', () => {
-            clearInterval(agentHeartbeat);
-            if (currentAgentHeartbeat === agentHeartbeat) {
-              currentAgentHeartbeat = null;
-            }
-            if (connectionGeneration !== agentGeneration) {
-              // Stale socket — counter already decremented by cleanupAgentConnection()
-              return;
-            }
-            // Spontaneous disconnect — counter was not decremented yet
-            recordAgentConnectionClosed();
-            agentReady = false;
-            agentWs = null;
-            if (browserWs.readyState === WebSocket.OPEN) {
-              send(browserWs, { type: 'error', error: 'Agent service disconnected' });
-            }
-          });
-
-          nextAgentWs.on('error', (err) => {
-            if (connectionGeneration !== agentGeneration) return;
-            console.error('Agent service WebSocket error:', err);
-            recordRelayError();
-            send(browserWs, { type: 'error', error: 'Agent service connection error' });
-          });
-        } catch {
-          recordAuthAttempt(false);
-          send(browserWs, { type: 'auth_fail', error: 'Invalid or expired token' });
-        }
-        return;
-      }
-
-      if (!browserUser) {
-        send(browserWs, { type: 'error', error: 'Not authenticated' });
         return;
       }
 
@@ -248,4 +339,6 @@ export function setupWebSocket(wss: WebSocketServer): void {
       cleanupAgentConnection();
     });
   });
+
+  return wss;
 }

--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -7,6 +7,7 @@
  */
 
 import express from 'express';
+import cookieParser from 'cookie-parser';
 import cors from 'cors';
 import rateLimit from 'express-rate-limit';
 import { existsSync } from 'fs';
@@ -26,14 +27,34 @@ import quickgenRoutes from './quickgen/routes.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
+function getAllowedCorsOrigins(): Set<string> {
+  const origins = new Set<string>([CONFIG.frontendUrl]);
+
+  if (!CONFIG.isProd) {
+    origins.add('http://localhost:5173');
+    origins.add('http://127.0.0.1:5173');
+  }
+
+  return origins;
+}
+
 export function createApp() {
   const app = express();
+  const allowedOrigins = getAllowedCorsOrigins();
 
   // Middleware
-  app.use(cors(CONFIG.isProd ? {
-    origin: process.env.CORS_ORIGIN ?? false,
+  app.use(cors({
+    origin(origin, callback) {
+      if (!origin || allowedOrigins.has(origin)) {
+        callback(null, true);
+        return;
+      }
+
+      callback(new Error(`Origin ${origin} is not allowed by CORS`));
+    },
     credentials: true,
-  } : {}));
+  }));
+  app.use(cookieParser());
   app.use(express.json());
 
   // Rate limiting

--- a/apps/gateway/src/auth/middleware.ts
+++ b/apps/gateway/src/auth/middleware.ts
@@ -1,39 +1,170 @@
-import { Request, Response, NextFunction } from 'express';
-import jwt from 'jsonwebtoken';
+import { NextFunction, Request, Response } from 'express';
+import jwt, { type JwtPayload, type SignOptions } from 'jsonwebtoken';
+import { v4 as uuid } from 'uuid';
+import { getDb } from '@goldilocks/data';
 import { CONFIG } from '@goldilocks/config';
 
 export interface AuthUser {
   id: string;
   email: string;
+  jti: string;
+}
+
+export interface AuthTokenPayload extends JwtPayload {
+  id: string;
+  email: string;
+  jti: string;
 }
 
 export interface AuthRequest extends Request {
   user?: AuthUser;
+  authToken?: string;
+  authClaims?: AuthTokenPayload;
+}
+
+const SESSION_COOKIE_OPTIONS = {
+  httpOnly: true,
+  sameSite: 'strict' as const,
+  secure: CONFIG.isProd,
+  path: '/',
+  maxAge: CONFIG.sessionCookieMaxAgeMs,
+};
+
+function parseCookies(cookieHeader?: string): Record<string, string> {
+  if (!cookieHeader) {
+    return {};
+  }
+
+  return cookieHeader
+    .split(';')
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .reduce<Record<string, string>>((cookies, part) => {
+      const separatorIndex = part.indexOf('=');
+      if (separatorIndex <= 0) {
+        return cookies;
+      }
+
+      const name = part.slice(0, separatorIndex).trim();
+      const value = part.slice(separatorIndex + 1).trim();
+      cookies[name] = decodeURIComponent(value);
+      return cookies;
+    }, {});
+}
+
+function getTokenFromAuthorizationHeader(authHeader?: string): string | null {
+  if (!authHeader?.startsWith('Bearer ')) {
+    return null;
+  }
+
+  const token = authHeader.slice(7).trim();
+  return token || null;
+}
+
+function assertValidPayload(payload: string | JwtPayload): AuthTokenPayload {
+  if (typeof payload === 'string') {
+    throw new Error('Invalid token payload');
+  }
+
+  if (typeof payload.id !== 'string' || typeof payload.email !== 'string' || typeof payload.jti !== 'string') {
+    throw new Error('Invalid token payload');
+  }
+
+  if (typeof payload.exp !== 'number') {
+    throw new Error('Token missing expiry');
+  }
+
+  return payload as AuthTokenPayload;
+}
+
+function pruneExpiredRevocations(): void {
+  getDb().prepare('DELETE FROM revoked_tokens WHERE expires_at <= ?').run(Date.now());
+}
+
+function isTokenRevoked(jti: string): boolean {
+  pruneExpiredRevocations();
+  const row = getDb().prepare('SELECT 1 FROM revoked_tokens WHERE jti = ?').get(jti);
+  return Boolean(row);
+}
+
+export function getTokenFromCookieHeader(cookieHeader?: string): string | null {
+  return parseCookies(cookieHeader)[CONFIG.sessionCookieName] ?? null;
+}
+
+export function getRequestToken(req: Request): string | null {
+  const cookieToken = (req as Request & { cookies?: Record<string, string> }).cookies?.[CONFIG.sessionCookieName]
+    ?? getTokenFromCookieHeader(req.headers.cookie);
+
+  return cookieToken ?? getTokenFromAuthorizationHeader(req.headers.authorization);
+}
+
+export function verifySignedToken(token: string): AuthTokenPayload {
+  const payload = jwt.verify(token, CONFIG.jwtSecret, {
+    issuer: CONFIG.jwtIssuer,
+    audience: CONFIG.jwtAudience,
+  });
+
+  const claims = assertValidPayload(payload);
+  if (isTokenRevoked(claims.jti)) {
+    throw new Error('Token revoked');
+  }
+
+  return claims;
+}
+
+export function revokeToken(claims: { jti: string; exp: number }): void {
+  getDb().prepare(`
+    INSERT OR REPLACE INTO revoked_tokens (jti, expires_at)
+    VALUES (?, ?)
+  `).run(claims.jti, claims.exp * 1000);
 }
 
 export function verifyToken(req: AuthRequest, res: Response, next: NextFunction): void {
-  const authHeader = req.headers.authorization;
-  
-  if (!authHeader?.startsWith('Bearer ')) {
-    res.status(401).json({ error: 'Missing or invalid authorization header' });
+  const token = getRequestToken(req);
+
+  if (!token) {
+    res.status(401).json({ error: 'Missing session cookie or bearer token' });
     return;
   }
-  
-  const token = authHeader.slice(7);
-  
+
   try {
-    const payload = jwt.verify(token, CONFIG.jwtSecret) as AuthUser;
-    req.user = payload;
+    const claims = verifySignedToken(token);
+    req.authToken = token;
+    req.authClaims = claims;
+    req.user = {
+      id: claims.id,
+      email: claims.email,
+      jti: claims.jti,
+    };
     next();
-  } catch (err) {
-    res.status(401).json({ error: 'Invalid or expired token' });
+  } catch {
+    res.status(401).json({ error: 'Invalid, expired, or revoked token' });
   }
 }
 
-export function generateToken(user: AuthUser): string {
+export function generateToken(user: Pick<AuthUser, 'id' | 'email'>): string {
   return jwt.sign(
-    { id: user.id, email: user.email },
+    {
+      id: user.id,
+      email: user.email,
+      jti: uuid(),
+    },
     CONFIG.jwtSecret,
-    { expiresIn: CONFIG.jwtExpiresIn }
+    {
+      expiresIn: CONFIG.jwtExpiresIn as SignOptions['expiresIn'],
+      issuer: CONFIG.jwtIssuer,
+      audience: CONFIG.jwtAudience,
+    }
   );
+}
+
+export function setSessionCookie(res: Response, token: string): void {
+  res.cookie(CONFIG.sessionCookieName, token, SESSION_COOKIE_OPTIONS);
+}
+
+export function clearSessionCookie(res: Response): void {
+  res.clearCookie(CONFIG.sessionCookieName, {
+    ...SESSION_COOKIE_OPTIONS,
+    maxAge: undefined,
+  });
 }

--- a/apps/gateway/src/auth/routes.ts
+++ b/apps/gateway/src/auth/routes.ts
@@ -2,7 +2,14 @@ import { Router, Request, Response } from 'express';
 import { v4 as uuid } from 'uuid';
 import { getDb } from '@goldilocks/data';
 import { hashPassword, verifyPassword } from './hash.js';
-import { generateToken, verifyToken, AuthRequest } from './middleware.js';
+import {
+  clearSessionCookie,
+  generateToken,
+  revokeToken,
+  setSessionCookie,
+  verifyToken,
+  AuthRequest,
+} from './middleware.js';
 
 const router = Router();
 
@@ -17,85 +24,105 @@ interface LoginBody {
   password: string;
 }
 
+interface UserRow {
+  id: string;
+  email: string;
+  password_hash: string;
+  display_name: string | null;
+  settings: string;
+  created_at?: number;
+}
+
+function formatUser(row: Pick<UserRow, 'id' | 'email' | 'display_name' | 'settings'> & { created_at?: number }) {
+  return {
+    id: row.id,
+    email: row.email,
+    displayName: row.display_name,
+    settings: JSON.parse(row.settings),
+    createdAt: row.created_at,
+  };
+}
+
 // POST /api/auth/register
 router.post('/register', async (req: Request<{}, {}, RegisterBody>, res: Response) => {
   const { email, password, displayName } = req.body;
-  
+
   if (!email || !password) {
     res.status(400).json({ error: 'Email and password are required' });
     return;
   }
 
-  // Basic email format validation (§5.13)
   const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
   if (!emailRegex.test(email)) {
     res.status(400).json({ error: 'Invalid email format' });
     return;
   }
-  
+
   if (password.length < 8) {
     res.status(400).json({ error: 'Password must be at least 8 characters' });
     return;
   }
-  
+
   const db = getDb();
-  
-  // Check if user exists
   const existing = db.prepare('SELECT id FROM users WHERE email = ?').get(email);
   if (existing) {
     res.status(409).json({ error: 'Email already registered' });
     return;
   }
-  
+
   const id = uuid();
   const passwordHash = await hashPassword(password);
-  
+
   db.prepare(`
     INSERT INTO users (id, email, password_hash, display_name)
     VALUES (?, ?, ?, ?)
   `).run(id, email, passwordHash, displayName ?? null);
-  
-  const user = { id, email, displayName: displayName ?? null };
+
   const token = generateToken({ id, email });
-  
-  res.status(201).json({ token, user });
+  setSessionCookie(res, token);
+
+  res.status(201).json({
+    user: {
+      id,
+      email,
+      displayName: displayName ?? null,
+      settings: {},
+    },
+  });
 });
 
 // POST /api/auth/login
 router.post('/login', async (req: Request<{}, {}, LoginBody>, res: Response) => {
   const { email, password } = req.body;
-  
+
   if (!email || !password) {
     res.status(400).json({ error: 'Email and password are required' });
     return;
   }
-  
+
   const db = getDb();
   const row = db.prepare(`
     SELECT id, email, password_hash, display_name, settings
     FROM users WHERE email = ?
-  `).get(email) as { id: string; email: string; password_hash: string; display_name: string | null; settings: string } | undefined;
-  
+  `).get(email) as UserRow | undefined;
+
   if (!row) {
     res.status(401).json({ error: 'Invalid email or password' });
     return;
   }
-  
+
   const valid = await verifyPassword(password, row.password_hash);
   if (!valid) {
     res.status(401).json({ error: 'Invalid email or password' });
     return;
   }
-  
+
   const token = generateToken({ id: row.id, email: row.email });
-  const user = {
-    id: row.id,
-    email: row.email,
-    displayName: row.display_name,
-    settings: JSON.parse(row.settings)
-  };
-  
-  res.json({ token, user });
+  setSessionCookie(res, token);
+
+  res.json({
+    user: formatUser(row),
+  });
 });
 
 // POST /api/auth/refresh
@@ -104,9 +131,22 @@ router.post('/refresh', verifyToken, (req: AuthRequest, res: Response) => {
     res.status(401).json({ error: 'Unauthorized' });
     return;
   }
-  
+
   const token = generateToken(req.user);
-  res.json({ token });
+  setSessionCookie(res, token);
+  res.json({ ok: true });
+});
+
+// POST /api/auth/logout
+router.post('/logout', verifyToken, (req: AuthRequest, res: Response) => {
+  if (!req.authClaims) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+
+  revokeToken({ jti: req.authClaims.jti, exp: req.authClaims.exp! });
+  clearSessionCookie(res);
+  res.json({ ok: true });
 });
 
 // GET /api/auth/me
@@ -115,27 +155,19 @@ router.get('/me', verifyToken, (req: AuthRequest, res: Response) => {
     res.status(401).json({ error: 'Unauthorized' });
     return;
   }
-  
+
   const db = getDb();
   const row = db.prepare(`
     SELECT id, email, display_name, settings, created_at
     FROM users WHERE id = ?
-  `).get(req.user.id) as { id: string; email: string; display_name: string | null; settings: string; created_at: number } | undefined;
-  
+  `).get(req.user.id) as UserRow | undefined;
+
   if (!row) {
     res.status(404).json({ error: 'User not found' });
     return;
   }
-  
-  res.json({
-    user: {
-      id: row.id,
-      email: row.email,
-      displayName: row.display_name,
-      settings: JSON.parse(row.settings),
-      createdAt: row.created_at
-    }
-  });
+
+  res.json({ user: formatUser(row) });
 });
 
 export default router;

--- a/apps/gateway/src/conversations/routes.ts
+++ b/apps/gateway/src/conversations/routes.ts
@@ -194,7 +194,7 @@ router.delete('/:id', async (req: AuthRequest, res: Response) => {
     try {
       const response = await agentServiceFetch('/internal/sessions/delete', {
         method: 'POST',
-        userId: req.user.id,
+        userToken: req.authToken!,
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ sessionPath: row.pi_session_id }),
       });

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -11,7 +11,6 @@
  */
 
 import { createServer } from 'http';
-import { WebSocketServer } from 'ws';
 import { createApp } from './app.js';
 import { CONFIG } from '@goldilocks/config';
 import { runMigrations, closeDb } from '@goldilocks/data';
@@ -25,8 +24,7 @@ export const app = createApp();
 const server = createServer(app);
 
 // WebSocket
-const wss = new WebSocketServer({ server, path: '/ws' });
-setupWebSocket(wss);
+const wss = setupWebSocket(server);
 
 // Graceful shutdown
 let shuttingDown = false;

--- a/apps/gateway/src/models/routes.ts
+++ b/apps/gateway/src/models/routes.ts
@@ -13,7 +13,7 @@ router.get('/', verifyToken, async (req: AuthRequest, res: Response) => {
   try {
     const response = await agentServiceFetch('/internal/models', {
       method: 'GET',
-      userId: req.user.id,
+      userToken: req.authToken!,
     });
     const json = await response.json();
     res.status(response.status).json(json);
@@ -32,7 +32,7 @@ router.post('/select', verifyToken, async (req: AuthRequest, res: Response) => {
   try {
     const response = await agentServiceFetch('/internal/models/select', {
       method: 'POST',
-      userId: req.user.id,
+      userToken: req.authToken!,
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(req.body ?? {}),
     });

--- a/apps/gateway/test/api/auth.test.ts
+++ b/apps/gateway/test/api/auth.test.ts
@@ -1,4 +1,6 @@
+import jwt from 'jsonwebtoken';
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { CONFIG } from '@goldilocks/config';
 import { createTestServer, type TestUser } from './helpers/test-server.js';
 
 describe('Auth', () => {
@@ -16,7 +18,7 @@ describe('Auth', () => {
 
   // ── Register ───────────────────────────────────────────────────────────────
 
-  it('registers a new user and returns a JWT', async () => {
+  it('registers a new user and sets a session cookie', async () => {
     const email = `new-${Date.now()}@example.com`;
     const res = await fetch(`${server.baseUrl}/api/auth/register`, {
       method: 'POST',
@@ -25,9 +27,25 @@ describe('Auth', () => {
     });
 
     expect(res.status).toBe(201);
-    const json = await res.json() as { token: string; user: { id: string; email: string } };
-    expect(json.token).toBeTruthy();
+    const json = await res.json() as { user: { id: string; email: string } };
+    const setCookie = res.headers.get('set-cookie') ?? '';
+
+    expect(setCookie).toContain(`${CONFIG.sessionCookieName}=`);
+    expect(setCookie).toContain('HttpOnly');
+    expect(setCookie).toContain('SameSite=Strict');
     expect(json.user.email).toBe(email);
+  });
+
+  it('issues JWT claims with iss, aud, and jti', async () => {
+    const claims = jwt.verify(user.token, CONFIG.jwtSecret, {
+      issuer: CONFIG.jwtIssuer,
+      audience: CONFIG.jwtAudience,
+    }) as jwt.JwtPayload & { id: string; email: string; jti: string };
+
+    expect(claims.id).toBe(user.userId);
+    expect(claims.email).toBe(user.email);
+    expect(typeof claims.jti).toBe('string');
+    expect(claims.jti.length).toBeGreaterThan(10);
   });
 
   it('rejects duplicate email', async () => {
@@ -52,7 +70,7 @@ describe('Auth', () => {
 
   // ── Login ─────────────────────────────────────────────────────────────────
 
-  it('logs in with valid credentials and returns a JWT', async () => {
+  it('logs in with valid credentials and sets a session cookie', async () => {
     const res = await fetch(`${server.baseUrl}/api/auth/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -60,8 +78,10 @@ describe('Auth', () => {
     });
 
     expect(res.status).toBe(200);
-    const json = await res.json() as { token: string; user: { id: string; email: string } };
-    expect(json.token).toBeTruthy();
+    const json = await res.json() as { user: { id: string; email: string } };
+    const setCookie = res.headers.get('set-cookie') ?? '';
+
+    expect(setCookie).toContain(`${CONFIG.sessionCookieName}=`);
     expect(json.user.id).toBe(user.userId);
   });
 
@@ -89,9 +109,9 @@ describe('Auth', () => {
 
   // ── GET /me ───────────────────────────────────────────────────────────────
 
-  it('returns the current user profile', async () => {
+  it('returns the current user profile via the session cookie', async () => {
     const res = await fetch(`${server.baseUrl}/api/auth/me`, {
-      headers: { authorization: server.authHeader(user) },
+      headers: { cookie: server.cookieHeader(user) },
     });
 
     expect(res.status).toBe(200);
@@ -99,6 +119,16 @@ describe('Auth', () => {
     expect(json.user.id).toBe(user.userId);
     expect(json.user.email).toBe(user.email);
     expect(json.user.displayName).toBe('Test User');
+  });
+
+  it('still accepts a bearer token during migration fallback', async () => {
+    const res = await fetch(`${server.baseUrl}/api/auth/me`, {
+      headers: { authorization: server.authHeader(user) },
+    });
+
+    expect(res.status).toBe(200);
+    const json = await res.json() as { user: { id: string } };
+    expect(json.user.id).toBe(user.userId);
   });
 
   it('rejects requests without a token', async () => {
@@ -118,5 +148,48 @@ describe('Auth', () => {
       headers: { authorization: 'NotBearer token' },
     });
     expect(res.status).toBe(401);
+  });
+
+  it('refreshes the cookie without returning the raw token', async () => {
+    const res = await fetch(`${server.baseUrl}/api/auth/refresh`, {
+      method: 'POST',
+      headers: { cookie: server.cookieHeader(user) },
+    });
+
+    expect(res.status).toBe(200);
+    const json = await res.json() as { ok: boolean; token?: string };
+    expect(json.ok).toBe(true);
+    expect(json).not.toHaveProperty('token');
+    expect(res.headers.get('set-cookie')).toContain(`${CONFIG.sessionCookieName}=`);
+  });
+
+  it('logout revokes the current token and clears the cookie', async () => {
+    const loginRes = await fetch(`${server.baseUrl}/api/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: user.email, password: 'TestPassword123!' }),
+    });
+    const loginCookie = (loginRes.headers.get('set-cookie') ?? '').split(';')[0];
+    const loginToken = decodeURIComponent(loginCookie.split('=').slice(1).join('='));
+
+    const logoutRes = await fetch(`${server.baseUrl}/api/auth/logout`, {
+      method: 'POST',
+      headers: { cookie: loginCookie },
+    });
+
+    expect(logoutRes.status).toBe(200);
+    const clearedCookie = logoutRes.headers.get('set-cookie') ?? '';
+    expect(clearedCookie).toContain(`${CONFIG.sessionCookieName}=`);
+    expect(clearedCookie.toLowerCase()).toContain('expires=thu, 01 jan 1970');
+
+    const revokedCookieRes = await fetch(`${server.baseUrl}/api/auth/me`, {
+      headers: { cookie: loginCookie },
+    });
+    expect(revokedCookieRes.status).toBe(401);
+
+    const revokedHeaderRes = await fetch(`${server.baseUrl}/api/auth/me`, {
+      headers: { authorization: `Bearer ${loginToken}` },
+    });
+    expect(revokedHeaderRes.status).toBe(401);
   });
 });

--- a/apps/gateway/test/api/helpers/test-server.ts
+++ b/apps/gateway/test/api/helpers/test-server.ts
@@ -26,6 +26,7 @@ import { EventEmitter } from 'events';
 
 export interface TestUser {
   token: string;
+  cookie: string;
   userId: string;
   email: string;
 }
@@ -36,6 +37,7 @@ export interface TestServer {
   stop: () => Promise<void>;
   registerUser: (overrides?: Partial<{ email: string; password: string; displayName: string }>) => Promise<TestUser>;
   authHeader: (user: TestUser) => string;
+  cookieHeader: (user: TestUser) => string;
 }
 
 /**
@@ -239,6 +241,7 @@ async function createTestServer(): Promise<TestServer> {
   process.env.ENCRYPTION_KEY = 'test-encryption-key-32bytes!!';
   process.env.AGENT_SERVICE_SHARED_SECRET = 'test-agent-shared-secret';
   process.env.NODE_ENV = 'test';
+  process.env.FRONTEND_URL = 'http://localhost:5173';
 
   const { sessionManager } = await import('@goldilocks/runtime');
 
@@ -425,12 +428,23 @@ async function createTestServer(): Promise<TestServer> {
             throw new Error(`Register failed: ${res.status} ${await res.text()}`);
           }
 
-          const json = await res.json() as { token: string; user: { id: string } };
-          return { token: json.token, userId: json.user.id, email };
+          const json = await res.json() as { user: { id: string } };
+          const setCookie = res.headers.get('set-cookie');
+          if (!setCookie) {
+            throw new Error('Register response missing session cookie');
+          }
+
+          const cookie = setCookie.split(';')[0];
+          const cookieValue = cookie.split('=').slice(1).join('=');
+          return { token: decodeURIComponent(cookieValue), cookie, userId: json.user.id, email };
         },
 
         authHeader(user: TestUser) {
           return `Bearer ${user.token}`;
+        },
+
+        cookieHeader(user: TestUser) {
+          return user.cookie;
         },
       });
     });

--- a/apps/gateway/test/setup.ts
+++ b/apps/gateway/test/setup.ts
@@ -24,6 +24,7 @@ process.env.JWT_SECRET = 'test-jwt-not-for-prod';
 process.env.ENCRYPTION_KEY = 'test-encryption-key-32bytes!!';
 process.env.AGENT_SERVICE_SHARED_SECRET = 'test-agent-shared-secret';
 process.env.NODE_ENV = 'test';
+process.env.FRONTEND_URL = 'http://localhost:5173';
 
 afterAll(() => {
   try {

--- a/apps/gateway/test/smoke-test.sh
+++ b/apps/gateway/test/smoke-test.sh
@@ -123,12 +123,15 @@ req_no_auth() {
     2>/dev/null
 }
 
-register_and_get_token() {
+register_and_capture_session() {
   local email=$1
   local password=$2
-  req_no_auth POST /api/auth/register \
+  local cookie_jar=$3
+  curl -s -c "$cookie_jar" -X POST \
+    -H 'Content-Type: application/json' \
     -d "{\"email\":\"$email\",\"password\":\"$password\",\"displayName\":\"Smoke Test\"}" \
-    | jq -r '.token // empty'
+    "$BASE/api/auth/register" \
+    2>/dev/null
 }
 
 # ── Health ──────────────────────────────────────────────────────────────────
@@ -150,16 +153,18 @@ note "Auth"
 EMAIL="smoke-$(date +%s)@example.com"
 PASSWORD="SmokeTest123!"
 
-TOKEN=$(register_and_get_token "$EMAIL" "$PASSWORD")
+COOKIE_JAR=$(mktemp)
+REGISTER=$(register_and_capture_session "$EMAIL" "$PASSWORD" "$COOKIE_JAR")
+TOKEN=$(awk '$6 == "goldilocks-session" { print $7 }' "$COOKIE_JAR" | tail -n1)
 if [[ -n "$TOKEN" && "$TOKEN" != "empty" ]]; then
-  pass "register → JWT token"
+  pass "register → session cookie"
 else
-  fail "register failed"
+  fail "register failed: $REGISTER"
   TOKEN=""
 fi
 
 if [[ -n "$TOKEN" ]]; then
-  ME=$(curl -s "$BASE/api/auth/me" -H "Authorization: Bearer $TOKEN" 2>/dev/null) || true
+  ME=$(curl -s -b "$COOKIE_JAR" "$BASE/api/auth/me" 2>/dev/null) || true
   if echo "$ME" | jq -r '.user.email' 2>/dev/null | grep -q "$EMAIL"; then
     pass "GET /api/auth/me → correct user"
   else
@@ -182,16 +187,15 @@ note "Conversations"
 if [[ -z "$TOKEN" ]]; then
   skip "auth failed, skipping conversations"
 else
-  CONV=$(curl -s -X POST "$BASE/api/conversations" \
+  CONV=$(curl -s -b "$COOKIE_JAR" -X POST "$BASE/api/conversations" \
     -H 'Content-Type: application/json' \
-    -H "Authorization: Bearer $TOKEN" \
     -d '{"title":"Smoke Test Conv"}' 2>/dev/null) || true
   CONV_ID=$(echo "$CONV" | jq -r '.conversation.id // empty' 2>/dev/null) || true
 
   if [[ -n "$CONV_ID" && "$CONV_ID" != "empty" ]]; then
     pass "create conversation → $CONV_ID"
 
-    CONVS=$(curl -s "$BASE/api/conversations" -H "Authorization: Bearer $TOKEN" 2>/dev/null) || true
+    CONVS=$(curl -s -b "$COOKIE_JAR" "$BASE/api/conversations" 2>/dev/null) || true
     COUNT=$(echo "$CONVS" | jq '.conversations | length' 2>/dev/null) || COUNT=0
     if [[ "$COUNT" -ge 1 ]]; then
       pass "list conversations → $COUNT found"
@@ -199,9 +203,8 @@ else
       fail "list conversations returned $COUNT"
     fi
 
-    RENAMED=$(curl -s -X PATCH "$BASE/api/conversations/$CONV_ID" \
+    RENAMED=$(curl -s -b "$COOKIE_JAR" -X PATCH "$BASE/api/conversations/$CONV_ID" \
       -H 'Content-Type: application/json' \
-      -H "Authorization: Bearer $TOKEN" \
       -d '{"title":"Renamed by Smoke Test"}' 2>/dev/null) || true
     if echo "$RENAMED" | jq -r '.conversation.title' 2>/dev/null | grep -q "Renamed by Smoke Test"; then
       pass "rename conversation"
@@ -209,8 +212,7 @@ else
       fail "rename failed: $RENAMED"
     fi
 
-    DELETED=$(curl -s -X DELETE "$BASE/api/conversations/$CONV_ID" \
-      -H "Authorization: Bearer $TOKEN" 2>/dev/null) || true
+    DELETED=$(curl -s -b "$COOKIE_JAR" -X DELETE "$BASE/api/conversations/$CONV_ID" 2>/dev/null) || true
     if echo "$DELETED" | jq -r '.ok' 2>/dev/null | grep -q 'true'; then
       pass "delete conversation"
     else
@@ -235,16 +237,15 @@ note "Settings"
 if [[ -z "$TOKEN" ]]; then
   skip "auth failed, skipping settings"
 else
-  GET=$(curl -s "$BASE/api/settings" -H "Authorization: Bearer $TOKEN" 2>/dev/null) || true
+  GET=$(curl -s -b "$COOKIE_JAR" "$BASE/api/settings" 2>/dev/null) || true
   if echo "$GET" | jq -r '.settings' >/dev/null 2>&1; then
     pass "GET /api/settings → { settings: {...} }"
   else
     fail "GET settings failed: $GET"
   fi
 
-  PATCH=$(curl -s -X PATCH "$BASE/api/settings" \
+  PATCH=$(curl -s -b "$COOKIE_JAR" -X PATCH "$BASE/api/settings" \
     -H 'Content-Type: application/json' \
-    -H "Authorization: Bearer $TOKEN" \
     -d '{"defaultModel":"claude-sonnet-4-20250514"}' 2>/dev/null) || true
   if echo "$PATCH" | jq -r '.settings.defaultModel' 2>/dev/null | grep -q 'claude-sonnet'; then
     pass "PATCH /api/settings → merge works"
@@ -252,7 +253,7 @@ else
     fail "PATCH settings failed: $PATCH"
   fi
 
-  KEYS=$(curl -s "$BASE/api/settings/api-keys" -H "Authorization: Bearer $TOKEN" 2>/dev/null) || true
+  KEYS=$(curl -s -b "$COOKIE_JAR" "$BASE/api/settings/api-keys" 2>/dev/null) || true
   if echo "$KEYS" | jq -r '.apiKeys' >/dev/null 2>&1; then
     pass "GET /api/settings/api-keys → key list returned"
   else

--- a/apps/gateway/test/websocket-auth.test.ts
+++ b/apps/gateway/test/websocket-auth.test.ts
@@ -1,0 +1,86 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { IncomingMessage } from 'http';
+import { closeDb, runMigrations } from '@goldilocks/data';
+import { CONFIG } from '@goldilocks/config';
+import {
+  authenticateWebSocketUpgrade,
+} from '../src/agent/websocket.js';
+import {
+  generateToken,
+  revokeToken,
+  verifySignedToken,
+} from '../src/auth/middleware.js';
+
+function makeUpgradeRequest(overrides: Partial<IncomingMessage['headers']> = {}): IncomingMessage {
+  return {
+    headers: {
+      host: 'localhost:3000',
+      origin: 'http://localhost:5173',
+      ...overrides,
+    },
+  } as IncomingMessage;
+}
+
+describe('gateway websocket upgrade auth', () => {
+  beforeAll(() => {
+    runMigrations();
+  });
+
+  afterAll(() => {
+    closeDb();
+  });
+
+  it('accepts upgrade requests from the allowed origin with a valid session cookie', () => {
+    const token = generateToken({ id: 'user-1', email: 'user@example.com' });
+    const req = makeUpgradeRequest({
+      cookie: `${CONFIG.sessionCookieName}=${encodeURIComponent(token)}`,
+    });
+
+    const result = authenticateWebSocketUpgrade(req);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.user.id).toBe('user-1');
+    expect(result.token).toBe(token);
+  });
+
+  it('rejects websocket upgrades from disallowed origins', () => {
+    const token = generateToken({ id: 'user-1', email: 'user@example.com' });
+    const req = makeUpgradeRequest({
+      origin: 'https://evil.example',
+      cookie: `${CONFIG.sessionCookieName}=${encodeURIComponent(token)}`,
+    });
+
+    const result = authenticateWebSocketUpgrade(req);
+    expect(result).toEqual({
+      ok: false,
+      status: 403,
+      error: 'WebSocket origin not allowed',
+    });
+  });
+
+  it('rejects websocket upgrades without a session cookie', () => {
+    const result = authenticateWebSocketUpgrade(makeUpgradeRequest());
+    expect(result).toEqual({
+      ok: false,
+      status: 401,
+      error: 'Missing session cookie',
+    });
+  });
+
+  it('rejects revoked websocket tokens', () => {
+    const token = generateToken({ id: 'user-2', email: 'revoked@example.com' });
+    const claims = verifySignedToken(token);
+    revokeToken(claims);
+
+    const req = makeUpgradeRequest({
+      cookie: `${CONFIG.sessionCookieName}=${encodeURIComponent(token)}`,
+    });
+
+    const result = authenticateWebSocketUpgrade(req);
+    expect(result).toEqual({
+      ok: false,
+      status: 401,
+      error: 'Invalid, expired, or revoked token',
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,10 +51,12 @@
         "@goldilocks/data": "file:../../packages/data",
         "@goldilocks/runtime": "file:../../packages/runtime",
         "express": "^5.1.0",
+        "jsonwebtoken": "^9.0.3",
         "ws": "^8.18.2"
       },
       "devDependencies": {
         "@types/express": "^5.0.2",
+        "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^22.15.3",
         "@types/ws": "^8.18.1",
         "tsx": "^4.19.4",
@@ -104,6 +106,7 @@
         "@goldilocks/runtime": "file:../../packages/runtime",
         "@mariozechner/pi-ai": "^0.64.0",
         "bcrypt": "^5.1.1",
+        "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "express": "^5.1.0",
         "express-rate-limit": "^8.3.2",
@@ -113,6 +116,7 @@
       },
       "devDependencies": {
         "@types/bcrypt": "^5.0.2",
+        "@types/cookie-parser": "^1.4.10",
         "@types/cors": "^2.8.17",
         "@types/express": "^5.0.2",
         "@types/jsonwebtoken": "^9.0.10",
@@ -5136,6 +5140,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookie-parser": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.10.tgz",
+      "integrity": "sha512-B4xqkqfZ8Wek+rCOeRxsjMS9OgvzebEzzLYw7NHYuvzb7IdxOkI0ZHGgeEBX4PUM7QGVvNSK60T3OvWj3YfBRg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/cors": {
       "version": "2.8.19",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
@@ -6854,6 +6868,25 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
     },
     "node_modules/cookie-signature": {
       "version": "1.2.2",

--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -5,6 +5,7 @@ config();
 
 const defaultStateDir = resolve(process.cwd(), '.dev');
 const dataDir = process.env.DATA_DIR ?? (process.env.GOLDILOCKS_STATE_DIR ? resolve(process.env.GOLDILOCKS_STATE_DIR) : defaultStateDir);
+const sessionCookieMaxAgeMs = parseInt(process.env.SESSION_COOKIE_MAX_AGE_MS ?? '28800000', 10);
 
 function requireEnv(name: 'JWT_SECRET' | 'ENCRYPTION_KEY' | 'AGENT_SERVICE_SHARED_SECRET'): string {
   const value = process.env[name]?.trim();
@@ -26,9 +27,28 @@ export const CONFIG = {
   get jwtSecret(): string {
     return requireEnv('JWT_SECRET');
   },
-  jwtExpiresIn: '7d',
+  jwtExpiresIn: process.env.JWT_EXPIRES_IN ?? '8h',
+  jwtIssuer: 'goldilocks-gateway',
+  jwtAudience: 'goldilocks-api',
+  sessionCookieName: process.env.SESSION_COOKIE_NAME ?? 'goldilocks-session',
+  sessionCookieMaxAgeMs,
   get encryptionKey(): string {
     return requireEnv('ENCRYPTION_KEY');
+  },
+
+  get frontendUrl(): string {
+    return process.env.FRONTEND_URL ?? (this.isProd ? `http://localhost:${this.port}` : 'http://localhost:5173');
+  },
+
+  get allowedWebSocketOrigins(): string[] {
+    const origins = new Set<string>([this.frontendUrl]);
+
+    if (!this.isProd) {
+      origins.add('http://localhost:5173');
+      origins.add('http://127.0.0.1:5173');
+    }
+
+    return [...origins];
   },
 
   // k8s

--- a/packages/config/test/config.test.ts
+++ b/packages/config/test/config.test.ts
@@ -53,3 +53,31 @@ describe('CONFIG required secrets', () => {
     expect(() => CONFIG.validateRequiredSecrets()).not.toThrow();
   });
 });
+
+describe('CONFIG auth defaults', () => {
+  it('uses cookie-session auth defaults tuned for wave 2', async () => {
+    process.env.NODE_ENV = 'test';
+    process.env.JWT_SECRET = 'test-jwt-not-for-prod';
+    process.env.ENCRYPTION_KEY = 'test-encryption-key-32bytes!!';
+    process.env.AGENT_SERVICE_SHARED_SECRET = 'test-agent-shared-secret';
+
+    const { CONFIG } = await loadConfig();
+    expect(CONFIG.jwtExpiresIn).toBe('8h');
+    expect(CONFIG.sessionCookieName).toBe('goldilocks-session');
+    expect(CONFIG.jwtIssuer).toBe('goldilocks-gateway');
+    expect(CONFIG.jwtAudience).toBe('goldilocks-api');
+    expect(CONFIG.sessionCookieMaxAgeMs).toBe(28_800_000);
+  });
+
+  it('builds websocket origin allowlist from frontendUrl plus localhost dev origin', async () => {
+    process.env.NODE_ENV = 'development';
+    process.env.FRONTEND_URL = 'https://goldilocks.example';
+    process.env.JWT_SECRET = 'test-jwt-not-for-prod';
+    process.env.ENCRYPTION_KEY = 'test-encryption-key-32bytes!!';
+    process.env.AGENT_SERVICE_SHARED_SECRET = 'test-agent-shared-secret';
+
+    const { CONFIG } = await loadConfig();
+    expect(CONFIG.allowedWebSocketOrigins).toContain('https://goldilocks.example');
+    expect(CONFIG.allowedWebSocketOrigins).toContain('http://localhost:5173');
+  });
+});

--- a/packages/contracts/src/websocket.ts
+++ b/packages/contracts/src/websocket.ts
@@ -1,9 +1,9 @@
 /**
- * Shared WebSocket message types used by both the frontend client and backend server.
+ * Shared browser WebSocket message types used by both the frontend client and gateway.
  *
- * Client → Server: auth, open, prompt, abort
- * Server → Client: auth_ok, auth_fail, ready, text_delta, thinking_delta,
- *                   tool_start, tool_update, tool_end, message_end, agent_end, error
+ * Client → Server: open, prompt, abort
+ * Server → Client: ready, text_delta, thinking_delta, tool_start,
+ *                   tool_update, tool_end, message_end, agent_end, error
  */
 
 // ---------------------------------------------------------------------------
@@ -11,7 +11,6 @@
 // ---------------------------------------------------------------------------
 
 export type ClientMessage =
-  | { type: 'auth'; token: string }
   | { type: 'open'; conversationId: string }
   | { type: 'prompt'; text: string; files?: string[] }
   | { type: 'abort' };
@@ -21,8 +20,6 @@ export type ClientMessage =
 // ---------------------------------------------------------------------------
 
 export type ServerMessage =
-  | { type: 'auth_ok'; userId: string }
-  | { type: 'auth_fail'; error: string }
   | { type: 'ready'; conversationId: string; messages?: HistoryMessage[] }
   | { type: 'text_delta'; delta: string }
   | { type: 'thinking_delta'; delta: string }

--- a/packages/data/src/migrations/003_revoked_tokens.sql
+++ b/packages/data/src/migrations/003_revoked_tokens.sql
@@ -1,0 +1,9 @@
+-- Wave 2 auth hardening: JWT revocation denylist
+
+CREATE TABLE IF NOT EXISTS revoked_tokens (
+  jti TEXT PRIMARY KEY,
+  expires_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_revoked_tokens_expires_at
+ON revoked_tokens (expires_at);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,8 @@ export default defineConfig({
       'apps/frontend/src/**/*.test.ts',
     ],
     exclude: ['node_modules/**'],
+    fileParallelism: false,
+    hookTimeout: 30_000,
     reporters: process.env.CI ? ['verbose'] : ['default'],
   },
 });


### PR DESCRIPTION
## Summary
- move browser auth from localStorage bearer tokens to httpOnly session cookies with JWT `jti` / `iss` / `aud` claims, logout revocation, and cookie-based frontend state
- authenticate browser WebSockets at upgrade time with cookie + origin allowlist checks, then pass the verified user JWT through to agent-service instead of trusting `x-goldilocks-user`
- add Wave 2 regression coverage for cookie auth, revoked tokens, websocket upgrade validation, and agent-service internal JWT verification

## What changed
- added cookie-parser + cookie session config (`goldilocks-session`, 8h TTL, strict same-site) and switched gateway auth routes to set/clear cookies instead of returning frontend-managed bearer state
- updated `verifyToken()` to read cookies first, keep temporary bearer fallback, validate `iss` / `aud`, and reject revoked JTIs from a new `revoked_tokens` table
- refactored browser websocket setup to reject bad origins / missing cookies before connection establishment and removed the browser message-based `{ type: 'auth' }` flow
- changed gateway→agent-service HTTP + WS auth to forward the verified JWT, with new agent-service-side JWT verification and revocation checks
- removed frontend token persistence, made API/file fetches use `credentials: 'include'`, and added a startup auth check so refreshes survive on the cookie alone
- stabilized vitest file execution because the API integration harness mutates shared env/config state
- refreshed the smoke script to use session cookies instead of parsing a JSON token that no longer exists

## Verification
- `npm run build:packages`
- `npx vitest run packages/config/test/config.test.ts apps/gateway/test/api/auth.test.ts apps/gateway/test/websocket-auth.test.ts apps/agent-service/test/internal-auth.test.ts`
- `npx vitest run`
- `npm run build`

## Roadmap
Implements Wave 2 of `scratchpad/plans/2026-04-14-security-hardening`:
- P3: auth refactor — cookie-based sessions
- P4: WebSocket origin validation

## Stack
Base branch: `feature/security-wave-1-critical-fixes` (PR #17)
