### PR TITLE
Wave 3: rate limiting and input hardening

### DIFF
--- a/apps/frontend/src/store/files.ts
+++ b/apps/frontend/src/store/files.ts
@@ -79,7 +79,11 @@ export const useFilesStore = create<FilesState>((set, get) => ({
         reader.readAsDataURL(file);
       });
 
-      const res = await api.post<{ ok: true; name: string; path: string; size: number }>('/files/upload', { filename: file.name, content });
+      const res = await api.post<{ ok: true; name: string; path: string; size: number }>('/files/upload', {
+        filename: file.name,
+        content,
+        contentType: file.type || 'application/octet-stream',
+      });
       set((state) => ({
         files: state.files.some((existing) => existing.path === res.path)
           ? state.files

--- a/apps/gateway/package.json
+++ b/apps/gateway/package.json
@@ -22,6 +22,7 @@
     "cors": "^2.8.5",
     "express": "^5.1.0",
     "express-rate-limit": "^8.3.2",
+    "helmet": "^8.1.0",
     "jsonwebtoken": "^9.0.2",
     "uuid": "^11.1.0",
     "ws": "^8.18.2"

--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -6,16 +6,18 @@
  *   - test/api/helpers/test-server.ts: to create an isolated test server
  */
 
-import express from 'express';
+import express, { type NextFunction, type Request, type Response } from 'express';
 import cookieParser from 'cookie-parser';
 import cors from 'cors';
-import rateLimit from 'express-rate-limit';
+import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
+import helmet, { type HelmetOptions } from 'helmet';
 import { existsSync } from 'fs';
 import { dirname, resolve } from 'path';
 import { fileURLToPath } from 'url';
 
 import { CONFIG } from '@goldilocks/config';
 import { getDb } from '@goldilocks/data';
+import { getRequestToken, verifySignedToken } from './auth/middleware.js';
 import { getRelayMetrics } from './agent/relay-metrics.js';
 import authRoutes from './auth/routes.js';
 import conversationRoutes from './conversations/routes.js';
@@ -38,6 +40,68 @@ function getAllowedCorsOrigins(): Set<string> {
   return origins;
 }
 
+function getHelmetOptions(): Readonly<HelmetOptions> {
+  const directives: Record<string, string[]> = {
+    'connect-src': ["'self'"],
+    'script-src': ["'self'"],
+    'style-src': ["'self'"],
+  };
+
+  if (!CONFIG.isProd) {
+    directives['connect-src'] = [
+      "'self'",
+      ...CONFIG.allowedWebSocketOrigins,
+      'ws://localhost:5173',
+      'ws://127.0.0.1:5173',
+    ];
+    directives['script-src'] = ["'self'", "'unsafe-inline'", "'unsafe-eval'"];
+    directives['style-src'] = ["'self'", "'unsafe-inline'"];
+  }
+
+  const options: HelmetOptions = {
+    contentSecurityPolicy: {
+      useDefaults: true,
+      directives,
+    },
+  };
+
+  if (!CONFIG.isProd) {
+    options.crossOriginEmbedderPolicy = false;
+  }
+
+  return options;
+}
+
+function parseJsonBody(req: Request, res: Response, next: NextFunction): void {
+  const jsonParser = req.path.startsWith('/api/files')
+    ? express.json({ limit: CONFIG.fileUploadBodyLimit })
+    : express.json();
+
+  jsonParser(req, res, next);
+}
+
+export function getRateLimitKey(req: Pick<Request, 'headers' | 'ip'> & { cookies?: Record<string, string> }): string {
+  const token = getRequestToken(req as Request);
+
+  if (token) {
+    try {
+      return verifySignedToken(token).id;
+    } catch {
+      // Invalid or revoked tokens fall back to IP bucketing.
+    }
+  }
+
+  return ipKeyGenerator(req.ip ?? '127.0.0.1');
+}
+
+export function buildReadinessFailureResponse(err: unknown) {
+  console.error('Readiness check failed:', err);
+  return {
+    status: 'degraded' as const,
+    error: 'Service unavailable',
+  };
+}
+
 export function createApp() {
   const app = express();
   const allowedOrigins = getAllowedCorsOrigins();
@@ -54,8 +118,9 @@ export function createApp() {
     },
     credentials: true,
   }));
+  app.use(helmet(getHelmetOptions()));
   app.use(cookieParser());
-  app.use(express.json());
+  app.use(parseJsonBody);
 
   // Rate limiting
   const limiter = rateLimit({
@@ -63,6 +128,7 @@ export function createApp() {
     max: CONFIG.isProd ? 60 : 300,
     standardHeaders: true,
     legacyHeaders: false,
+    keyGenerator: getRateLimitKey,
     message: { error: 'Too many requests, please try again later' },
   });
   app.use('/api', limiter);
@@ -70,9 +136,22 @@ export function createApp() {
   const authLimiter = rateLimit({
     windowMs: 15 * 60 * 1000,
     max: 20,
+    standardHeaders: true,
+    legacyHeaders: false,
+    keyGenerator: getRateLimitKey,
     message: { error: 'Too many auth attempts, please try again later' },
   });
   app.use('/api/auth', authLimiter);
+
+  const registerLimiter = rateLimit({
+    windowMs: 60 * 60 * 1000,
+    max: 3,
+    standardHeaders: true,
+    legacyHeaders: false,
+    keyGenerator: (req) => ipKeyGenerator(req.ip ?? '127.0.0.1'),
+    message: { error: 'Too many registration attempts, please try again later' },
+  });
+  app.use('/api/auth/register', registerLimiter);
 
   // Health check
   app.get('/api/health', (_req, res) => {
@@ -84,10 +163,7 @@ export function createApp() {
       getDb().prepare('SELECT 1').get();
       res.json({ status: 'ready', dependencies: { db: 'ok' } });
     } catch (err) {
-      res.status(503).json({
-        status: 'degraded',
-        error: err instanceof Error ? err.message : 'Readiness check failed',
-      });
+      res.status(503).json(buildReadinessFailureResponse(err));
     }
   });
 
@@ -104,6 +180,22 @@ export function createApp() {
   app.use('/api/structures', structureRoutes);
   app.use('/api/library', libraryRouter);
   app.use('/api', quickgenRoutes);
+
+  app.use((err: unknown, req: Request, res: Response, next: NextFunction) => {
+    if (req.path.startsWith('/api')) {
+      if (typeof err === 'object' && err !== null && 'type' in err && err.type === 'entity.too.large') {
+        res.status(413).json({ error: `File upload exceeds limit of ${CONFIG.fileUploadMaxBytes} bytes` });
+        return;
+      }
+
+      if (err instanceof SyntaxError && 'body' in err) {
+        res.status(400).json({ error: 'Invalid JSON body' });
+        return;
+      }
+    }
+
+    next(err);
+  });
 
   // Static file serving (frontend dist)
   const frontendDist = resolve(__dirname, '../../frontend/dist');

--- a/apps/gateway/src/auth/routes.ts
+++ b/apps/gateway/src/auth/routes.ts
@@ -33,6 +33,17 @@ interface UserRow {
   created_at?: number;
 }
 
+interface FailedAuthAttemptRow {
+  email: string;
+  attempts: number;
+  locked_until: number | null;
+  last_attempt: number;
+}
+
+const AUTH_FAILURE_WINDOW_MS = 15 * 60 * 1000;
+const AUTH_FAILURE_THRESHOLD = 5;
+const BASE_LOCKOUT_MS = 15 * 60 * 1000;
+
 function formatUser(row: Pick<UserRow, 'id' | 'email' | 'display_name' | 'settings'> & { created_at?: number }) {
   return {
     id: row.id,
@@ -41,6 +52,73 @@ function formatUser(row: Pick<UserRow, 'id' | 'email' | 'display_name' | 'settin
     settings: JSON.parse(row.settings),
     createdAt: row.created_at,
   };
+}
+
+function getFailedAuthAttempt(email: string): FailedAuthAttemptRow | undefined {
+  return getDb().prepare(`
+    SELECT email, attempts, locked_until, last_attempt
+    FROM failed_auth_attempts
+    WHERE email = ?
+  `).get(email) as FailedAuthAttemptRow | undefined;
+}
+
+function clearFailedAuthAttempts(email: string): void {
+  getDb().prepare('DELETE FROM failed_auth_attempts WHERE email = ?').run(email);
+}
+
+function getLockoutDurationMs(attempts: number): number {
+  const cycle = Math.max(1, Math.floor(attempts / AUTH_FAILURE_THRESHOLD));
+  return BASE_LOCKOUT_MS * (2 ** (cycle - 1));
+}
+
+function getLockoutMessage(lockedUntil: number): string {
+  const remainingMinutes = Math.max(1, Math.ceil((lockedUntil - Date.now()) / 60_000));
+  return `Account temporarily locked. Try again in ${remainingMinutes} minute${remainingMinutes === 1 ? '' : 's'}.`;
+}
+
+function recordFailedLogin(email: string): { lockedUntil: number | null } {
+  const db = getDb();
+  const now = Date.now();
+  const existing = getFailedAuthAttempt(email);
+
+  const shouldContinueFailureCycle = Boolean(
+    existing && (
+      existing.attempts >= AUTH_FAILURE_THRESHOLD
+      || now - existing.last_attempt <= AUTH_FAILURE_WINDOW_MS
+    )
+  );
+
+  const attempts = shouldContinueFailureCycle
+    ? (existing?.attempts ?? 0) + 1
+    : 1;
+
+  const lockedUntil = attempts % AUTH_FAILURE_THRESHOLD === 0
+    ? now + getLockoutDurationMs(attempts)
+    : null;
+
+  db.prepare(`
+    INSERT INTO failed_auth_attempts (email, attempts, locked_until, last_attempt)
+    VALUES (?, ?, ?, ?)
+    ON CONFLICT(email) DO UPDATE SET
+      attempts = excluded.attempts,
+      locked_until = excluded.locked_until,
+      last_attempt = excluded.last_attempt
+  `).run(email, attempts, lockedUntil, now);
+
+  return { lockedUntil };
+}
+
+function getActiveLockout(email: string): FailedAuthAttemptRow | null {
+  const attempt = getFailedAuthAttempt(email);
+  if (!attempt?.locked_until) {
+    return null;
+  }
+
+  if (attempt.locked_until <= Date.now()) {
+    return null;
+  }
+
+  return attempt;
 }
 
 // POST /api/auth/register
@@ -100,6 +178,12 @@ router.post('/login', async (req: Request<{}, {}, LoginBody>, res: Response) => 
     return;
   }
 
+  const activeLockout = getActiveLockout(email);
+  if (activeLockout?.locked_until) {
+    res.status(429).json({ error: getLockoutMessage(activeLockout.locked_until) });
+    return;
+  }
+
   const db = getDb();
   const row = db.prepare(`
     SELECT id, email, password_hash, display_name, settings
@@ -107,15 +191,29 @@ router.post('/login', async (req: Request<{}, {}, LoginBody>, res: Response) => 
   `).get(email) as UserRow | undefined;
 
   if (!row) {
+    const failure = recordFailedLogin(email);
+    if (failure.lockedUntil) {
+      res.status(429).json({ error: getLockoutMessage(failure.lockedUntil) });
+      return;
+    }
+
     res.status(401).json({ error: 'Invalid email or password' });
     return;
   }
 
   const valid = await verifyPassword(password, row.password_hash);
   if (!valid) {
+    const failure = recordFailedLogin(email);
+    if (failure.lockedUntil) {
+      res.status(429).json({ error: getLockoutMessage(failure.lockedUntil) });
+      return;
+    }
+
     res.status(401).json({ error: 'Invalid email or password' });
     return;
   }
+
+  clearFailedAuthAttempts(email);
 
   const token = generateToken({ id: row.id, email: row.email });
   setSessionCookie(res, token);

--- a/apps/gateway/src/files/routes.ts
+++ b/apps/gateway/src/files/routes.ts
@@ -27,6 +27,19 @@ import { verifyToken, AuthRequest } from '../auth/middleware.js';
 const router = Router();
 const SEARCH_LIMIT = 50;
 const SEARCH_MAX_DEPTH = 2;
+const ALLOWED_UPLOAD_CONTENT_TYPES = new Set([
+  'application/json',
+  'application/octet-stream',
+  'application/pdf',
+  'application/xml',
+  'application/yaml',
+  'application/x-yaml',
+  'text/csv',
+  'text/html',
+  'text/markdown',
+  'text/plain',
+  'text/xml',
+]);
 
 router.use(verifyToken);
 
@@ -266,6 +279,17 @@ function invalidPathResponse(res: Response): void {
   res.status(400).json({ error: 'Invalid path' });
 }
 
+function isAllowedUploadContentType(contentType: string): boolean {
+  const normalized = contentType.split(';')[0]?.trim().toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+
+  return normalized.startsWith('text/')
+    || normalized.startsWith('image/')
+    || ALLOWED_UPLOAD_CONTENT_TYPES.has(normalized);
+}
+
 // --- Route 1: GET / -- List workspace files as a tree ------------------------
 
 router.get('/', async (req: AuthRequest, res: Response) => {
@@ -297,10 +321,15 @@ router.post('/upload', async (req: AuthRequest, res: Response) => {
     return;
   }
 
-  const { filename, content } = req.body as { filename?: string; content?: string };
+  const { filename, content, contentType } = req.body as { filename?: string; content?: string; contentType?: string };
 
-  if (!filename || !content) {
-    res.status(400).json({ error: 'filename and content are required' });
+  if (!filename || !content || !contentType) {
+    res.status(400).json({ error: 'filename, content, and contentType are required' });
+    return;
+  }
+
+  if (!isAllowedUploadContentType(contentType)) {
+    res.status(400).json({ error: `Unsupported content type: ${contentType}` });
     return;
   }
 
@@ -314,7 +343,13 @@ router.post('/upload', async (req: AuthRequest, res: Response) => {
     const fileBuffer = Buffer.from(content, 'base64');
     await writeUserFile(req.user.id, safeName, fileBuffer);
 
-    res.status(201).json({ ok: true, name: safeName.split('/').pop() ?? safeName, path: safeName, size: fileBuffer.length });
+    res.status(201).json({
+      ok: true,
+      name: safeName.split('/').pop() ?? safeName,
+      path: safeName,
+      size: fileBuffer.length,
+      contentType: contentType.split(';')[0]?.trim().toLowerCase(),
+    });
   } catch (err) {
     if (err instanceof Error && err.message === 'Invalid path') {
       invalidPathResponse(res);

--- a/apps/gateway/src/settings/routes.ts
+++ b/apps/gateway/src/settings/routes.ts
@@ -1,7 +1,7 @@
 import { Router, Response } from 'express';
 import { getDb } from '@goldilocks/data';
 import { verifyToken, AuthRequest } from '../auth/middleware.js';
-import { encrypt, decrypt } from '@goldilocks/config';
+import { encrypt } from '@goldilocks/config';
 import { getProviders, getModels } from '@mariozechner/pi-ai';
 
 const router = Router();
@@ -75,6 +75,152 @@ const GROUP_LABELS: Record<string, string> = {
   regional: 'Regional',
 };
 
+const ALLOWED_SETTING_KEYS = new Set(['defaultModel', 'defaultFunctional', 'workspaceViewer']);
+const ALLOWED_WORKSPACE_VIEWER_KEYS = new Set([
+  'monacoExtensions',
+  'imageViewerExtensions',
+  'imageBackground',
+  'imageFitMode',
+  'pdfDefaultZoom',
+  'monacoFontSize',
+  'monacoTabSize',
+  'monacoWordWrap',
+  'monacoLineNumbers',
+  'monacoMinimap',
+]);
+
+function normalizeExtension(value: string): string {
+  return value.trim().toLowerCase().replace(/^\./, '');
+}
+
+function normalizeExtensions(values: unknown): string[] {
+  if (!Array.isArray(values) || values.some((value) => typeof value !== 'string')) {
+    throw new Error('workspaceViewer extension lists must be string arrays');
+  }
+
+  return Array.from(new Set(values.map(normalizeExtension).filter(Boolean)));
+}
+
+function parseSettings(raw: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function validateWorkspaceViewerPatch(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('workspaceViewer must be an object');
+  }
+
+  const patch = value as Record<string, unknown>;
+  const normalized: Record<string, unknown> = {};
+
+  for (const key of Object.keys(patch)) {
+    if (!ALLOWED_WORKSPACE_VIEWER_KEYS.has(key)) {
+      throw new Error(`Unknown workspaceViewer setting: ${key}`);
+    }
+  }
+
+  if ('monacoExtensions' in patch) {
+    normalized.monacoExtensions = normalizeExtensions(patch.monacoExtensions);
+  }
+
+  if ('imageViewerExtensions' in patch) {
+    normalized.imageViewerExtensions = normalizeExtensions(patch.imageViewerExtensions);
+  }
+
+  if ('imageBackground' in patch) {
+    if (!['checkered', 'dark', 'light'].includes(String(patch.imageBackground))) {
+      throw new Error('workspaceViewer.imageBackground must be checkered, dark, or light');
+    }
+    normalized.imageBackground = patch.imageBackground;
+  }
+
+  if ('imageFitMode' in patch) {
+    if (!['contain', 'actual'].includes(String(patch.imageFitMode))) {
+      throw new Error('workspaceViewer.imageFitMode must be contain or actual');
+    }
+    normalized.imageFitMode = patch.imageFitMode;
+  }
+
+  if ('pdfDefaultZoom' in patch) {
+    if (![50, 75, 100, 125, 150, 200].includes(Number(patch.pdfDefaultZoom))) {
+      throw new Error('workspaceViewer.pdfDefaultZoom must be one of 50, 75, 100, 125, 150, or 200');
+    }
+    normalized.pdfDefaultZoom = Number(patch.pdfDefaultZoom);
+  }
+
+  if ('monacoFontSize' in patch) {
+    const value = Number(patch.monacoFontSize);
+    if (!Number.isFinite(value)) {
+      throw new Error('workspaceViewer.monacoFontSize must be a number');
+    }
+    normalized.monacoFontSize = Math.min(24, Math.max(10, Math.round(value)));
+  }
+
+  if ('monacoTabSize' in patch) {
+    if (![2, 4, 8].includes(Number(patch.monacoTabSize))) {
+      throw new Error('workspaceViewer.monacoTabSize must be 2, 4, or 8');
+    }
+    normalized.monacoTabSize = Number(patch.monacoTabSize);
+  }
+
+  for (const booleanKey of ['monacoWordWrap', 'monacoLineNumbers', 'monacoMinimap'] as const) {
+    if (booleanKey in patch) {
+      if (typeof patch[booleanKey] !== 'boolean') {
+        throw new Error(`workspaceViewer.${booleanKey} must be a boolean`);
+      }
+      normalized[booleanKey] = patch[booleanKey];
+    }
+  }
+
+  return normalized;
+}
+
+function validateSettingsPatch(updates: unknown, current: Record<string, unknown>): Record<string, unknown> {
+  if (!updates || typeof updates !== 'object' || Array.isArray(updates)) {
+    throw new Error('Request body must be a JSON object');
+  }
+
+  const patch = updates as Record<string, unknown>;
+  const normalized: Record<string, unknown> = {};
+
+  for (const key of Object.keys(patch)) {
+    if (!ALLOWED_SETTING_KEYS.has(key)) {
+      throw new Error(`Unknown setting: ${key}`);
+    }
+  }
+
+  if ('defaultModel' in patch) {
+    if (patch.defaultModel !== null && typeof patch.defaultModel !== 'string') {
+      throw new Error('defaultModel must be a string or null');
+    }
+    normalized.defaultModel = patch.defaultModel;
+  }
+
+  if ('defaultFunctional' in patch) {
+    if (patch.defaultFunctional !== 'PBE' && patch.defaultFunctional !== 'PBEsol') {
+      throw new Error('defaultFunctional must be PBE or PBEsol');
+    }
+    normalized.defaultFunctional = patch.defaultFunctional;
+  }
+
+  if ('workspaceViewer' in patch) {
+    const currentViewer = current.workspaceViewer && typeof current.workspaceViewer === 'object' && !Array.isArray(current.workspaceViewer)
+      ? current.workspaceViewer as Record<string, unknown>
+      : {};
+    normalized.workspaceViewer = {
+      ...currentViewer,
+      ...validateWorkspaceViewerPatch(patch.workspaceViewer),
+    };
+  }
+
+  return normalized;
+}
+
 // GET /api/settings/providers - Returns all built-in Pi providers with metadata
 router.get('/providers', (_req: AuthRequest, res: Response) => {
   const providers = getProviders()
@@ -109,19 +255,13 @@ router.get('/', (req: AuthRequest, res: Response) => {
     return;
   }
 
-  res.json({ settings: JSON.parse(row.settings) });
+  res.json({ settings: parseSettings(row.settings) });
 });
 
 // PATCH /api/settings - Update user settings (merge with existing)
 router.patch('/', (req: AuthRequest, res: Response) => {
   if (!req.user) {
     res.status(401).json({ error: 'Unauthorized' });
-    return;
-  }
-
-  const updates = req.body;
-  if (!updates || typeof updates !== 'object' || Array.isArray(updates)) {
-    res.status(400).json({ error: 'Request body must be a JSON object' });
     return;
   }
 
@@ -135,15 +275,24 @@ router.patch('/', (req: AuthRequest, res: Response) => {
     return;
   }
 
-  const current = JSON.parse(row.settings);
-  const merged = { ...current, ...updates };
+  const current = parseSettings(row.settings);
 
-  db.prepare('UPDATE users SET settings = ? WHERE id = ?').run(
-    JSON.stringify(merged),
-    req.user.id,
-  );
+  try {
+    const normalizedPatch = validateSettingsPatch(req.body, current);
+    const merged = {
+      ...current,
+      ...normalizedPatch,
+    };
 
-  res.json({ settings: merged });
+    db.prepare('UPDATE users SET settings = ? WHERE id = ?').run(
+      JSON.stringify(merged),
+      req.user.id,
+    );
+
+    res.json({ settings: merged });
+  } catch (err) {
+    res.status(400).json({ error: err instanceof Error ? err.message : 'Invalid settings payload' });
+  }
 });
 
 // GET /api/settings/api-keys - List API key metadata (NOT the actual keys)

--- a/apps/gateway/test/api/auth.test.ts
+++ b/apps/gateway/test/api/auth.test.ts
@@ -1,195 +1,410 @@
 import jwt from 'jsonwebtoken';
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect } from 'vitest';
+import { getDb } from '@goldilocks/data';
 import { CONFIG } from '@goldilocks/config';
-import { createTestServer, type TestUser } from './helpers/test-server.js';
+import { createTestServer } from './helpers/test-server.js';
 
-describe('Auth', () => {
-  let server: Awaited<ReturnType<typeof createTestServer>>;
-  let user: TestUser;
+async function createSessionFixture(overrides?: Partial<{ email: string; password: string; displayName: string }>) {
+  const server = await createTestServer();
+  const user = await server.registerUser(overrides);
+  return { server, user };
+}
 
-  beforeAll(async () => {
-    server = await createTestServer();
-    user = await server.registerUser();
-  });
-
-  afterAll(async () => {
-    await server.stop();
-  });
-
-  // ── Register ───────────────────────────────────────────────────────────────
-
+describe('Auth registration', () => {
   it('registers a new user and sets a session cookie', async () => {
-    const email = `new-${Date.now()}@example.com`;
-    const res = await fetch(`${server.baseUrl}/api/auth/register`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email, password: 'Password123!', displayName: 'New User' }),
-    });
+    const server = await createTestServer();
 
-    expect(res.status).toBe(201);
-    const json = await res.json() as { user: { id: string; email: string } };
-    const setCookie = res.headers.get('set-cookie') ?? '';
+    try {
+      const email = `new-${Date.now()}@example.com`;
+      const res = await fetch(`${server.baseUrl}/api/auth/register`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password: 'Password123!', displayName: 'New User' }),
+      });
 
-    expect(setCookie).toContain(`${CONFIG.sessionCookieName}=`);
-    expect(setCookie).toContain('HttpOnly');
-    expect(setCookie).toContain('SameSite=Strict');
-    expect(json.user.email).toBe(email);
-  });
+      expect(res.status).toBe(201);
+      const json = await res.json() as { user: { id: string; email: string } };
+      const setCookie = res.headers.get('set-cookie') ?? '';
 
-  it('issues JWT claims with iss, aud, and jti', async () => {
-    const claims = jwt.verify(user.token, CONFIG.jwtSecret, {
-      issuer: CONFIG.jwtIssuer,
-      audience: CONFIG.jwtAudience,
-    }) as jwt.JwtPayload & { id: string; email: string; jti: string };
-
-    expect(claims.id).toBe(user.userId);
-    expect(claims.email).toBe(user.email);
-    expect(typeof claims.jti).toBe('string');
-    expect(claims.jti.length).toBeGreaterThan(10);
-  });
+      expect(setCookie).toContain(`${CONFIG.sessionCookieName}=`);
+      expect(setCookie).toContain('HttpOnly');
+      expect(setCookie).toContain('SameSite=Strict');
+      expect(json.user.email).toBe(email);
+    } finally {
+      await server.stop();
+    }
+  }, 15000);
 
   it('rejects duplicate email', async () => {
-    const res = await fetch(`${server.baseUrl}/api/auth/register`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email: user.email, password: 'Password123!', displayName: 'Duplicate' }),
-    });
+    const server = await createTestServer();
 
-    expect(res.status).toBe(409);
+    try {
+      const user = await server.registerUser();
+      const res = await fetch(`${server.baseUrl}/api/auth/register`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: user.email, password: 'Password123!', displayName: 'Duplicate' }),
+      });
+
+      expect(res.status).toBe(409);
+    } finally {
+      await server.stop();
+    }
   });
 
   it('rejects registration with missing fields', async () => {
-    const res = await fetch(`${server.baseUrl}/api/auth/register`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email: 'no-password@example.com' }),
-    });
+    const server = await createTestServer();
 
-    expect(res.status).toBe(400);
+    try {
+      const res = await fetch(`${server.baseUrl}/api/auth/register`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: 'no-password@example.com' }),
+      });
+
+      expect(res.status).toBe(400);
+    } finally {
+      await server.stop();
+    }
   });
 
-  // ── Login ─────────────────────────────────────────────────────────────────
+  it('rate limits registrations to three per hour per IP', async () => {
+    const server = await createTestServer();
+
+    try {
+      for (let i = 0; i < 3; i++) {
+        const res = await fetch(`${server.baseUrl}/api/auth/register`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            email: `rate-limit-${i}-${Date.now()}@example.com`,
+            password: 'Password123!',
+            displayName: 'Rate Limited',
+          }),
+        });
+
+        expect(res.status).toBe(201);
+      }
+
+      const blocked = await fetch(`${server.baseUrl}/api/auth/register`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email: `rate-limit-blocked-${Date.now()}@example.com`,
+          password: 'Password123!',
+          displayName: 'Blocked',
+        }),
+      });
+
+      expect(blocked.status).toBe(429);
+      const json = await blocked.json() as { error: string };
+      expect(json.error).toMatch(/registration/i);
+    } finally {
+      await server.stop();
+    }
+  });
+});
+
+describe('Auth session and lockout flow', () => {
+  it('issues JWT claims with iss, aud, and jti', async () => {
+    const { server, user } = await createSessionFixture();
+
+    try {
+      const claims = jwt.verify(user.token, CONFIG.jwtSecret, {
+        issuer: CONFIG.jwtIssuer,
+        audience: CONFIG.jwtAudience,
+      }) as jwt.JwtPayload & { id: string; email: string; jti: string };
+
+      expect(claims.id).toBe(user.userId);
+      expect(claims.email).toBe(user.email);
+      expect(typeof claims.jti).toBe('string');
+      expect(claims.jti.length).toBeGreaterThan(10);
+    } finally {
+      await server.stop();
+    }
+  });
 
   it('logs in with valid credentials and sets a session cookie', async () => {
-    const res = await fetch(`${server.baseUrl}/api/auth/login`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email: user.email, password: 'TestPassword123!' }),
-    });
+    const { server, user } = await createSessionFixture();
 
-    expect(res.status).toBe(200);
-    const json = await res.json() as { user: { id: string; email: string } };
-    const setCookie = res.headers.get('set-cookie') ?? '';
+    try {
+      const res = await fetch(`${server.baseUrl}/api/auth/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: user.email, password: 'TestPassword123!' }),
+      });
 
-    expect(setCookie).toContain(`${CONFIG.sessionCookieName}=`);
-    expect(json.user.id).toBe(user.userId);
+      expect(res.status).toBe(200);
+      const json = await res.json() as { user: { id: string; email: string } };
+      const setCookie = res.headers.get('set-cookie') ?? '';
+
+      expect(setCookie).toContain(`${CONFIG.sessionCookieName}=`);
+      expect(json.user.id).toBe(user.userId);
+    } finally {
+      await server.stop();
+    }
+  }, 10000);
+
+  it('clears failed auth attempts after a successful login', async () => {
+    const { server, user } = await createSessionFixture();
+
+    try {
+      await fetch(`${server.baseUrl}/api/auth/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: user.email, password: 'WrongPassword!' }),
+      });
+
+      const beforeSuccess = getDb().prepare('SELECT attempts FROM failed_auth_attempts WHERE email = ?').get(user.email) as { attempts: number } | undefined;
+      expect(beforeSuccess?.attempts).toBe(1);
+
+      const success = await fetch(`${server.baseUrl}/api/auth/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: user.email, password: 'TestPassword123!' }),
+      });
+
+      expect(success.status).toBe(200);
+
+      const afterSuccess = getDb().prepare('SELECT attempts FROM failed_auth_attempts WHERE email = ?').get(user.email);
+      expect(afterSuccess).toBeUndefined();
+    } finally {
+      await server.stop();
+    }
+  }, 10000);
+
+  it('locks an account after five failed attempts and rejects further attempts immediately', async () => {
+    const { server } = await createSessionFixture();
+    const email = `lockout-${Date.now()}@example.com`;
+    await server.registerUser({ email, password: 'Lockout123!' });
+
+    try {
+      for (let i = 1; i <= 4; i++) {
+        const res = await fetch(`${server.baseUrl}/api/auth/login`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email, password: 'wrong-password' }),
+        });
+
+        expect(res.status).toBe(401);
+      }
+
+      const locked = await fetch(`${server.baseUrl}/api/auth/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password: 'wrong-password' }),
+      });
+
+      expect(locked.status).toBe(429);
+      const lockedJson = await locked.json() as { error: string };
+      expect(lockedJson.error).toMatch(/temporarily locked/i);
+
+      const lockedAgain = await fetch(`${server.baseUrl}/api/auth/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password: 'Lockout123!' }),
+      });
+
+      expect(lockedAgain.status).toBe(429);
+    } finally {
+      await server.stop();
+    }
+  }, 10000);
+
+  it('doubles the lockout duration on the next failure cycle', async () => {
+    const { server } = await createSessionFixture();
+    const email = `backoff-${Date.now()}@example.com`;
+    await server.registerUser({ email, password: 'Backoff123!' });
+
+    try {
+      for (let i = 0; i < 5; i++) {
+        await fetch(`${server.baseUrl}/api/auth/login`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email, password: 'wrong-password' }),
+        });
+      }
+
+      const firstCycle = getDb().prepare(
+        'SELECT attempts, locked_until FROM failed_auth_attempts WHERE email = ?'
+      ).get(email) as { attempts: number; locked_until: number };
+
+      getDb().prepare(
+        'UPDATE failed_auth_attempts SET locked_until = ?, last_attempt = ? WHERE email = ?'
+      ).run(Date.now() - 1, Date.now(), email);
+
+      for (let i = 0; i < 5; i++) {
+        await fetch(`${server.baseUrl}/api/auth/login`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email, password: 'still-wrong' }),
+        });
+      }
+
+      const secondCycle = getDb().prepare(
+        'SELECT attempts, locked_until FROM failed_auth_attempts WHERE email = ?'
+      ).get(email) as { attempts: number; locked_until: number };
+
+      expect(firstCycle.attempts).toBe(5);
+      expect(secondCycle.attempts).toBe(10);
+
+      const firstDuration = firstCycle.locked_until - Date.now();
+      const secondDuration = secondCycle.locked_until - Date.now();
+      expect(secondDuration).toBeGreaterThan(firstDuration + (10 * 60 * 1000));
+    } finally {
+      await server.stop();
+    }
+  }, 15000);
+
+  it('rejects unknown email until lockout triggers', async () => {
+    const { server } = await createSessionFixture();
+
+    try {
+      for (let i = 0; i < 4; i++) {
+        const res = await fetch(`${server.baseUrl}/api/auth/login`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email: 'nobody@example.com', password: 'Anything!' }),
+        });
+
+        expect(res.status).toBe(401);
+      }
+
+      const locked = await fetch(`${server.baseUrl}/api/auth/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: 'nobody@example.com', password: 'Anything!' }),
+      });
+
+      expect(locked.status).toBe(429);
+    } finally {
+      await server.stop();
+    }
   });
-
-  it('rejects invalid password', async () => {
-    const res = await fetch(`${server.baseUrl}/api/auth/login`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email: user.email, password: 'WrongPassword!' }),
-    });
-
-    expect(res.status).toBe(401);
-    const json = await res.json() as { error: string };
-    expect(json.error.toLowerCase()).toMatch(/password|credential/i);
-  });
-
-  it('rejects unknown email', async () => {
-    const res = await fetch(`${server.baseUrl}/api/auth/login`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email: 'nobody@example.com', password: 'Anything!' }),
-    });
-
-    expect(res.status).toBe(401);
-  });
-
-  // ── GET /me ───────────────────────────────────────────────────────────────
 
   it('returns the current user profile via the session cookie', async () => {
-    const res = await fetch(`${server.baseUrl}/api/auth/me`, {
-      headers: { cookie: server.cookieHeader(user) },
-    });
+    const { server, user } = await createSessionFixture();
 
-    expect(res.status).toBe(200);
-    const json = await res.json() as { user: { id: string; email: string; displayName: string } };
-    expect(json.user.id).toBe(user.userId);
-    expect(json.user.email).toBe(user.email);
-    expect(json.user.displayName).toBe('Test User');
+    try {
+      const res = await fetch(`${server.baseUrl}/api/auth/me`, {
+        headers: { cookie: server.cookieHeader(user) },
+      });
+
+      expect(res.status).toBe(200);
+      const json = await res.json() as { user: { id: string; email: string; displayName: string } };
+      expect(json.user.id).toBe(user.userId);
+      expect(json.user.email).toBe(user.email);
+      expect(json.user.displayName).toBe('Test User');
+    } finally {
+      await server.stop();
+    }
   });
 
   it('still accepts a bearer token during migration fallback', async () => {
-    const res = await fetch(`${server.baseUrl}/api/auth/me`, {
-      headers: { authorization: server.authHeader(user) },
-    });
+    const { server, user } = await createSessionFixture();
 
-    expect(res.status).toBe(200);
-    const json = await res.json() as { user: { id: string } };
-    expect(json.user.id).toBe(user.userId);
+    try {
+      const res = await fetch(`${server.baseUrl}/api/auth/me`, {
+        headers: { authorization: server.authHeader(user) },
+      });
+
+      expect(res.status).toBe(200);
+      const json = await res.json() as { user: { id: string } };
+      expect(json.user.id).toBe(user.userId);
+    } finally {
+      await server.stop();
+    }
   });
 
   it('rejects requests without a token', async () => {
-    const res = await fetch(`${server.baseUrl}/api/auth/me`);
-    expect(res.status).toBe(401);
+    const { server } = await createSessionFixture();
+
+    try {
+      const res = await fetch(`${server.baseUrl}/api/auth/me`);
+      expect(res.status).toBe(401);
+    } finally {
+      await server.stop();
+    }
   });
 
   it('rejects requests with an invalid token', async () => {
-    const res = await fetch(`${server.baseUrl}/api/auth/me`, {
-      headers: { authorization: 'Bearer not-a-real-token' },
-    });
-    expect(res.status).toBe(401);
+    const { server } = await createSessionFixture();
+
+    try {
+      const res = await fetch(`${server.baseUrl}/api/auth/me`, {
+        headers: { authorization: 'Bearer not-a-real-token' },
+      });
+      expect(res.status).toBe(401);
+    } finally {
+      await server.stop();
+    }
   });
 
   it('rejects requests with a malformed Authorization header', async () => {
-    const res = await fetch(`${server.baseUrl}/api/auth/me`, {
-      headers: { authorization: 'NotBearer token' },
-    });
-    expect(res.status).toBe(401);
+    const { server } = await createSessionFixture();
+
+    try {
+      const res = await fetch(`${server.baseUrl}/api/auth/me`, {
+        headers: { authorization: 'NotBearer token' },
+      });
+      expect(res.status).toBe(401);
+    } finally {
+      await server.stop();
+    }
   });
 
   it('refreshes the cookie without returning the raw token', async () => {
-    const res = await fetch(`${server.baseUrl}/api/auth/refresh`, {
-      method: 'POST',
-      headers: { cookie: server.cookieHeader(user) },
-    });
+    const { server, user } = await createSessionFixture();
 
-    expect(res.status).toBe(200);
-    const json = await res.json() as { ok: boolean; token?: string };
-    expect(json.ok).toBe(true);
-    expect(json).not.toHaveProperty('token');
-    expect(res.headers.get('set-cookie')).toContain(`${CONFIG.sessionCookieName}=`);
+    try {
+      const res = await fetch(`${server.baseUrl}/api/auth/refresh`, {
+        method: 'POST',
+        headers: { cookie: server.cookieHeader(user) },
+      });
+
+      expect(res.status).toBe(200);
+      const json = await res.json() as { ok: boolean; token?: string };
+      expect(json.ok).toBe(true);
+      expect(json).not.toHaveProperty('token');
+      expect(res.headers.get('set-cookie')).toContain(`${CONFIG.sessionCookieName}=`);
+    } finally {
+      await server.stop();
+    }
   });
 
   it('logout revokes the current token and clears the cookie', async () => {
-    const loginRes = await fetch(`${server.baseUrl}/api/auth/login`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email: user.email, password: 'TestPassword123!' }),
-    });
-    const loginCookie = (loginRes.headers.get('set-cookie') ?? '').split(';')[0];
-    const loginToken = decodeURIComponent(loginCookie.split('=').slice(1).join('='));
+    const { server, user } = await createSessionFixture();
 
-    const logoutRes = await fetch(`${server.baseUrl}/api/auth/logout`, {
-      method: 'POST',
-      headers: { cookie: loginCookie },
-    });
+    try {
+      const loginRes = await fetch(`${server.baseUrl}/api/auth/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: user.email, password: 'TestPassword123!' }),
+      });
+      const loginCookie = (loginRes.headers.get('set-cookie') ?? '').split(';')[0];
+      const loginToken = decodeURIComponent(loginCookie.split('=').slice(1).join('='));
 
-    expect(logoutRes.status).toBe(200);
-    const clearedCookie = logoutRes.headers.get('set-cookie') ?? '';
-    expect(clearedCookie).toContain(`${CONFIG.sessionCookieName}=`);
-    expect(clearedCookie.toLowerCase()).toContain('expires=thu, 01 jan 1970');
+      const logoutRes = await fetch(`${server.baseUrl}/api/auth/logout`, {
+        method: 'POST',
+        headers: { cookie: loginCookie },
+      });
 
-    const revokedCookieRes = await fetch(`${server.baseUrl}/api/auth/me`, {
-      headers: { cookie: loginCookie },
-    });
-    expect(revokedCookieRes.status).toBe(401);
+      expect(logoutRes.status).toBe(200);
+      const clearedCookie = logoutRes.headers.get('set-cookie') ?? '';
+      expect(clearedCookie).toContain(`${CONFIG.sessionCookieName}=`);
+      expect(clearedCookie.toLowerCase()).toContain('expires=thu, 01 jan 1970');
 
-    const revokedHeaderRes = await fetch(`${server.baseUrl}/api/auth/me`, {
-      headers: { authorization: `Bearer ${loginToken}` },
-    });
-    expect(revokedHeaderRes.status).toBe(401);
+      const revokedCookieRes = await fetch(`${server.baseUrl}/api/auth/me`, {
+        headers: { cookie: loginCookie },
+      });
+      expect(revokedCookieRes.status).toBe(401);
+
+      const revokedHeaderRes = await fetch(`${server.baseUrl}/api/auth/me`, {
+        headers: { authorization: `Bearer ${loginToken}` },
+      });
+      expect(revokedHeaderRes.status).toBe(401);
+    } finally {
+      await server.stop();
+    }
   });
 });

--- a/apps/gateway/test/api/files.test.ts
+++ b/apps/gateway/test/api/files.test.ts
@@ -200,7 +200,7 @@ describe('Files', () => {
 
     const res = await fetch(`${server.baseUrl}/api/files/upload`, {
       method: 'POST', headers: authHeaders(user),
-      body: JSON.stringify({ filename: 'uploaded.txt', content: b64 }),
+      body: JSON.stringify({ filename: 'uploaded.txt', content: b64, contentType: 'text/plain' }),
     });
 
     expect(res.status).toBe(201);
@@ -216,7 +216,7 @@ describe('Files', () => {
 
     const uploadRes = await fetch(`${server.baseUrl}/api/files/upload`, {
       method: 'POST', headers: authHeaders(user),
-      body: JSON.stringify({ filename, content: Buffer.from(content).toString('base64') }),
+      body: JSON.stringify({ filename, content: Buffer.from(content).toString('base64'), contentType: 'text/plain' }),
     });
     expect(uploadRes.status).toBe(201);
 
@@ -231,7 +231,7 @@ describe('Files', () => {
   it('rejects upload without filename', async () => {
     const res = await fetch(`${server.baseUrl}/api/files/upload`, {
       method: 'POST', headers: authHeaders(user),
-      body: JSON.stringify({ content: Buffer.from('hello').toString('base64') }),
+      body: JSON.stringify({ content: Buffer.from('hello').toString('base64'), contentType: 'text/plain' }),
     });
 
     expect(res.status).toBe(400);
@@ -246,10 +246,60 @@ describe('Files', () => {
     expect(res.status).toBe(400);
   });
 
+  it('rejects upload without contentType', async () => {
+    const res = await fetch(`${server.baseUrl}/api/files/upload`, {
+      method: 'POST', headers: authHeaders(user),
+      body: JSON.stringify({ filename: 'no-type.txt', content: Buffer.from('hello').toString('base64') }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects upload with a disallowed content type', async () => {
+    const res = await fetch(`${server.baseUrl}/api/files/upload`, {
+      method: 'POST', headers: authHeaders(user),
+      body: JSON.stringify({
+        filename: 'malware.exe',
+        content: Buffer.from('definitely-not-safe').toString('base64'),
+        contentType: 'application/x-msdownload',
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    const json = await res.json() as { error: string };
+    expect(json.error).toMatch(/unsupported content type/i);
+  });
+
+  it('rejects oversized file payloads with 413', async () => {
+    const tinyLimitServer = await createTestServer({ env: { FILE_UPLOAD_MAX_BYTES: '64' } });
+    const limitedUser = await tinyLimitServer.registerUser();
+
+    try {
+      const res = await fetch(`${tinyLimitServer.baseUrl}/api/files/upload`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          authorization: tinyLimitServer.authHeader(limitedUser),
+        },
+        body: JSON.stringify({
+          filename: 'too-large.txt',
+          content: Buffer.from('x'.repeat(256)).toString('base64'),
+          contentType: 'text/plain',
+        }),
+      });
+
+      expect(res.status).toBe(413);
+      const json = await res.json() as { error: string };
+      expect(json.error).toMatch(/exceeds limit/i);
+    } finally {
+      await tinyLimitServer.stop();
+    }
+  });
+
   it('rejects hidden filenames', async () => {
     const res = await fetch(`${server.baseUrl}/api/files/upload`, {
       method: 'POST', headers: authHeaders(user),
-      body: JSON.stringify({ filename: '.env', content: Buffer.from('SECRET=123').toString('base64') }),
+      body: JSON.stringify({ filename: '.env', content: Buffer.from('SECRET=123').toString('base64'), contentType: 'text/plain' }),
     });
 
     expect(res.status).toBe(400);
@@ -383,7 +433,7 @@ describe('Files', () => {
     // Upload via the upload route (base64, preserves raw bytes)
     await fetch(`${server.baseUrl}/api/files/upload`, {
       method: 'POST', headers: authHeaders(user),
-      body: JSON.stringify({ filename: path, content: originalBytes.toString('base64') }),
+      body: JSON.stringify({ filename: path, content: originalBytes.toString('base64'), contentType: 'application/octet-stream' }),
     });
 
     const res = await fetch(`${server.baseUrl}/api/files/${path}/raw`, {

--- a/apps/gateway/test/api/helpers/test-server.ts
+++ b/apps/gateway/test/api/helpers/test-server.ts
@@ -40,6 +40,10 @@ export interface TestServer {
   cookieHeader: (user: TestUser) => string;
 }
 
+interface TestServerOptions {
+  env?: Record<string, string | undefined>;
+}
+
 /**
  * Create a stream that emits `data` events with Buffer content, then `end`.
  * If content is null, emits an `error` event instead (simulates command failure
@@ -229,19 +233,30 @@ function parseCommand(command: string[]): {
   return { op: 'unknown' };
 }
 
-async function createTestServer(): Promise<TestServer> {
+async function createTestServer(options: TestServerOptions = {}): Promise<TestServer> {
   const testId = randomUUID().slice(0, 8);
   const dataDir = `/tmp/goldilocks-test-${testId}`;
   const workspaceRoot = `${dataDir}/workspaces`;
   mkdirSync(workspaceRoot, { recursive: true });
 
-  process.env.DATA_DIR = dataDir;
-  process.env.WORKSPACE_ROOT = workspaceRoot;
-  process.env.JWT_SECRET = 'test-jwt-not-for-prod';
-  process.env.ENCRYPTION_KEY = 'test-encryption-key-32bytes!!';
-  process.env.AGENT_SERVICE_SHARED_SECRET = 'test-agent-shared-secret';
-  process.env.NODE_ENV = 'test';
-  process.env.FRONTEND_URL = 'http://localhost:5173';
+  const nextEnv: Record<string, string> = {
+    DATA_DIR: dataDir,
+    WORKSPACE_ROOT: workspaceRoot,
+    JWT_SECRET: 'test-jwt-not-for-prod',
+    ENCRYPTION_KEY: 'test-encryption-key-32bytes!!',
+    AGENT_SERVICE_SHARED_SECRET: 'test-agent-shared-secret',
+    NODE_ENV: 'test',
+    FRONTEND_URL: 'http://localhost:5173',
+    ...Object.fromEntries(
+      Object.entries(options.env ?? {}).filter(([, value]): value is string => value !== undefined)
+    ),
+  };
+
+  const previousEnv = new Map<string, string | undefined>();
+  for (const [key, value] of Object.entries(nextEnv)) {
+    previousEnv.set(key, process.env[key]);
+    process.env[key] = value;
+  }
 
   const { sessionManager } = await import('@goldilocks/runtime');
 
@@ -407,6 +422,13 @@ async function createTestServer(): Promise<TestServer> {
             server.close(async () => {
               const { closeDb } = await import('@goldilocks/data');
               closeDb();
+              for (const [key, value] of previousEnv.entries()) {
+                if (value === undefined) {
+                  delete process.env[key];
+                } else {
+                  process.env[key] = value;
+                }
+              }
               try { rmSync(dataDir, { recursive: true, force: true }); } catch { /* ignore */ }
               res();
             });

--- a/apps/gateway/test/api/settings.test.ts
+++ b/apps/gateway/test/api/settings.test.ts
@@ -85,6 +85,36 @@ describe('Settings', () => {
     expect(json.settings.workspaceViewer.monacoExtensions).toContain('ts');
   });
 
+  it('rejects unknown settings keys', async () => {
+    const res = await fetch(`${server.baseUrl}/api/settings`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        authorization: server.authHeader(user),
+      },
+      body: JSON.stringify({ isAdmin: true }),
+    });
+
+    expect(res.status).toBe(400);
+    const json = await res.json() as { error: string };
+    expect(json.error).toContain('Unknown setting: isAdmin');
+  });
+
+  it('rejects invalid workspaceViewer payloads', async () => {
+    const res = await fetch(`${server.baseUrl}/api/settings`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        authorization: server.authHeader(user),
+      },
+      body: JSON.stringify({ workspaceViewer: { monacoTabSize: 3 } }),
+    });
+
+    expect(res.status).toBe(400);
+    const json = await res.json() as { error: string };
+    expect(json.error).toMatch(/monacoTabSize/i);
+  });
+
   it('rejects unauthenticated PATCH', async () => {
     const res = await fetch(`${server.baseUrl}/api/settings`, {
       method: 'PATCH',

--- a/apps/gateway/test/app-security.test.ts
+++ b/apps/gateway/test/app-security.test.ts
@@ -1,0 +1,70 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { buildReadinessFailureResponse, getRateLimitKey } from '../src/app.js';
+import { createTestServer, type TestUser } from './api/helpers/test-server.js';
+
+describe('Gateway security middleware', () => {
+  let server: Awaited<ReturnType<typeof createTestServer>>;
+  let user: TestUser;
+
+  beforeAll(async () => {
+    server = await createTestServer();
+    user = await server.registerUser();
+  });
+
+  afterAll(async () => {
+    await server.stop();
+  });
+
+  it('keys rate limits by authenticated user id when a valid token is present', () => {
+    expect(getRateLimitKey({
+      ip: '127.0.0.1',
+      headers: { authorization: server.authHeader(user) },
+    } as never)).toBe(user.userId);
+
+    expect(getRateLimitKey({
+      ip: '127.0.0.1',
+      headers: { cookie: server.cookieHeader(user) },
+      cookies: { 'goldilocks-session': user.token },
+    } as never)).toBe(user.userId);
+  });
+
+  it('falls back to IP bucketing when the token is invalid', () => {
+    const unauthenticatedKey = getRateLimitKey({
+      ip: '127.0.0.1',
+      headers: {},
+    } as never);
+
+    const invalidTokenKey = getRateLimitKey({
+      ip: '127.0.0.1',
+      headers: { authorization: 'Bearer definitely-not-valid' },
+    } as never);
+
+    expect(invalidTokenKey).toBe(unauthenticatedKey);
+    expect(invalidTokenKey).not.toBe(user.userId);
+  });
+
+  it('sanitizes readiness failures', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    try {
+      const response = buildReadinessFailureResponse(new Error('sqlite exploded in a dramatic fashion'));
+      expect(response).toEqual({
+        status: 'degraded',
+        error: 'Service unavailable',
+      });
+      expect(errorSpy).toHaveBeenCalled();
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it('sets helmet security headers on API responses', async () => {
+    const res = await fetch(`${server.baseUrl}/api/health`);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('x-content-type-options')).toBe('nosniff');
+    expect(res.headers.get('x-frame-options')).toBe('SAMEORIGIN');
+    expect(res.headers.get('content-security-policy')).toContain("default-src 'self'");
+    expect(res.headers.get('referrer-policy')).toBeTruthy();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -110,6 +110,7 @@
         "cors": "^2.8.5",
         "express": "^5.1.0",
         "express-rate-limit": "^8.3.2",
+        "helmet": "^8.1.0",
         "jsonwebtoken": "^9.0.2",
         "uuid": "^11.1.0",
         "ws": "^8.18.2"
@@ -8668,6 +8669,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/highlight.js": {

--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -6,6 +6,7 @@ config();
 const defaultStateDir = resolve(process.cwd(), '.dev');
 const dataDir = process.env.DATA_DIR ?? (process.env.GOLDILOCKS_STATE_DIR ? resolve(process.env.GOLDILOCKS_STATE_DIR) : defaultStateDir);
 const sessionCookieMaxAgeMs = parseInt(process.env.SESSION_COOKIE_MAX_AGE_MS ?? '28800000', 10);
+const defaultFileUploadMaxBytes = 50 * 1024 * 1024;
 
 function requireEnv(name: 'JWT_SECRET' | 'ENCRYPTION_KEY' | 'AGENT_SERVICE_SHARED_SECRET'): string {
   const value = process.env[name]?.trim();
@@ -38,6 +39,15 @@ export const CONFIG = {
 
   get frontendUrl(): string {
     return process.env.FRONTEND_URL ?? (this.isProd ? `http://localhost:${this.port}` : 'http://localhost:5173');
+  },
+
+  get fileUploadMaxBytes(): number {
+    const parsed = parseInt(process.env.FILE_UPLOAD_MAX_BYTES ?? `${defaultFileUploadMaxBytes}`, 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : defaultFileUploadMaxBytes;
+  },
+
+  get fileUploadBodyLimit(): string {
+    return `${this.fileUploadMaxBytes}b`;
   },
 
   get allowedWebSocketOrigins(): string[] {

--- a/packages/config/test/config.test.ts
+++ b/packages/config/test/config.test.ts
@@ -80,4 +80,16 @@ describe('CONFIG auth defaults', () => {
     expect(CONFIG.allowedWebSocketOrigins).toContain('https://goldilocks.example');
     expect(CONFIG.allowedWebSocketOrigins).toContain('http://localhost:5173');
   });
+
+  it('exposes configurable file upload limits', async () => {
+    process.env.NODE_ENV = 'test';
+    process.env.FILE_UPLOAD_MAX_BYTES = '1234';
+    process.env.JWT_SECRET = 'test-jwt-not-for-prod';
+    process.env.ENCRYPTION_KEY = 'test-encryption-key-32bytes!!';
+    process.env.AGENT_SERVICE_SHARED_SECRET = 'test-agent-shared-secret';
+
+    const { CONFIG } = await loadConfig();
+    expect(CONFIG.fileUploadMaxBytes).toBe(1234);
+    expect(CONFIG.fileUploadBodyLimit).toBe('1234b');
+  });
 });

--- a/packages/data/src/migrations/004_failed_auth_attempts.sql
+++ b/packages/data/src/migrations/004_failed_auth_attempts.sql
@@ -1,0 +1,11 @@
+-- Wave 3 auth hardening: account lockout tracking
+
+CREATE TABLE IF NOT EXISTS failed_auth_attempts (
+  email TEXT PRIMARY KEY,
+  attempts INTEGER NOT NULL DEFAULT 0,
+  locked_until INTEGER,
+  last_attempt INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_failed_auth_attempts_locked_until
+ON failed_auth_attempts (locked_until);


### PR DESCRIPTION
## Summary
- add Wave 3 account lockout and per-user/IP rate limiting on the gateway auth/API surface
- harden the API with helmet headers, sanitized readiness failures, settings PATCH validation, and file upload limits/content-type checks
- expand the integration harness so the new auth, settings, file, and security middleware behavior is covered in regression tests

## What changed
- added `failed_auth_attempts` tracking with progressive lockouts, login reset-on-success, and a new migration
- keyed general/auth rate limits by authenticated user ID when possible, with a stricter registration limiter per IP
- added helmet with dev-safe CSP, generic `/api/ready` failures, and JSON 413/invalid-body handling for API routes
- locked `/api/settings` PATCH to an explicit allowlist with nested `workspaceViewer` validation
- enforced configurable file upload body/content-type limits and sent upload content types from the frontend
- made the test server support env overrides/restoration so limit-sensitive tests stay isolated

## Verification
- `npm run build:packages`
- `npx vitest run packages/config/test/config.test.ts apps/gateway/test/app-security.test.ts apps/gateway/test/api/auth.test.ts apps/gateway/test/api/files.test.ts apps/gateway/test/api/settings.test.ts`
- `npx vitest run`
- `npm run build`

## Roadmap
Implements Wave 3 of `scratchpad/plans/2026-04-14-security-hardening`:
- P5: Rate limiting and auth lockout
- P6: Input validation and security headers

Stacked on Wave 2 / PR #18.
