### PR TITLE
Wave 4: Infrastructure hardening — admin roles, key rotation, audit trail

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -1,0 +1,28 @@
+# Copy this file to .env.dev and fill in real values before starting Goldilocks.
+# Example secret generation:
+#   openssl rand -hex 32
+#   python3 - <<'PY'
+#   import secrets
+#   print(secrets.token_hex(32))
+#   PY
+
+# Server
+PORT=3000
+NODE_ENV=development
+CORS_ORIGIN=http://localhost:5173
+
+# State
+DATA_DIR=.dev
+WORKSPACE_ROOT=.dev/workspaces
+
+# Required secrets
+JWT_SECRET=replace-with-a-random-secret
+ENCRYPTION_KEY=replace-with-a-random-secret
+AGENT_SERVICE_SHARED_SECRET=replace-with-a-random-secret
+
+# Runtime / k8s
+K8S_NAMESPACE=goldilocks
+AGENT_IMAGE=goldilocks-agent:latest
+AGENT_SERVICE_URL=http://agent-service:3001
+AGENT_SERVICE_WS_URL=ws://agent-service:3001/ws
+AGENT_IDLE_TIMEOUT_MS=1800000

--- a/.env.example
+++ b/.env.example
@@ -1,13 +1,16 @@
 # Server
 PORT=3000
 NODE_ENV=development
+CORS_ORIGIN=http://localhost:5173
 
-# Database
-DATA_DIR=./data
+# State
+DATA_DIR=.dev
+WORKSPACE_ROOT=.dev/workspaces
 
-# Auth
-JWT_SECRET=change-me-in-production-use-a-long-random-string
-ENCRYPTION_KEY=change-me-32-bytes-for-aes-256
+# Required secrets
+JWT_SECRET=replace-with-a-random-secret
+ENCRYPTION_KEY=replace-with-a-random-secret
+AGENT_SERVICE_SHARED_SECRET=replace-with-a-random-secret
 
 # API Keys (optional - users can provide their own)
 ANTHROPIC_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ build/
 # Environment
 .env
 .env.local
+.env.dev
 .env.*.local
 
 # Data

--- a/apps/agent-service/package.json
+++ b/apps/agent-service/package.json
@@ -17,10 +17,12 @@
     "@goldilocks/data": "file:../../packages/data",
     "@goldilocks/runtime": "file:../../packages/runtime",
     "express": "^5.1.0",
+    "jsonwebtoken": "^9.0.3",
     "ws": "^8.18.2"
   },
   "devDependencies": {
     "@types/express": "^5.0.2",
+    "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^22.15.3",
     "@types/ws": "^8.18.1",
     "tsx": "^4.19.4",

--- a/apps/agent-service/src/index.ts
+++ b/apps/agent-service/src/index.ts
@@ -16,6 +16,10 @@ import {
   recordTtft,
   websocketErrored,
 } from './metrics.js';
+import {
+  authenticateInternalHttpRequest,
+  authenticateInternalWebSocketMessage,
+} from './internal-auth.js';
 
 CONFIG.validateRequiredSecrets();
 
@@ -36,11 +40,16 @@ interface InternalWsState {
 
 interface GatewayAuthMessage {
   type: 'auth';
-  userId: string;
   gatewayToken: string;
+  userToken: string;
 }
 
-function send(ws: WebSocket, msg: ServerMessage): void {
+type InternalServerMessage =
+  | ServerMessage
+  | { type: 'auth_ok'; userId: string }
+  | { type: 'auth_fail'; error: string };
+
+function send(ws: WebSocket, msg: InternalServerMessage): void {
   if (ws.readyState !== WebSocket.OPEN) return;
   ws.send(JSON.stringify(msg));
 }
@@ -245,17 +254,14 @@ function normalizeMessages(history: unknown[]): HistoryMessage[] {
 }
 
 function verifyInternalRequest(req: InternalAuthRequest, res: Response, next: express.NextFunction): void {
-  const sharedSecret = req.header('x-goldilocks-shared-secret');
-  const userId = req.header('x-goldilocks-user');
-
-  if (sharedSecret !== CONFIG.agentServiceSharedSecret || !userId) {
+  try {
+    const auth = authenticateInternalHttpRequest(req);
+    req.internalUserId = auth.userId;
+    next();
+  } catch {
     internalAuthFailed();
     res.status(401).json({ error: 'Unauthorized internal request' });
-    return;
   }
-
-  req.internalUserId = userId;
-  next();
 }
 
 const app = express();
@@ -386,13 +392,17 @@ wss.on('connection', (ws: WebSocket, _req: IncomingMessage) => {
 
     try {
       if (msg.type === 'auth' && 'gatewayToken' in msg) {
-        if (msg.gatewayToken !== CONFIG.agentServiceSharedSecret) {
+        try {
+          const auth = authenticateInternalWebSocketMessage(msg);
+          state.userId = auth.userId;
+          send(ws, { type: 'auth_ok', userId: auth.userId });
+        } catch (err) {
           internalAuthFailed();
-          send(ws, { type: 'auth_fail', error: 'Invalid gateway token' });
-          return;
+          send(ws, {
+            type: 'auth_fail',
+            error: err instanceof Error ? err.message : 'Unauthorized gateway websocket',
+          });
         }
-        state.userId = msg.userId;
-        send(ws, { type: 'auth_ok', userId: msg.userId });
         return;
       }
 

--- a/apps/agent-service/src/index.ts
+++ b/apps/agent-service/src/index.ts
@@ -17,6 +17,8 @@ import {
   websocketErrored,
 } from './metrics.js';
 
+CONFIG.validateRequiredSecrets();
+
 interface InternalAuthRequest extends express.Request {
   internalUserId?: string;
 }

--- a/apps/agent-service/src/internal-auth.ts
+++ b/apps/agent-service/src/internal-auth.ts
@@ -1,0 +1,103 @@
+import type express from 'express';
+import jwt, { type JwtPayload } from 'jsonwebtoken';
+import { CONFIG } from '@goldilocks/config';
+import { getDb } from '@goldilocks/data';
+
+export interface InternalUserClaims extends JwtPayload {
+  id: string;
+  email: string;
+  jti: string;
+}
+
+export interface InternalHttpAuthResult {
+  ok: true;
+  userId: string;
+  claims: InternalUserClaims;
+}
+
+export interface InternalWsAuthResult extends InternalHttpAuthResult {}
+
+function assertValidClaims(payload: string | JwtPayload): InternalUserClaims {
+  if (typeof payload === 'string') {
+    throw new Error('Invalid token payload');
+  }
+
+  if (typeof payload.id !== 'string' || typeof payload.email !== 'string' || typeof payload.jti !== 'string') {
+    throw new Error('Invalid token payload');
+  }
+
+  if (typeof payload.exp !== 'number') {
+    throw new Error('Token missing expiry');
+  }
+
+  return payload as InternalUserClaims;
+}
+
+function pruneExpiredRevocations(): void {
+  getDb().prepare('DELETE FROM revoked_tokens WHERE expires_at <= ?').run(Date.now());
+}
+
+function isRevoked(jti: string): boolean {
+  pruneExpiredRevocations();
+  const row = getDb().prepare('SELECT 1 FROM revoked_tokens WHERE jti = ?').get(jti);
+  return Boolean(row);
+}
+
+function getBearerToken(authHeader?: string): string | null {
+  if (!authHeader?.startsWith('Bearer ')) {
+    return null;
+  }
+
+  const token = authHeader.slice(7).trim();
+  return token || null;
+}
+
+export function verifyInternalUserToken(token: string): InternalUserClaims {
+  const payload = jwt.verify(token, CONFIG.jwtSecret, {
+    issuer: CONFIG.jwtIssuer,
+    audience: CONFIG.jwtAudience,
+  });
+
+  const claims = assertValidClaims(payload);
+  if (isRevoked(claims.jti)) {
+    throw new Error('Token revoked');
+  }
+
+  return claims;
+}
+
+export function authenticateInternalHttpRequest(req: express.Request): InternalHttpAuthResult {
+  const sharedSecret = req.header('x-goldilocks-shared-secret');
+  if (sharedSecret !== CONFIG.agentServiceSharedSecret) {
+    throw new Error('Invalid shared secret');
+  }
+
+  const token = getBearerToken(req.header('authorization'));
+  if (!token) {
+    throw new Error('Missing bearer token');
+  }
+
+  const claims = verifyInternalUserToken(token);
+  return {
+    ok: true,
+    userId: claims.id,
+    claims,
+  };
+}
+
+export function authenticateInternalWebSocketMessage(message: { gatewayToken?: string; userToken?: string }): InternalWsAuthResult {
+  if (message.gatewayToken !== CONFIG.agentServiceSharedSecret) {
+    throw new Error('Invalid gateway token');
+  }
+
+  if (!message.userToken) {
+    throw new Error('Missing user token');
+  }
+
+  const claims = verifyInternalUserToken(message.userToken);
+  return {
+    ok: true,
+    userId: claims.id,
+    claims,
+  };
+}

--- a/apps/agent-service/test/internal-auth.test.ts
+++ b/apps/agent-service/test/internal-auth.test.ts
@@ -1,0 +1,71 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { closeDb, runMigrations } from '@goldilocks/data';
+import { CONFIG } from '@goldilocks/config';
+import { generateToken, revokeToken, verifySignedToken } from '../../gateway/src/auth/middleware.js';
+import {
+  authenticateInternalHttpRequest,
+  authenticateInternalWebSocketMessage,
+} from '../src/internal-auth.js';
+
+describe('agent-service internal auth', () => {
+  beforeAll(() => {
+    runMigrations();
+  });
+
+  afterAll(() => {
+    closeDb();
+  });
+
+  it('accepts internal HTTP requests with the shared secret and a verified JWT', () => {
+    const token = generateToken({ id: 'user-1', email: 'user@example.com' });
+    const req = {
+      header(name: string) {
+        if (name === 'x-goldilocks-shared-secret') {
+          return CONFIG.agentServiceSharedSecret;
+        }
+        if (name === 'authorization') {
+          return `Bearer ${token}`;
+        }
+        return undefined;
+      },
+    };
+
+    const auth = authenticateInternalHttpRequest(req as any);
+    expect(auth.userId).toBe('user-1');
+    expect(auth.claims.email).toBe('user@example.com');
+  });
+
+  it('rejects internal HTTP requests without a bearer token', () => {
+    const req = {
+      header(name: string) {
+        if (name === 'x-goldilocks-shared-secret') {
+          return CONFIG.agentServiceSharedSecret;
+        }
+        return undefined;
+      },
+    };
+
+    expect(() => authenticateInternalHttpRequest(req as any)).toThrow('Missing bearer token');
+  });
+
+  it('authenticates gateway websocket messages using the shared secret and JWT', () => {
+    const token = generateToken({ id: 'user-2', email: 'ws@example.com' });
+    const auth = authenticateInternalWebSocketMessage({
+      gatewayToken: CONFIG.agentServiceSharedSecret,
+      userToken: token,
+    });
+
+    expect(auth.userId).toBe('user-2');
+    expect(auth.claims.email).toBe('ws@example.com');
+  });
+
+  it('rejects revoked JWTs on internal websocket auth', () => {
+    const token = generateToken({ id: 'user-3', email: 'revoked@example.com' });
+    revokeToken(verifySignedToken(token));
+
+    expect(() => authenticateInternalWebSocketMessage({
+      gatewayToken: CONFIG.agentServiceSharedSecret,
+      userToken: token,
+    })).toThrow('Token revoked');
+  });
+});

--- a/apps/agent-service/test/internal-auth.test.ts
+++ b/apps/agent-service/test/internal-auth.test.ts
@@ -17,7 +17,7 @@ describe('agent-service internal auth', () => {
   });
 
   it('accepts internal HTTP requests with the shared secret and a verified JWT', () => {
-    const token = generateToken({ id: 'user-1', email: 'user@example.com' });
+    const token = generateToken({ id: 'user-1', email: 'user@example.com', role: 'user' });
     const req = {
       header(name: string) {
         if (name === 'x-goldilocks-shared-secret') {
@@ -49,7 +49,7 @@ describe('agent-service internal auth', () => {
   });
 
   it('authenticates gateway websocket messages using the shared secret and JWT', () => {
-    const token = generateToken({ id: 'user-2', email: 'ws@example.com' });
+    const token = generateToken({ id: 'user-2', email: 'ws@example.com', role: 'user' });
     const auth = authenticateInternalWebSocketMessage({
       gatewayToken: CONFIG.agentServiceSharedSecret,
       userToken: token,
@@ -60,7 +60,7 @@ describe('agent-service internal auth', () => {
   });
 
   it('rejects revoked JWTs on internal websocket auth', () => {
-    const token = generateToken({ id: 'user-3', email: 'revoked@example.com' });
+    const token = generateToken({ id: 'user-3', email: 'revoked@example.com', role: 'user' });
     revokeToken(verifySignedToken(token));
 
     expect(() => authenticateInternalWebSocketMessage({

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { Routes, Route, Navigate } from 'react-router-dom';
-import { lazy, Suspense } from 'react';
+import { lazy, Suspense, useEffect } from 'react';
 import { useAuthStore } from './store/auth';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import Login from './pages/Login';
@@ -9,26 +9,46 @@ import ToastContainer from './components/ui/Toast';
 
 const Settings = lazy(() => import('./pages/Settings'));
 
+function FullScreenLoading({ label = 'Loading…' }: { label?: string }) {
+  return <div className="flex items-center justify-center h-screen text-slate-400">{label}</div>;
+}
+
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
-  
+  const hasCheckedAuth = useAuthStore((s) => s.hasCheckedAuth);
+
+  if (!hasCheckedAuth) {
+    return <FullScreenLoading label="Checking session…" />;
+  }
+
   if (!isAuthenticated) {
     return <Navigate to="/login" replace />;
   }
-  
+
   return <>{children}</>;
 }
 
 export default function App() {
+  const checkAuth = useAuthStore((s) => s.checkAuth);
+  const hasCheckedAuth = useAuthStore((s) => s.hasCheckedAuth);
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+
+  useEffect(() => {
+    void checkAuth();
+  }, [checkAuth]);
+
   return (
     <ErrorBoundary>
       <Routes>
-        <Route path="/login" element={<Login />} />
+        <Route
+          path="/login"
+          element={hasCheckedAuth && isAuthenticated ? <Navigate to="/" replace /> : <Login />}
+        />
         <Route
           path="/settings"
           element={
             <ProtectedRoute>
-              <Suspense fallback={<div className="flex items-center justify-center h-screen text-slate-400">Loading…</div>}>
+              <Suspense fallback={<FullScreenLoading />}>
                 <Settings />
               </Suspense>
             </ProtectedRoute>

--- a/apps/frontend/src/api/client.ts
+++ b/apps/frontend/src/api/client.ts
@@ -1,5 +1,3 @@
-import { useAuthStore } from '../store/auth';
-
 const API_BASE = '/api';
 
 class ApiError extends Error {
@@ -18,32 +16,27 @@ async function request<T>(
   path: string,
   data?: unknown
 ): Promise<T> {
-  const token = useAuthStore.getState().token;
-  
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
   };
-  
-  if (token) {
-    headers['Authorization'] = `Bearer ${token}`;
-  }
-  
+
   const res = await fetch(`${API_BASE}${path}`, {
     method,
     headers,
+    credentials: 'include',
     body: data ? JSON.stringify(data) : undefined,
   });
-  
+
   const json = await res.json().catch(() => ({}));
-  
+
   if (!res.ok) {
     throw new ApiError(
-      json.error ?? `Request failed with status ${res.status}`,
+      (json as { error?: string }).error ?? `Request failed with status ${res.status}`,
       res.status,
       json
     );
   }
-  
+
   return json as T;
 }
 
@@ -97,13 +90,8 @@ export function rawFileUrl(path: string): string {
   return `/api/files/${encodeURIComponent(path)}/raw`;
 }
 
-export function getAuthHeaders(): Record<string, string> {
-  const token = useAuthStore.getState().token;
-  return token ? { Authorization: `Bearer ${token}` } : {};
-}
-
 export async function downloadWorkspaceFile(path: string): Promise<void> {
-  const res = await fetch(rawFileUrl(path), { headers: getAuthHeaders() });
+  const res = await fetch(rawFileUrl(path), { credentials: 'include' });
   if (!res.ok) {
     throw new ApiError(`Request failed with status ${res.status}`, res.status);
   }

--- a/apps/frontend/src/components/layout/Header.tsx
+++ b/apps/frontend/src/components/layout/Header.tsx
@@ -149,7 +149,7 @@ export default function Header({
                 Settings
               </button>
               <button
-                onClick={logout}
+                onClick={() => { void logout(); setMenuOpen(false); }}
                 className="w-full flex items-center gap-2 px-4 py-2 text-sm text-red-400 hover:bg-slate-600"
               >
                 <LogOut className="w-4 h-4" />

--- a/apps/frontend/src/components/workspace/ImageViewer.tsx
+++ b/apps/frontend/src/components/workspace/ImageViewer.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Maximize, ZoomIn, ZoomOut } from 'lucide-react';
-import { getAuthHeaders, rawFileUrl } from '../../api/client';
+import { rawFileUrl } from '../../api/client';
 import { useSettingsStore } from '../../store/settings';
 
 function backgroundStyle(background: 'checkered' | 'dark' | 'light') {
@@ -34,7 +34,7 @@ export default function ImageViewer({ path }: { path: string }) {
     let cancelled = false;
     setLoading(true);
 
-    fetch(rawFileUrl(path), { headers: getAuthHeaders() })
+    fetch(rawFileUrl(path), { credentials: 'include' })
       .then((response) => {
         if (!response.ok) throw new Error(`HTTP ${response.status}`);
         return response.blob();

--- a/apps/frontend/src/components/workspace/PdfViewer.tsx
+++ b/apps/frontend/src/components/workspace/PdfViewer.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { ZoomIn, ZoomOut } from 'lucide-react';
 import * as pdfjsLib from 'pdfjs-dist';
 import pdfjsWorker from 'pdfjs-dist/build/pdf.worker.min.mjs?url';
-import { getAuthHeaders, rawFileUrl } from '../../api/client';
+import { rawFileUrl } from '../../api/client';
 import { useSettingsStore } from '../../store/settings';
 
 pdfjsLib.GlobalWorkerOptions.workerSrc = pdfjsWorker;
@@ -36,7 +36,7 @@ export default function PdfViewer({ path }: { path: string }) {
 
     async function loadPdf() {
       try {
-        const response = await fetch(rawFileUrl(path), { headers: getAuthHeaders() });
+        const response = await fetch(rawFileUrl(path), { credentials: 'include' });
         if (!response.ok) {
           throw new Error(`HTTP ${response.status}`);
         }

--- a/apps/frontend/src/hooks/useAgent.ts
+++ b/apps/frontend/src/hooks/useAgent.ts
@@ -4,11 +4,11 @@ import { useChatStore } from '../store/chat';
 import { useFilesStore } from '../store/files';
 import type { ServerMessage } from '@goldilocks/contracts';
 
-export type AgentStatus = 'disconnected' | 'connecting' | 'authenticating' | 'opening' | 'ready';
+export type AgentStatus = 'disconnected' | 'connecting' | 'opening' | 'ready';
 
 export function useAgent(conversationId: string | null) {
   const ws = useRef<WebSocket | null>(null);
-  const token = useAuthStore((s) => s.token);
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
   const [status, setStatus] = useState<AgentStatus>('disconnected');
   const [error, setError] = useState<string | null>(null);
 
@@ -28,7 +28,7 @@ export function useAgent(conversationId: string | null) {
 
   useEffect(() => {
     const generation = ++generationRef.current;
-    if (!conversationId || !token) {
+    if (!conversationId || !isAuthenticated) {
       setStatus('disconnected');
       return;
     }
@@ -46,9 +46,9 @@ export function useAgent(conversationId: string | null) {
     const socket = new WebSocket(`${protocol}//${window.location.host}/ws`);
 
     socket.onopen = () => {
-      setStatus('authenticating');
+      setStatus('opening');
       setError(null);
-      socket.send(JSON.stringify({ type: 'auth', token }));
+      socket.send(JSON.stringify({ type: 'open', conversationId }));
     };
 
     socket.onmessage = (event) => {
@@ -66,48 +66,37 @@ export function useAgent(conversationId: string | null) {
       const store = useChatStore.getState();
 
       switch (msg.type) {
-        case 'auth_ok':
-          setStatus('opening');
-          socket.send(JSON.stringify({ type: 'open', conversationId }));
-          break;
-
-        case 'auth_fail':
-          setError(msg.error);
-          setStatus('disconnected');
-          break;
-
         case 'ready': {
-          // Load message history from pi if available
           if (msg.messages && msg.messages.length > 0) {
             const chatMessages = msg.messages.map((m) => {
               if (m.role === 'user') {
                 return { role: 'user' as const, text: m.text, timestamp: Date.now() };
-              } else {
-                const blocks: import('../store/chat').AssistantBlock[] = [];
-                if (m.text) {
-                  blocks.push({ type: 'text' as const, content: m.text });
-                }
-                if (m.toolCalls) {
-                  for (const tc of m.toolCalls) {
-                    blocks.push({
-                      type: 'tool_call' as const,
-                      data: {
-                        toolCallId: tc.toolCallId,
-                        toolName: tc.toolName,
-                        args: tc.args,
-                        result: tc.result,
-                        isError: tc.isError,
-                        status: 'done' as const,
-                      },
-                    });
-                  }
-                }
-                return {
-                  role: 'assistant' as const,
-                  blocks,
-                  timestamp: Date.now(),
-                };
               }
+
+              const blocks: import('../store/chat').AssistantBlock[] = [];
+              if (m.text) {
+                blocks.push({ type: 'text' as const, content: m.text });
+              }
+              if (m.toolCalls) {
+                for (const tc of m.toolCalls) {
+                  blocks.push({
+                    type: 'tool_call' as const,
+                    data: {
+                      toolCallId: tc.toolCallId,
+                      toolName: tc.toolName,
+                      args: tc.args,
+                      result: tc.result,
+                      isError: tc.isError,
+                      status: 'done' as const,
+                    },
+                  });
+                }
+              }
+              return {
+                role: 'assistant' as const,
+                blocks,
+                timestamp: Date.now(),
+              };
             });
             store.setMessages(chatMessages);
           }
@@ -173,7 +162,7 @@ export function useAgent(conversationId: string | null) {
         refreshWorkspaceTimerRef.current = null;
       }
     };
-  }, [conversationId, token, scheduleWorkspaceRefresh]);
+  }, [conversationId, isAuthenticated, scheduleWorkspaceRefresh]);
 
   const isReady = status === 'ready';
 

--- a/apps/frontend/src/store/auth.ts
+++ b/apps/frontend/src/store/auth.ts
@@ -1,10 +1,8 @@
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
 import { api } from '../api/client';
 import { resetUserScopedFrontendState } from './session-reset';
 
 interface AuthResponse {
-  token: string;
   user: User;
 }
 
@@ -17,98 +15,110 @@ export interface User {
   email: string;
   displayName: string | null;
   settings: Record<string, unknown>;
+  createdAt?: number;
 }
 
 interface AuthState {
   user: User | null;
-  token: string | null;
   isAuthenticated: boolean;
   isLoading: boolean;
+  hasCheckedAuth: boolean;
   error: string | null;
-  
+
   login: (email: string, password: string) => Promise<void>;
   register: (email: string, password: string, displayName?: string) => Promise<void>;
-  logout: () => void;
+  logout: () => Promise<void>;
   clearError: () => void;
   checkAuth: () => Promise<void>;
 }
 
-export const useAuthStore = create<AuthState>()(
-  persist(
-    (set, get) => ({
-      user: null,
-      token: null,
-      isAuthenticated: false,
-      isLoading: false,
-      error: null,
-      
-      login: async (email, password) => {
-        set({ isLoading: true, error: null });
-        try {
-          const res = await api.post<AuthResponse>('/auth/login', { email, password });
-          resetUserScopedFrontendState();
-          set({
-            user: res.user,
-            token: res.token,
-            isAuthenticated: true,
-            isLoading: false,
-          });
-        } catch (err: any) {
-          set({
-            error: err.message ?? 'Login failed',
-            isLoading: false,
-          });
-          throw err;
-        }
-      },
-      
-      register: async (email, password, displayName) => {
-        set({ isLoading: true, error: null });
-        try {
-          const res = await api.post<AuthResponse>('/auth/register', { email, password, displayName });
-          resetUserScopedFrontendState();
-          set({
-            user: res.user,
-            token: res.token,
-            isAuthenticated: true,
-            isLoading: false,
-          });
-        } catch (err: any) {
-          set({
-            error: err.message ?? 'Registration failed',
-            isLoading: false,
-          });
-          throw err;
-        }
-      },
-      
-      logout: () => {
-        resetUserScopedFrontendState();
-        set({
-          user: null,
-          token: null,
-          isAuthenticated: false,
-        });
-      },
-      
-      clearError: () => set({ error: null }),
-      
-      checkAuth: async () => {
-        const { token } = get();
-        if (!token) return;
-        
-        try {
-          const res = await api.get<MeResponse>('/auth/me');
-          set({ user: res.user, isAuthenticated: true });
-        } catch {
-          resetUserScopedFrontendState();
-          set({ user: null, token: null, isAuthenticated: false });
-        }
-      },
-    }),
-    {
-      name: 'goldilocks-auth',
-      partialize: (state) => ({ token: state.token }),
+export const useAuthStore = create<AuthState>()((set) => ({
+  user: null,
+  isAuthenticated: false,
+  isLoading: false,
+  hasCheckedAuth: false,
+  error: null,
+
+  login: async (email, password) => {
+    set({ isLoading: true, error: null });
+    try {
+      const res = await api.post<AuthResponse>('/auth/login', { email, password });
+      resetUserScopedFrontendState();
+      set({
+        user: res.user,
+        isAuthenticated: true,
+        isLoading: false,
+        hasCheckedAuth: true,
+      });
+    } catch (err: any) {
+      set({
+        error: err.message ?? 'Login failed',
+        isLoading: false,
+        hasCheckedAuth: true,
+      });
+      throw err;
     }
-  )
-);
+  },
+
+  register: async (email, password, displayName) => {
+    set({ isLoading: true, error: null });
+    try {
+      const res = await api.post<AuthResponse>('/auth/register', { email, password, displayName });
+      resetUserScopedFrontendState();
+      set({
+        user: res.user,
+        isAuthenticated: true,
+        isLoading: false,
+        hasCheckedAuth: true,
+      });
+    } catch (err: any) {
+      set({
+        error: err.message ?? 'Registration failed',
+        isLoading: false,
+        hasCheckedAuth: true,
+      });
+      throw err;
+    }
+  },
+
+  logout: async () => {
+    set({ isLoading: true });
+    try {
+      await api.post('/auth/logout');
+    } catch {
+      // If the cookie is already gone, local cleanup still matters.
+    } finally {
+      resetUserScopedFrontendState();
+      set({
+        user: null,
+        isAuthenticated: false,
+        isLoading: false,
+        hasCheckedAuth: true,
+        error: null,
+      });
+    }
+  },
+
+  clearError: () => set({ error: null }),
+
+  checkAuth: async () => {
+    set({ isLoading: true });
+    try {
+      const res = await api.get<MeResponse>('/auth/me');
+      set({
+        user: res.user,
+        isAuthenticated: true,
+        isLoading: false,
+        hasCheckedAuth: true,
+      });
+    } catch {
+      resetUserScopedFrontendState();
+      set({
+        user: null,
+        isAuthenticated: false,
+        isLoading: false,
+        hasCheckedAuth: true,
+      });
+    }
+  },
+}));

--- a/apps/frontend/src/store/files.ts
+++ b/apps/frontend/src/store/files.ts
@@ -79,7 +79,11 @@ export const useFilesStore = create<FilesState>((set, get) => ({
         reader.readAsDataURL(file);
       });
 
-      const res = await api.post<{ ok: true; name: string; path: string; size: number }>('/files/upload', { filename: file.name, content });
+      const res = await api.post<{ ok: true; name: string; path: string; size: number }>('/files/upload', {
+        filename: file.name,
+        content,
+        contentType: file.type || 'application/octet-stream',
+      });
       set((state) => ({
         files: state.files.some((existing) => existing.path === res.path)
           ? state.files

--- a/apps/gateway/package.json
+++ b/apps/gateway/package.json
@@ -22,6 +22,7 @@
     "cors": "^2.8.5",
     "express": "^5.1.0",
     "express-rate-limit": "^8.3.2",
+    "helmet": "^8.1.0",
     "jsonwebtoken": "^9.0.2",
     "uuid": "^11.1.0",
     "ws": "^8.18.2"

--- a/apps/gateway/package.json
+++ b/apps/gateway/package.json
@@ -16,17 +16,19 @@
     "@goldilocks/contracts": "file:../../packages/contracts",
     "@goldilocks/data": "file:../../packages/data",
     "@goldilocks/runtime": "file:../../packages/runtime",
+    "@mariozechner/pi-ai": "^0.64.0",
     "bcrypt": "^5.1.1",
+    "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "express": "^5.1.0",
     "express-rate-limit": "^8.3.2",
     "jsonwebtoken": "^9.0.2",
     "uuid": "^11.1.0",
-    "ws": "^8.18.2",
-    "@mariozechner/pi-ai": "^0.64.0"
+    "ws": "^8.18.2"
   },
   "devDependencies": {
     "@types/bcrypt": "^5.0.2",
+    "@types/cookie-parser": "^1.4.10",
     "@types/cors": "^2.8.17",
     "@types/express": "^5.0.2",
     "@types/jsonwebtoken": "^9.0.10",

--- a/apps/gateway/package.json
+++ b/apps/gateway/package.json
@@ -16,7 +16,7 @@
     "@goldilocks/contracts": "file:../../packages/contracts",
     "@goldilocks/data": "file:../../packages/data",
     "@goldilocks/runtime": "file:../../packages/runtime",
-    "@mariozechner/pi-ai": "^0.64.0",
+    "@earendil-works/pi-ai": "^0.75.5",
     "bcrypt": "^5.1.1",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",

--- a/apps/gateway/src/agent/agent-service-client.ts
+++ b/apps/gateway/src/agent/agent-service-client.ts
@@ -2,10 +2,10 @@ import { CONFIG } from '@goldilocks/config';
 
 export async function agentServiceFetch(
   path: string,
-  options: RequestInit & { userId: string },
+  options: RequestInit & { userToken: string },
 ): Promise<Response> {
   const headers = new Headers(options.headers ?? {});
-  headers.set('x-goldilocks-user', options.userId);
+  headers.set('authorization', `Bearer ${options.userToken}`);
   headers.set('x-goldilocks-shared-secret', CONFIG.agentServiceSharedSecret);
 
   return fetch(`${CONFIG.agentServiceUrl}${path}`, {

--- a/apps/gateway/src/agent/websocket.ts
+++ b/apps/gateway/src/agent/websocket.ts
@@ -1,7 +1,11 @@
-import { IncomingMessage } from 'http';
-import jwt from 'jsonwebtoken';
+import { IncomingMessage, Server as HttpServer } from 'http';
 import { WebSocket, WebSocketServer } from 'ws';
 import { CONFIG } from '@goldilocks/config';
+import {
+  getTokenFromCookieHeader,
+  verifySignedToken,
+  type AuthUser,
+} from '../auth/middleware.js';
 import {
   recordAgentConnectionClosed,
   recordAgentConnectionOpened,
@@ -13,16 +17,40 @@ import {
 } from './relay-metrics.js';
 import type { ClientMessage, ServerMessage } from '@goldilocks/contracts';
 
-interface AuthUser {
-  id: string;
-  email: string;
-}
-
 interface GatewayToAgentMessage {
   type: 'auth';
-  userId: string;
   gatewayToken: string;
+  userToken: string;
 }
+
+interface AgentAuthOkMessage {
+  type: 'auth_ok';
+  userId: string;
+}
+
+interface AgentAuthFailMessage {
+  type: 'auth_fail';
+  error: string;
+}
+
+interface AuthenticatedWebSocketRequest extends IncomingMessage {
+  authContext?: {
+    user: AuthUser;
+    token: string;
+  };
+}
+
+export type WebSocketUpgradeAuthResult =
+  | {
+      ok: true;
+      token: string;
+      user: AuthUser;
+    }
+  | {
+      ok: false;
+      status: 401 | 403;
+      error: string;
+    };
 
 const HEARTBEAT_INTERVAL_MS = 30_000;
 const HEARTBEAT_TIMEOUT_MS = 60_000;
@@ -41,10 +69,86 @@ function send(ws: WebSocket, msg: ServerMessage): void {
   }
 }
 
-export function setupWebSocket(wss: WebSocketServer): void {
-  wss.on('connection', (browserWs: WebSocket, _req: IncomingMessage) => {
+function rejectUpgrade(socket: import('stream').Duplex, status: 401 | 403, error: string): void {
+  const statusText = status === 403 ? 'Forbidden' : 'Unauthorized';
+  socket.write(
+    `HTTP/1.1 ${status} ${statusText}\r\n` +
+    'Connection: close\r\n' +
+    'Content-Type: text/plain\r\n' +
+    `Content-Length: ${Buffer.byteLength(error)}\r\n` +
+    '\r\n' +
+    error,
+  );
+  socket.destroy();
+}
+
+export function authenticateWebSocketUpgrade(req: IncomingMessage): WebSocketUpgradeAuthResult {
+  const origin = req.headers.origin;
+  if (!origin || !CONFIG.allowedWebSocketOrigins.includes(origin)) {
+    return { ok: false, status: 403, error: 'WebSocket origin not allowed' };
+  }
+
+  const token = getTokenFromCookieHeader(req.headers.cookie);
+  if (!token) {
+    return { ok: false, status: 401, error: 'Missing session cookie' };
+  }
+
+  try {
+    const claims = verifySignedToken(token);
+    return {
+      ok: true,
+      token,
+      user: {
+        id: claims.id,
+        email: claims.email,
+        jti: claims.jti,
+      },
+    };
+  } catch {
+    return { ok: false, status: 401, error: 'Invalid, expired, or revoked token' };
+  }
+}
+
+export function setupWebSocket(server: HttpServer): WebSocketServer {
+  const wss = new WebSocketServer({ noServer: true });
+
+  server.on('upgrade', (req, socket, head) => {
+    const pathname = new URL(req.url ?? '/', `http://${req.headers.host ?? 'localhost'}`).pathname;
+    if (pathname !== '/ws') {
+      socket.destroy();
+      return;
+    }
+
+    const authResult = authenticateWebSocketUpgrade(req);
+    recordAuthAttempt(authResult.ok);
+
+    if (!authResult.ok) {
+      rejectUpgrade(socket, authResult.status, authResult.error);
+      return;
+    }
+
+    const authReq = req as AuthenticatedWebSocketRequest;
+    authReq.authContext = {
+      user: authResult.user,
+      token: authResult.token,
+    };
+
+    wss.handleUpgrade(req, socket, head, (ws) => {
+      wss.emit('connection', ws, authReq);
+    });
+  });
+
+  wss.on('connection', (browserWs: WebSocket, req: IncomingMessage) => {
+    const authReq = req as AuthenticatedWebSocketRequest;
+    const authContext = authReq.authContext;
+    if (!authContext) {
+      browserWs.close();
+      return;
+    }
+
     recordBrowserConnectionOpened();
-    let browserUser: AuthUser | null = null;
+    const browserUser = authContext.user;
+    const browserToken = authContext.token;
     let agentWs: WebSocket | null = null;
     let agentReady = false;
     let agentGeneration = 0;
@@ -101,125 +205,112 @@ export function setupWebSocket(wss: WebSocketServer): void {
       }
     };
 
+    const connectToAgentService = () => {
+      cleanupAgentConnection();
+
+      const connectionGeneration = agentGeneration;
+      const nextAgentWs = new WebSocket(CONFIG.agentServiceWsUrl);
+      agentWs = nextAgentWs;
+      recordAgentConnectionOpened();
+
+      // ── Agent keepalive ──
+      // Same pattern: ping at interval, enforce pong timeout.
+      let agentLastPong = Date.now();
+      const agentHeartbeat = setInterval(() => {
+        if (nextAgentWs.readyState !== WebSocket.OPEN) {
+          clearInterval(agentHeartbeat);
+          return;
+        }
+        nextAgentWs.ping();
+
+        if (Date.now() - agentLastPong > HEARTBEAT_TIMEOUT_MS) {
+          console.warn('Agent service WebSocket pong timeout — closing connection');
+          nextAgentWs.terminate();
+          clearInterval(agentHeartbeat);
+        }
+      }, HEARTBEAT_INTERVAL_MS);
+      currentAgentHeartbeat = agentHeartbeat;
+
+      nextAgentWs.on('pong', () => {
+        agentLastPong = Date.now();
+      });
+
+      nextAgentWs.on('open', () => {
+        if (connectionGeneration !== agentGeneration) return;
+        const authMessage: GatewayToAgentMessage = {
+          type: 'auth',
+          gatewayToken: CONFIG.agentServiceSharedSecret,
+          userToken: browserToken,
+        };
+        nextAgentWs.send(JSON.stringify(authMessage));
+      });
+
+      nextAgentWs.on('message', (agentRaw) => {
+        if (connectionGeneration !== agentGeneration) return;
+
+        let agentMsg: ServerMessage | AgentAuthOkMessage | AgentAuthFailMessage;
+        try {
+          agentMsg = JSON.parse(agentRaw.toString()) as ServerMessage | AgentAuthOkMessage | AgentAuthFailMessage;
+        } catch {
+          send(browserWs, { type: 'error', error: 'Invalid agent-service message' });
+          return;
+        }
+
+        if (agentMsg.type === 'auth_ok') {
+          agentReady = true;
+          flushPending();
+          return;
+        }
+
+        if (agentMsg.type === 'auth_fail') {
+          send(browserWs, { type: 'error', error: agentMsg.error });
+          cleanupAgentConnection();
+          return;
+        }
+
+        // TTFT: record time from prompt send to first meaningful output
+        if (promptSentAt !== null && TTFT_CLEAR_TYPES.has(agentMsg.type)) {
+          recordTtft(Date.now() - promptSentAt);
+          promptSentAt = null;
+        }
+
+        send(browserWs, agentMsg);
+      });
+
+      nextAgentWs.on('close', () => {
+        clearInterval(agentHeartbeat);
+        if (currentAgentHeartbeat === agentHeartbeat) {
+          currentAgentHeartbeat = null;
+        }
+        if (connectionGeneration !== agentGeneration) {
+          // Stale socket — counter already decremented by cleanupAgentConnection()
+          return;
+        }
+        // Spontaneous disconnect — counter was not decremented yet
+        recordAgentConnectionClosed();
+        agentReady = false;
+        agentWs = null;
+        if (browserWs.readyState === WebSocket.OPEN) {
+          send(browserWs, { type: 'error', error: 'Agent service disconnected' });
+        }
+      });
+
+      nextAgentWs.on('error', (err) => {
+        if (connectionGeneration !== agentGeneration) return;
+        console.error('Agent service WebSocket error:', err);
+        recordRelayError();
+        send(browserWs, { type: 'error', error: 'Agent service connection error' });
+      });
+    };
+
+    connectToAgentService();
+
     browserWs.on('message', (raw) => {
       let msg: ClientMessage;
       try {
         msg = JSON.parse(raw.toString()) as ClientMessage;
       } catch {
         send(browserWs, { type: 'error', error: 'Invalid JSON' });
-        return;
-      }
-
-      if (msg.type === 'auth') {
-        cleanupAgentConnection();
-
-        try {
-          const payload = jwt.verify(msg.token, CONFIG.jwtSecret) as AuthUser;
-          recordAuthAttempt(true);
-          browserUser = payload;
-          const connectionGeneration = agentGeneration;
-          const nextAgentWs = new WebSocket(CONFIG.agentServiceWsUrl);
-          agentWs = nextAgentWs;
-          recordAgentConnectionOpened();
-
-          // ── Agent keepalive ──
-          // Same pattern: ping at interval, enforce pong timeout.
-          let agentLastPong = Date.now();
-          const agentHeartbeat = setInterval(() => {
-            if (nextAgentWs.readyState !== WebSocket.OPEN) {
-              clearInterval(agentHeartbeat);
-              return;
-            }
-            nextAgentWs.ping();
-
-            if (Date.now() - agentLastPong > HEARTBEAT_TIMEOUT_MS) {
-              console.warn('Agent service WebSocket pong timeout — closing connection');
-              nextAgentWs.terminate();
-              clearInterval(agentHeartbeat);
-            }
-          }, HEARTBEAT_INTERVAL_MS);
-          currentAgentHeartbeat = agentHeartbeat;
-
-          nextAgentWs.on('pong', () => {
-            agentLastPong = Date.now();
-          });
-
-          nextAgentWs.on('open', () => {
-            if (connectionGeneration !== agentGeneration) return;
-            const authMessage: GatewayToAgentMessage = {
-              type: 'auth',
-              userId: payload.id,
-              gatewayToken: CONFIG.agentServiceSharedSecret,
-            };
-            nextAgentWs.send(JSON.stringify(authMessage));
-          });
-
-          nextAgentWs.on('message', (agentRaw) => {
-            if (connectionGeneration !== agentGeneration) return;
-
-            let agentMsg: ServerMessage;
-            try {
-              agentMsg = JSON.parse(agentRaw.toString()) as ServerMessage;
-            } catch {
-              send(browserWs, { type: 'error', error: 'Invalid agent-service message' });
-              return;
-            }
-
-            if (agentMsg.type === 'auth_ok') {
-              agentReady = true;
-              send(browserWs, { type: 'auth_ok', userId: payload.id });
-              flushPending();
-              return;
-            }
-
-            if (agentMsg.type === 'auth_fail') {
-              send(browserWs, agentMsg);
-              cleanupAgentConnection();
-              return;
-            }
-
-            // TTFT: record time from prompt send to first meaningful output
-            if (promptSentAt !== null && TTFT_CLEAR_TYPES.has(agentMsg.type)) {
-              recordTtft(Date.now() - promptSentAt);
-              promptSentAt = null;
-            }
-
-            send(browserWs, agentMsg);
-          });
-
-          nextAgentWs.on('close', () => {
-            clearInterval(agentHeartbeat);
-            if (currentAgentHeartbeat === agentHeartbeat) {
-              currentAgentHeartbeat = null;
-            }
-            if (connectionGeneration !== agentGeneration) {
-              // Stale socket — counter already decremented by cleanupAgentConnection()
-              return;
-            }
-            // Spontaneous disconnect — counter was not decremented yet
-            recordAgentConnectionClosed();
-            agentReady = false;
-            agentWs = null;
-            if (browserWs.readyState === WebSocket.OPEN) {
-              send(browserWs, { type: 'error', error: 'Agent service disconnected' });
-            }
-          });
-
-          nextAgentWs.on('error', (err) => {
-            if (connectionGeneration !== agentGeneration) return;
-            console.error('Agent service WebSocket error:', err);
-            recordRelayError();
-            send(browserWs, { type: 'error', error: 'Agent service connection error' });
-          });
-        } catch {
-          recordAuthAttempt(false);
-          send(browserWs, { type: 'auth_fail', error: 'Invalid or expired token' });
-        }
-        return;
-      }
-
-      if (!browserUser) {
-        send(browserWs, { type: 'error', error: 'Not authenticated' });
         return;
       }
 
@@ -248,4 +339,6 @@ export function setupWebSocket(wss: WebSocketServer): void {
       cleanupAgentConnection();
     });
   });
+
+  return wss;
 }

--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -7,6 +7,7 @@
  */
 
 import express from 'express';
+import cookieParser from 'cookie-parser';
 import cors from 'cors';
 import rateLimit from 'express-rate-limit';
 import { existsSync } from 'fs';
@@ -26,14 +27,34 @@ import quickgenRoutes from './quickgen/routes.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
+function getAllowedCorsOrigins(): Set<string> {
+  const origins = new Set<string>([CONFIG.frontendUrl]);
+
+  if (!CONFIG.isProd) {
+    origins.add('http://localhost:5173');
+    origins.add('http://127.0.0.1:5173');
+  }
+
+  return origins;
+}
+
 export function createApp() {
   const app = express();
+  const allowedOrigins = getAllowedCorsOrigins();
 
   // Middleware
-  app.use(cors(CONFIG.isProd ? {
-    origin: process.env.CORS_ORIGIN ?? false,
+  app.use(cors({
+    origin(origin, callback) {
+      if (!origin || allowedOrigins.has(origin)) {
+        callback(null, true);
+        return;
+      }
+
+      callback(new Error(`Origin ${origin} is not allowed by CORS`));
+    },
     credentials: true,
-  } : {}));
+  }));
+  app.use(cookieParser());
   app.use(express.json());
 
   // Rate limiting

--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -6,16 +6,18 @@
  *   - test/api/helpers/test-server.ts: to create an isolated test server
  */
 
-import express from 'express';
+import express, { type NextFunction, type Request, type Response } from 'express';
 import cookieParser from 'cookie-parser';
 import cors from 'cors';
-import rateLimit from 'express-rate-limit';
+import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
+import helmet, { type HelmetOptions } from 'helmet';
 import { existsSync } from 'fs';
 import { dirname, resolve } from 'path';
 import { fileURLToPath } from 'url';
 
 import { CONFIG } from '@goldilocks/config';
 import { getDb } from '@goldilocks/data';
+import { getRequestToken, verifySignedToken } from './auth/middleware.js';
 import { getRelayMetrics } from './agent/relay-metrics.js';
 import authRoutes from './auth/routes.js';
 import conversationRoutes from './conversations/routes.js';
@@ -38,6 +40,68 @@ function getAllowedCorsOrigins(): Set<string> {
   return origins;
 }
 
+function getHelmetOptions(): Readonly<HelmetOptions> {
+  const directives: Record<string, string[]> = {
+    'connect-src': ["'self'"],
+    'script-src': ["'self'"],
+    'style-src': ["'self'"],
+  };
+
+  if (!CONFIG.isProd) {
+    directives['connect-src'] = [
+      "'self'",
+      ...CONFIG.allowedWebSocketOrigins,
+      'ws://localhost:5173',
+      'ws://127.0.0.1:5173',
+    ];
+    directives['script-src'] = ["'self'", "'unsafe-inline'", "'unsafe-eval'"];
+    directives['style-src'] = ["'self'", "'unsafe-inline'"];
+  }
+
+  const options: HelmetOptions = {
+    contentSecurityPolicy: {
+      useDefaults: true,
+      directives,
+    },
+  };
+
+  if (!CONFIG.isProd) {
+    options.crossOriginEmbedderPolicy = false;
+  }
+
+  return options;
+}
+
+function parseJsonBody(req: Request, res: Response, next: NextFunction): void {
+  const jsonParser = req.path.startsWith('/api/files')
+    ? express.json({ limit: CONFIG.fileUploadBodyLimit })
+    : express.json();
+
+  jsonParser(req, res, next);
+}
+
+export function getRateLimitKey(req: Pick<Request, 'headers' | 'ip'> & { cookies?: Record<string, string> }): string {
+  const token = getRequestToken(req as Request);
+
+  if (token) {
+    try {
+      return verifySignedToken(token).id;
+    } catch {
+      // Invalid or revoked tokens fall back to IP bucketing.
+    }
+  }
+
+  return ipKeyGenerator(req.ip ?? '127.0.0.1');
+}
+
+export function buildReadinessFailureResponse(err: unknown) {
+  console.error('Readiness check failed:', err);
+  return {
+    status: 'degraded' as const,
+    error: 'Service unavailable',
+  };
+}
+
 export function createApp() {
   const app = express();
   const allowedOrigins = getAllowedCorsOrigins();
@@ -54,8 +118,9 @@ export function createApp() {
     },
     credentials: true,
   }));
+  app.use(helmet(getHelmetOptions()));
   app.use(cookieParser());
-  app.use(express.json());
+  app.use(parseJsonBody);
 
   // Rate limiting
   const limiter = rateLimit({
@@ -63,6 +128,7 @@ export function createApp() {
     max: CONFIG.isProd ? 60 : 300,
     standardHeaders: true,
     legacyHeaders: false,
+    keyGenerator: getRateLimitKey,
     message: { error: 'Too many requests, please try again later' },
   });
   app.use('/api', limiter);
@@ -70,9 +136,22 @@ export function createApp() {
   const authLimiter = rateLimit({
     windowMs: 15 * 60 * 1000,
     max: 20,
+    standardHeaders: true,
+    legacyHeaders: false,
+    keyGenerator: getRateLimitKey,
     message: { error: 'Too many auth attempts, please try again later' },
   });
   app.use('/api/auth', authLimiter);
+
+  const registerLimiter = rateLimit({
+    windowMs: 60 * 60 * 1000,
+    max: 3,
+    standardHeaders: true,
+    legacyHeaders: false,
+    keyGenerator: (req) => ipKeyGenerator(req.ip ?? '127.0.0.1'),
+    message: { error: 'Too many registration attempts, please try again later' },
+  });
+  app.use('/api/auth/register', registerLimiter);
 
   // Health check
   app.get('/api/health', (_req, res) => {
@@ -84,10 +163,7 @@ export function createApp() {
       getDb().prepare('SELECT 1').get();
       res.json({ status: 'ready', dependencies: { db: 'ok' } });
     } catch (err) {
-      res.status(503).json({
-        status: 'degraded',
-        error: err instanceof Error ? err.message : 'Readiness check failed',
-      });
+      res.status(503).json(buildReadinessFailureResponse(err));
     }
   });
 
@@ -104,6 +180,22 @@ export function createApp() {
   app.use('/api/structures', structureRoutes);
   app.use('/api/library', libraryRouter);
   app.use('/api', quickgenRoutes);
+
+  app.use((err: unknown, req: Request, res: Response, next: NextFunction) => {
+    if (req.path.startsWith('/api')) {
+      if (typeof err === 'object' && err !== null && 'type' in err && err.type === 'entity.too.large') {
+        res.status(413).json({ error: `File upload exceeds limit of ${CONFIG.fileUploadMaxBytes} bytes` });
+        return;
+      }
+
+      if (err instanceof SyntaxError && 'body' in err) {
+        res.status(400).json({ error: 'Invalid JSON body' });
+        return;
+      }
+    }
+
+    next(err);
+  });
 
   // Static file serving (frontend dist)
   const frontendDist = resolve(__dirname, '../../frontend/dist');

--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -17,9 +17,11 @@ import { fileURLToPath } from 'url';
 
 import { CONFIG } from '@goldilocks/config';
 import { getDb } from '@goldilocks/data';
-import { getRequestToken, verifySignedToken } from './auth/middleware.js';
+import { getRequestToken, requireAdmin, verifySignedToken } from './auth/middleware.js';
+import { audit } from './logging/audit-logger.js';
 import { getRelayMetrics } from './agent/relay-metrics.js';
 import authRoutes from './auth/routes.js';
+import { verifyToken } from './auth/middleware.js';
 import conversationRoutes from './conversations/routes.js';
 import fileRoutes from './files/routes.js';
 import modelRoutes from './models/routes.js';
@@ -167,7 +169,8 @@ export function createApp() {
     }
   });
 
-  app.get('/api/metrics', (_req, res) => {
+  app.get('/api/metrics', verifyToken, requireAdmin, (req, res) => {
+    audit('admin.action', req, { userId: (req as any).user?.id, userAgent: req.headers['user-agent'], details: { action: 'metrics' } });
     res.json({ relay: getRelayMetrics() });
   });
 

--- a/apps/gateway/src/auth/middleware.ts
+++ b/apps/gateway/src/auth/middleware.ts
@@ -1,39 +1,170 @@
-import { Request, Response, NextFunction } from 'express';
-import jwt from 'jsonwebtoken';
+import { NextFunction, Request, Response } from 'express';
+import jwt, { type JwtPayload, type SignOptions } from 'jsonwebtoken';
+import { v4 as uuid } from 'uuid';
+import { getDb } from '@goldilocks/data';
 import { CONFIG } from '@goldilocks/config';
 
 export interface AuthUser {
   id: string;
   email: string;
+  jti: string;
+}
+
+export interface AuthTokenPayload extends JwtPayload {
+  id: string;
+  email: string;
+  jti: string;
 }
 
 export interface AuthRequest extends Request {
   user?: AuthUser;
+  authToken?: string;
+  authClaims?: AuthTokenPayload;
+}
+
+const SESSION_COOKIE_OPTIONS = {
+  httpOnly: true,
+  sameSite: 'strict' as const,
+  secure: CONFIG.isProd,
+  path: '/',
+  maxAge: CONFIG.sessionCookieMaxAgeMs,
+};
+
+function parseCookies(cookieHeader?: string): Record<string, string> {
+  if (!cookieHeader) {
+    return {};
+  }
+
+  return cookieHeader
+    .split(';')
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .reduce<Record<string, string>>((cookies, part) => {
+      const separatorIndex = part.indexOf('=');
+      if (separatorIndex <= 0) {
+        return cookies;
+      }
+
+      const name = part.slice(0, separatorIndex).trim();
+      const value = part.slice(separatorIndex + 1).trim();
+      cookies[name] = decodeURIComponent(value);
+      return cookies;
+    }, {});
+}
+
+function getTokenFromAuthorizationHeader(authHeader?: string): string | null {
+  if (!authHeader?.startsWith('Bearer ')) {
+    return null;
+  }
+
+  const token = authHeader.slice(7).trim();
+  return token || null;
+}
+
+function assertValidPayload(payload: string | JwtPayload): AuthTokenPayload {
+  if (typeof payload === 'string') {
+    throw new Error('Invalid token payload');
+  }
+
+  if (typeof payload.id !== 'string' || typeof payload.email !== 'string' || typeof payload.jti !== 'string') {
+    throw new Error('Invalid token payload');
+  }
+
+  if (typeof payload.exp !== 'number') {
+    throw new Error('Token missing expiry');
+  }
+
+  return payload as AuthTokenPayload;
+}
+
+function pruneExpiredRevocations(): void {
+  getDb().prepare('DELETE FROM revoked_tokens WHERE expires_at <= ?').run(Date.now());
+}
+
+function isTokenRevoked(jti: string): boolean {
+  pruneExpiredRevocations();
+  const row = getDb().prepare('SELECT 1 FROM revoked_tokens WHERE jti = ?').get(jti);
+  return Boolean(row);
+}
+
+export function getTokenFromCookieHeader(cookieHeader?: string): string | null {
+  return parseCookies(cookieHeader)[CONFIG.sessionCookieName] ?? null;
+}
+
+export function getRequestToken(req: Request): string | null {
+  const cookieToken = (req as Request & { cookies?: Record<string, string> }).cookies?.[CONFIG.sessionCookieName]
+    ?? getTokenFromCookieHeader(req.headers.cookie);
+
+  return cookieToken ?? getTokenFromAuthorizationHeader(req.headers.authorization);
+}
+
+export function verifySignedToken(token: string): AuthTokenPayload {
+  const payload = jwt.verify(token, CONFIG.jwtSecret, {
+    issuer: CONFIG.jwtIssuer,
+    audience: CONFIG.jwtAudience,
+  });
+
+  const claims = assertValidPayload(payload);
+  if (isTokenRevoked(claims.jti)) {
+    throw new Error('Token revoked');
+  }
+
+  return claims;
+}
+
+export function revokeToken(claims: { jti: string; exp: number }): void {
+  getDb().prepare(`
+    INSERT OR REPLACE INTO revoked_tokens (jti, expires_at)
+    VALUES (?, ?)
+  `).run(claims.jti, claims.exp * 1000);
 }
 
 export function verifyToken(req: AuthRequest, res: Response, next: NextFunction): void {
-  const authHeader = req.headers.authorization;
-  
-  if (!authHeader?.startsWith('Bearer ')) {
-    res.status(401).json({ error: 'Missing or invalid authorization header' });
+  const token = getRequestToken(req);
+
+  if (!token) {
+    res.status(401).json({ error: 'Missing session cookie or bearer token' });
     return;
   }
-  
-  const token = authHeader.slice(7);
-  
+
   try {
-    const payload = jwt.verify(token, CONFIG.jwtSecret) as AuthUser;
-    req.user = payload;
+    const claims = verifySignedToken(token);
+    req.authToken = token;
+    req.authClaims = claims;
+    req.user = {
+      id: claims.id,
+      email: claims.email,
+      jti: claims.jti,
+    };
     next();
-  } catch (err) {
-    res.status(401).json({ error: 'Invalid or expired token' });
+  } catch {
+    res.status(401).json({ error: 'Invalid, expired, or revoked token' });
   }
 }
 
-export function generateToken(user: AuthUser): string {
+export function generateToken(user: Pick<AuthUser, 'id' | 'email'>): string {
   return jwt.sign(
-    { id: user.id, email: user.email },
+    {
+      id: user.id,
+      email: user.email,
+      jti: uuid(),
+    },
     CONFIG.jwtSecret,
-    { expiresIn: CONFIG.jwtExpiresIn }
+    {
+      expiresIn: CONFIG.jwtExpiresIn as SignOptions['expiresIn'],
+      issuer: CONFIG.jwtIssuer,
+      audience: CONFIG.jwtAudience,
+    }
   );
+}
+
+export function setSessionCookie(res: Response, token: string): void {
+  res.cookie(CONFIG.sessionCookieName, token, SESSION_COOKIE_OPTIONS);
+}
+
+export function clearSessionCookie(res: Response): void {
+  res.clearCookie(CONFIG.sessionCookieName, {
+    ...SESSION_COOKIE_OPTIONS,
+    maxAge: undefined,
+  });
 }

--- a/apps/gateway/src/auth/middleware.ts
+++ b/apps/gateway/src/auth/middleware.ts
@@ -4,16 +4,20 @@ import { v4 as uuid } from 'uuid';
 import { getDb } from '@goldilocks/data';
 import { CONFIG } from '@goldilocks/config';
 
+export type UserRole = 'user' | 'admin';
+
 export interface AuthUser {
   id: string;
   email: string;
   jti: string;
+  role: UserRole;
 }
 
 export interface AuthTokenPayload extends JwtPayload {
   id: string;
   email: string;
   jti: string;
+  role: UserRole;
 }
 
 export interface AuthRequest extends Request {
@@ -66,7 +70,8 @@ function assertValidPayload(payload: string | JwtPayload): AuthTokenPayload {
     throw new Error('Invalid token payload');
   }
 
-  if (typeof payload.id !== 'string' || typeof payload.email !== 'string' || typeof payload.jti !== 'string') {
+  if (typeof payload.id !== 'string' || typeof payload.email !== 'string' || typeof payload.jti !== 'string'
+    || (payload.role !== 'user' && payload.role !== 'admin')) {
     throw new Error('Invalid token payload');
   }
 
@@ -135,6 +140,7 @@ export function verifyToken(req: AuthRequest, res: Response, next: NextFunction)
       id: claims.id,
       email: claims.email,
       jti: claims.jti,
+      role: claims.role,
     };
     next();
   } catch {
@@ -142,11 +148,12 @@ export function verifyToken(req: AuthRequest, res: Response, next: NextFunction)
   }
 }
 
-export function generateToken(user: Pick<AuthUser, 'id' | 'email'>): string {
+export function generateToken(user: Pick<AuthUser, 'id' | 'email' | 'role'>): string {
   return jwt.sign(
     {
       id: user.id,
       email: user.email,
+      role: user.role,
       jti: uuid(),
     },
     CONFIG.jwtSecret,
@@ -156,6 +163,19 @@ export function generateToken(user: Pick<AuthUser, 'id' | 'email'>): string {
       audience: CONFIG.jwtAudience,
     }
   );
+}
+
+/**
+ * Require the authenticated user to have the admin role.
+ * Must be used after verifyToken in the middleware chain.
+ */
+export function requireAdmin(req: AuthRequest, res: Response, next: NextFunction): void {
+  if (!req.user || req.user.role !== 'admin') {
+    res.status(403).json({ error: 'Admin access required' });
+    return;
+  }
+
+  next();
 }
 
 export function setSessionCookie(res: Response, token: string): void {

--- a/apps/gateway/src/auth/routes.ts
+++ b/apps/gateway/src/auth/routes.ts
@@ -2,7 +2,14 @@ import { Router, Request, Response } from 'express';
 import { v4 as uuid } from 'uuid';
 import { getDb } from '@goldilocks/data';
 import { hashPassword, verifyPassword } from './hash.js';
-import { generateToken, verifyToken, AuthRequest } from './middleware.js';
+import {
+  clearSessionCookie,
+  generateToken,
+  revokeToken,
+  setSessionCookie,
+  verifyToken,
+  AuthRequest,
+} from './middleware.js';
 
 const router = Router();
 
@@ -17,85 +24,105 @@ interface LoginBody {
   password: string;
 }
 
+interface UserRow {
+  id: string;
+  email: string;
+  password_hash: string;
+  display_name: string | null;
+  settings: string;
+  created_at?: number;
+}
+
+function formatUser(row: Pick<UserRow, 'id' | 'email' | 'display_name' | 'settings'> & { created_at?: number }) {
+  return {
+    id: row.id,
+    email: row.email,
+    displayName: row.display_name,
+    settings: JSON.parse(row.settings),
+    createdAt: row.created_at,
+  };
+}
+
 // POST /api/auth/register
 router.post('/register', async (req: Request<{}, {}, RegisterBody>, res: Response) => {
   const { email, password, displayName } = req.body;
-  
+
   if (!email || !password) {
     res.status(400).json({ error: 'Email and password are required' });
     return;
   }
 
-  // Basic email format validation (§5.13)
   const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
   if (!emailRegex.test(email)) {
     res.status(400).json({ error: 'Invalid email format' });
     return;
   }
-  
+
   if (password.length < 8) {
     res.status(400).json({ error: 'Password must be at least 8 characters' });
     return;
   }
-  
+
   const db = getDb();
-  
-  // Check if user exists
   const existing = db.prepare('SELECT id FROM users WHERE email = ?').get(email);
   if (existing) {
     res.status(409).json({ error: 'Email already registered' });
     return;
   }
-  
+
   const id = uuid();
   const passwordHash = await hashPassword(password);
-  
+
   db.prepare(`
     INSERT INTO users (id, email, password_hash, display_name)
     VALUES (?, ?, ?, ?)
   `).run(id, email, passwordHash, displayName ?? null);
-  
-  const user = { id, email, displayName: displayName ?? null };
+
   const token = generateToken({ id, email });
-  
-  res.status(201).json({ token, user });
+  setSessionCookie(res, token);
+
+  res.status(201).json({
+    user: {
+      id,
+      email,
+      displayName: displayName ?? null,
+      settings: {},
+    },
+  });
 });
 
 // POST /api/auth/login
 router.post('/login', async (req: Request<{}, {}, LoginBody>, res: Response) => {
   const { email, password } = req.body;
-  
+
   if (!email || !password) {
     res.status(400).json({ error: 'Email and password are required' });
     return;
   }
-  
+
   const db = getDb();
   const row = db.prepare(`
     SELECT id, email, password_hash, display_name, settings
     FROM users WHERE email = ?
-  `).get(email) as { id: string; email: string; password_hash: string; display_name: string | null; settings: string } | undefined;
-  
+  `).get(email) as UserRow | undefined;
+
   if (!row) {
     res.status(401).json({ error: 'Invalid email or password' });
     return;
   }
-  
+
   const valid = await verifyPassword(password, row.password_hash);
   if (!valid) {
     res.status(401).json({ error: 'Invalid email or password' });
     return;
   }
-  
+
   const token = generateToken({ id: row.id, email: row.email });
-  const user = {
-    id: row.id,
-    email: row.email,
-    displayName: row.display_name,
-    settings: JSON.parse(row.settings)
-  };
-  
-  res.json({ token, user });
+  setSessionCookie(res, token);
+
+  res.json({
+    user: formatUser(row),
+  });
 });
 
 // POST /api/auth/refresh
@@ -104,9 +131,22 @@ router.post('/refresh', verifyToken, (req: AuthRequest, res: Response) => {
     res.status(401).json({ error: 'Unauthorized' });
     return;
   }
-  
+
   const token = generateToken(req.user);
-  res.json({ token });
+  setSessionCookie(res, token);
+  res.json({ ok: true });
+});
+
+// POST /api/auth/logout
+router.post('/logout', verifyToken, (req: AuthRequest, res: Response) => {
+  if (!req.authClaims) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+
+  revokeToken({ jti: req.authClaims.jti, exp: req.authClaims.exp! });
+  clearSessionCookie(res);
+  res.json({ ok: true });
 });
 
 // GET /api/auth/me
@@ -115,27 +155,19 @@ router.get('/me', verifyToken, (req: AuthRequest, res: Response) => {
     res.status(401).json({ error: 'Unauthorized' });
     return;
   }
-  
+
   const db = getDb();
   const row = db.prepare(`
     SELECT id, email, display_name, settings, created_at
     FROM users WHERE id = ?
-  `).get(req.user.id) as { id: string; email: string; display_name: string | null; settings: string; created_at: number } | undefined;
-  
+  `).get(req.user.id) as UserRow | undefined;
+
   if (!row) {
     res.status(404).json({ error: 'User not found' });
     return;
   }
-  
-  res.json({
-    user: {
-      id: row.id,
-      email: row.email,
-      displayName: row.display_name,
-      settings: JSON.parse(row.settings),
-      createdAt: row.created_at
-    }
-  });
+
+  res.json({ user: formatUser(row) });
 });
 
 export default router;

--- a/apps/gateway/src/auth/routes.ts
+++ b/apps/gateway/src/auth/routes.ts
@@ -33,6 +33,17 @@ interface UserRow {
   created_at?: number;
 }
 
+interface FailedAuthAttemptRow {
+  email: string;
+  attempts: number;
+  locked_until: number | null;
+  last_attempt: number;
+}
+
+const AUTH_FAILURE_WINDOW_MS = 15 * 60 * 1000;
+const AUTH_FAILURE_THRESHOLD = 5;
+const BASE_LOCKOUT_MS = 15 * 60 * 1000;
+
 function formatUser(row: Pick<UserRow, 'id' | 'email' | 'display_name' | 'settings'> & { created_at?: number }) {
   return {
     id: row.id,
@@ -41,6 +52,73 @@ function formatUser(row: Pick<UserRow, 'id' | 'email' | 'display_name' | 'settin
     settings: JSON.parse(row.settings),
     createdAt: row.created_at,
   };
+}
+
+function getFailedAuthAttempt(email: string): FailedAuthAttemptRow | undefined {
+  return getDb().prepare(`
+    SELECT email, attempts, locked_until, last_attempt
+    FROM failed_auth_attempts
+    WHERE email = ?
+  `).get(email) as FailedAuthAttemptRow | undefined;
+}
+
+function clearFailedAuthAttempts(email: string): void {
+  getDb().prepare('DELETE FROM failed_auth_attempts WHERE email = ?').run(email);
+}
+
+function getLockoutDurationMs(attempts: number): number {
+  const cycle = Math.max(1, Math.floor(attempts / AUTH_FAILURE_THRESHOLD));
+  return BASE_LOCKOUT_MS * (2 ** (cycle - 1));
+}
+
+function getLockoutMessage(lockedUntil: number): string {
+  const remainingMinutes = Math.max(1, Math.ceil((lockedUntil - Date.now()) / 60_000));
+  return `Account temporarily locked. Try again in ${remainingMinutes} minute${remainingMinutes === 1 ? '' : 's'}.`;
+}
+
+function recordFailedLogin(email: string): { lockedUntil: number | null } {
+  const db = getDb();
+  const now = Date.now();
+  const existing = getFailedAuthAttempt(email);
+
+  const shouldContinueFailureCycle = Boolean(
+    existing && (
+      existing.attempts >= AUTH_FAILURE_THRESHOLD
+      || now - existing.last_attempt <= AUTH_FAILURE_WINDOW_MS
+    )
+  );
+
+  const attempts = shouldContinueFailureCycle
+    ? (existing?.attempts ?? 0) + 1
+    : 1;
+
+  const lockedUntil = attempts % AUTH_FAILURE_THRESHOLD === 0
+    ? now + getLockoutDurationMs(attempts)
+    : null;
+
+  db.prepare(`
+    INSERT INTO failed_auth_attempts (email, attempts, locked_until, last_attempt)
+    VALUES (?, ?, ?, ?)
+    ON CONFLICT(email) DO UPDATE SET
+      attempts = excluded.attempts,
+      locked_until = excluded.locked_until,
+      last_attempt = excluded.last_attempt
+  `).run(email, attempts, lockedUntil, now);
+
+  return { lockedUntil };
+}
+
+function getActiveLockout(email: string): FailedAuthAttemptRow | null {
+  const attempt = getFailedAuthAttempt(email);
+  if (!attempt?.locked_until) {
+    return null;
+  }
+
+  if (attempt.locked_until <= Date.now()) {
+    return null;
+  }
+
+  return attempt;
 }
 
 // POST /api/auth/register
@@ -100,6 +178,12 @@ router.post('/login', async (req: Request<{}, {}, LoginBody>, res: Response) => 
     return;
   }
 
+  const activeLockout = getActiveLockout(email);
+  if (activeLockout?.locked_until) {
+    res.status(429).json({ error: getLockoutMessage(activeLockout.locked_until) });
+    return;
+  }
+
   const db = getDb();
   const row = db.prepare(`
     SELECT id, email, password_hash, display_name, settings
@@ -107,15 +191,29 @@ router.post('/login', async (req: Request<{}, {}, LoginBody>, res: Response) => 
   `).get(email) as UserRow | undefined;
 
   if (!row) {
+    const failure = recordFailedLogin(email);
+    if (failure.lockedUntil) {
+      res.status(429).json({ error: getLockoutMessage(failure.lockedUntil) });
+      return;
+    }
+
     res.status(401).json({ error: 'Invalid email or password' });
     return;
   }
 
   const valid = await verifyPassword(password, row.password_hash);
   if (!valid) {
+    const failure = recordFailedLogin(email);
+    if (failure.lockedUntil) {
+      res.status(429).json({ error: getLockoutMessage(failure.lockedUntil) });
+      return;
+    }
+
     res.status(401).json({ error: 'Invalid email or password' });
     return;
   }
+
+  clearFailedAuthAttempts(email);
 
   const token = generateToken({ id: row.id, email: row.email });
   setSessionCookie(res, token);

--- a/apps/gateway/src/auth/routes.ts
+++ b/apps/gateway/src/auth/routes.ts
@@ -10,6 +10,8 @@ import {
   verifyToken,
   AuthRequest,
 } from './middleware.js';
+import { CONFIG } from '@goldilocks/config';
+import { audit, pruneExpiredLockouts } from '../logging/audit-logger.js';
 
 const router = Router();
 
@@ -30,6 +32,7 @@ interface UserRow {
   password_hash: string;
   display_name: string | null;
   settings: string;
+  role: string;
   created_at?: number;
 }
 
@@ -44,12 +47,13 @@ const AUTH_FAILURE_WINDOW_MS = 15 * 60 * 1000;
 const AUTH_FAILURE_THRESHOLD = 5;
 const BASE_LOCKOUT_MS = 15 * 60 * 1000;
 
-function formatUser(row: Pick<UserRow, 'id' | 'email' | 'display_name' | 'settings'> & { created_at?: number }) {
+function formatUser(row: Pick<UserRow, 'id' | 'email' | 'display_name' | 'settings' | 'role'> & { created_at?: number }) {
   return {
     id: row.id,
     email: row.email,
     displayName: row.display_name,
     settings: JSON.parse(row.settings),
+    role: row.role,
     createdAt: row.created_at,
   };
 }
@@ -150,14 +154,17 @@ router.post('/register', async (req: Request<{}, {}, RegisterBody>, res: Respons
 
   const id = uuid();
   const passwordHash = await hashPassword(password);
+  const role = CONFIG.adminEmails.includes(email.toLowerCase()) ? 'admin' : 'user';
 
   db.prepare(`
-    INSERT INTO users (id, email, password_hash, display_name)
-    VALUES (?, ?, ?, ?)
-  `).run(id, email, passwordHash, displayName ?? null);
+    INSERT INTO users (id, email, password_hash, display_name, role)
+    VALUES (?, ?, ?, ?, ?)
+  `).run(id, email, passwordHash, displayName ?? null, role);
 
-  const token = generateToken({ id, email });
+  const token = generateToken({ id, email, role });
   setSessionCookie(res, token);
+
+  audit('auth.register.success', req, { userId: id, userAgent: req.headers['user-agent'] });
 
   res.status(201).json({
     user: {
@@ -165,6 +172,7 @@ router.post('/register', async (req: Request<{}, {}, RegisterBody>, res: Respons
       email,
       displayName: displayName ?? null,
       settings: {},
+      role,
     },
   });
 });
@@ -186,7 +194,7 @@ router.post('/login', async (req: Request<{}, {}, LoginBody>, res: Response) => 
 
   const db = getDb();
   const row = db.prepare(`
-    SELECT id, email, password_hash, display_name, settings
+    SELECT id, email, password_hash, display_name, settings, role
     FROM users WHERE email = ?
   `).get(email) as UserRow | undefined;
 
@@ -197,6 +205,7 @@ router.post('/login', async (req: Request<{}, {}, LoginBody>, res: Response) => 
       return;
     }
 
+    audit('auth.login.failure', req, { attemptedEmail: email, userAgent: req.headers['user-agent'] });
     res.status(401).json({ error: 'Invalid email or password' });
     return;
   }
@@ -209,14 +218,24 @@ router.post('/login', async (req: Request<{}, {}, LoginBody>, res: Response) => 
       return;
     }
 
+    audit('auth.login.failure', req, { attemptedEmail: email, userAgent: req.headers['user-agent'] });
     res.status(401).json({ error: 'Invalid email or password' });
     return;
   }
 
   clearFailedAuthAttempts(email);
+  pruneExpiredLockouts(db);
 
-  const token = generateToken({ id: row.id, email: row.email });
+  // Auto-promote if email is in ADMIN_EMAILS and role hasn't been updated yet
+  const effectiveRole = (row.role === 'user' && CONFIG.adminEmails.includes(row.email.toLowerCase())) ? 'admin' : (row.role as 'user' | 'admin');
+  if (effectiveRole !== row.role) {
+    getDb().prepare('UPDATE users SET role = ? WHERE id = ?').run(effectiveRole, row.id);
+  }
+
+  const token = generateToken({ id: row.id, email: row.email, role: effectiveRole });
   setSessionCookie(res, token);
+
+  audit('auth.login.success', req, { userId: row.id, userAgent: req.headers['user-agent'] });
 
   res.json({
     user: formatUser(row),
@@ -244,6 +263,7 @@ router.post('/logout', verifyToken, (req: AuthRequest, res: Response) => {
 
   revokeToken({ jti: req.authClaims.jti, exp: req.authClaims.exp! });
   clearSessionCookie(res);
+  audit('auth.logout', req, { userId: req.user.id, userAgent: req.headers['user-agent'] });
   res.json({ ok: true });
 });
 
@@ -256,7 +276,7 @@ router.get('/me', verifyToken, (req: AuthRequest, res: Response) => {
 
   const db = getDb();
   const row = db.prepare(`
-    SELECT id, email, display_name, settings, created_at
+    SELECT id, email, display_name, settings, created_at, role
     FROM users WHERE id = ?
   `).get(req.user.id) as UserRow | undefined;
 

--- a/apps/gateway/src/conversations/routes.ts
+++ b/apps/gateway/src/conversations/routes.ts
@@ -194,7 +194,7 @@ router.delete('/:id', async (req: AuthRequest, res: Response) => {
     try {
       const response = await agentServiceFetch('/internal/sessions/delete', {
         method: 'POST',
-        userId: req.user.id,
+        userToken: req.authToken!,
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ sessionPath: row.pi_session_id }),
       });

--- a/apps/gateway/src/files/routes.ts
+++ b/apps/gateway/src/files/routes.ts
@@ -1,24 +1,32 @@
 /**
- * File routes -- workspace file operations via k8s exec into the user's pod.
+ * File routes -- workspace file operations via the user's pod-backed home directory.
  *
- * Files live on the user's PVC at /home/node/.
- * All operations exec into the pod to read/write the PVC.
+ * Files live on the user's mounted home at /home/node in the pod, backed by a host
+ * path managed by the pod manager. Read/raw/move/delete still use pod exec, while
+ * list/search/write now operate directly on the host-mounted path to avoid any shell
+ * interpolation with user-controlled input.
  *
  * Note: These routes are scoped per user (via auth), not per conversation.
  *
  * Route order matters (Express matches first):
- *   1. GET /          -- list (static)
- *   2. POST /upload   -- upload (static)
- *   3. POST /move     -- move (static)
- *   4. GET /<path>/raw -- raw download (specific, before catch-all)
- *   5. GET /<path>     -- read file (regex catch-all, also used for PUT/DELETE)
+ *   1. GET /           -- list (static)
+ *   2. POST /upload    -- upload (static)
+ *   3. POST /move      -- move (static)
+ *   4. POST /mkdir     -- mkdir (static)
+ *   5. GET /<path>/raw -- raw download (specific, before catch-all)
+ *   6. GET /<path>     -- read file (regex catch-all, also used for PUT/DELETE)
  */
 
+import { promises as fs } from 'fs';
+import { dirname, relative, resolve, sep } from 'path';
 import { Router, Response } from 'express';
-import { verifyToken, AuthRequest } from '../auth/middleware.js';
+import { CONFIG } from '@goldilocks/config';
 import { sessionManager } from '@goldilocks/runtime';
+import { verifyToken, AuthRequest } from '../auth/middleware.js';
 
 const router = Router();
+const SEARCH_LIMIT = 50;
+const SEARCH_MAX_DEPTH = 2;
 
 router.use(verifyToken);
 
@@ -33,12 +41,19 @@ interface FileEntry {
   modified?: number;
 }
 
+interface FlatFileEntry {
+  path: string;
+  type: 'file' | 'dir';
+  size: number;
+  modified: number;
+}
+
 async function execCommand(userId: string, command: string[]): Promise<string> {
   const podManager = sessionManager.getPodManager();
   await podManager.ensurePod(userId);
   const exec = await podManager.execInPod(userId, command);
 
-  return new Promise((resolve, reject) => {
+  return new Promise((resolveOutput, reject) => {
     const chunks: Buffer[] = [];
     const errChunks: Buffer[] = [];
     let settled = false;
@@ -54,7 +69,7 @@ async function execCommand(userId: string, command: string[]): Promise<string> {
       const output = Buffer.concat(chunks).toString();
       const errOutput = Buffer.concat(errChunks).toString().trim();
       if (errOutput) console.error(`exec stderr for user ${userId}: ${errOutput}`);
-      resolve(output);
+      resolveOutput(output);
     };
 
     exec.stdout.on('data', (chunk: Buffer) => chunks.push(chunk));
@@ -68,12 +83,6 @@ async function execCommand(userId: string, command: string[]): Promise<string> {
   });
 }
 
-async function writeFileViaExec(userId: string, path: string, base64Content: string): Promise<void> {
-  await execCommand(userId, [
-    'sh', '-c', `echo '${base64Content}' | base64 -d > /home/node/${path} && echo OK`
-  ]);
-}
-
 function sanitizePath(path: string): string {
   let decoded = path;
   try {
@@ -81,17 +90,111 @@ function sanitizePath(path: string): string {
   } catch {
     decoded = path;
   }
-  return decoded.replace(/\.\./g, '').replace(/^\/+/, '');
+  return decoded.replace(/\0/g, '').replace(/^\/+/, '');
 }
 
-function buildTree(
-  flat: { path: string; type: 'file' | 'dir'; size?: number; modified?: number }[]
-): FileEntry[] {
+function getUserHomeRoot(userId: string): string {
+  const podManager = sessionManager.getPodManager() as { getUserHomeHostPath?: (userId: string) => string };
+  if (typeof podManager.getUserHomeHostPath === 'function') {
+    return podManager.getUserHomeHostPath(userId);
+  }
+  if (CONFIG.nodeEnv === 'test') {
+    return resolve(CONFIG.workspaceRoot, userId);
+  }
+  throw new Error('PodManager does not expose a host user-home path');
+}
+
+function resolveUserPath(userId: string, path: string): { root: string; absolutePath: string; relativePath: string } {
+  const root = resolve(getUserHomeRoot(userId));
+  const sanitized = sanitizePath(path);
+  if (!sanitized) {
+    throw new Error('Invalid path');
+  }
+
+  const absolutePath = resolve(root, sanitized);
+  if (absolutePath !== root && !absolutePath.startsWith(`${root}${sep}`)) {
+    throw new Error('Invalid path');
+  }
+
+  return {
+    root,
+    absolutePath,
+    relativePath: relative(root, absolutePath),
+  };
+}
+
+async function ensureUserHome(userId: string): Promise<string> {
+  const root = getUserHomeRoot(userId);
+  await fs.mkdir(root, { recursive: true });
+  return root;
+}
+
+async function writeUserFile(userId: string, path: string, content: Buffer): Promise<void> {
+  const { absolutePath } = resolveUserPath(userId, path);
+  await fs.mkdir(dirname(absolutePath), { recursive: true });
+  await fs.writeFile(absolutePath, content);
+}
+
+async function collectWorkspaceEntries(
+  root: string,
+  options: { search?: string; maxDepth?: number; limit?: number } = {}
+): Promise<FlatFileEntry[]> {
+  await fs.mkdir(root, { recursive: true });
+
+  const results: FlatFileEntry[] = [];
+  const searchTerm = options.search?.toLowerCase();
+  const maxDepth = options.maxDepth ?? Number.POSITIVE_INFINITY;
+  const limit = options.limit ?? Number.POSITIVE_INFINITY;
+
+  const walk = async (currentRelativePath = ''): Promise<boolean> => {
+    const currentAbsolutePath = currentRelativePath ? resolve(root, currentRelativePath) : root;
+    const entries = await fs.readdir(currentAbsolutePath, { withFileTypes: true });
+    entries.sort((a, b) => a.name.localeCompare(b.name));
+
+    for (const entry of entries) {
+      if (entry.name.startsWith('.')) {
+        continue;
+      }
+
+      const entryRelativePath = currentRelativePath ? `${currentRelativePath}/${entry.name}` : entry.name;
+      const entryAbsolutePath = resolve(root, entryRelativePath);
+      const stats = await fs.stat(entryAbsolutePath);
+      const matchesSearch = !searchTerm || entry.name.toLowerCase().includes(searchTerm);
+
+      if (matchesSearch) {
+        results.push({
+          path: entryRelativePath,
+          type: entry.isDirectory() ? 'dir' : 'file',
+          size: stats.size,
+          modified: stats.mtimeMs,
+        });
+
+        if (results.length >= limit) {
+          return true;
+        }
+      }
+
+      const entryDepth = entryRelativePath.split('/').length;
+      if (entry.isDirectory() && entryDepth < maxDepth) {
+        const shouldStop = await walk(entryRelativePath);
+        if (shouldStop) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  };
+
+  await walk();
+  return results;
+}
+
+function buildTree(flat: FlatFileEntry[]): FileEntry[] {
   const root: FileEntry[] = [];
   const index: Map<string, FileEntry> = new Map();
 
   function ensureAncestors(path: string): FileEntry | null {
-    // Ensure all parent directories exist, return the direct parent entry
     const parts = path.split('/').filter(Boolean);
     let children: FileEntry[] = root;
     let currentPath = '';
@@ -114,7 +217,6 @@ function buildTree(
       children = dir.children!;
     }
 
-    // Return the parent's children array for the leaf entry
     return parts.length > 1 ? index.get(parts.slice(0, -1).join('/')) ?? null : null;
   }
 
@@ -140,7 +242,6 @@ function buildTree(
       if (parent?.children) {
         parent.children.push(fileEntry);
       } else {
-        // Shouldn't happen if the find output is consistent, but safe fallback
         root.push(fileEntry);
       }
     }
@@ -152,13 +253,17 @@ function buildTree(
       if (a.type === 'file' && b.type === 'dir') return 1;
       return a.name.localeCompare(b.name);
     });
-    for (const e of entries) {
-      if (e.children) sort(e.children);
+    for (const entry of entries) {
+      if (entry.children) sort(entry.children);
     }
   };
 
   sort(root);
   return root;
+}
+
+function invalidPathResponse(res: Response): void {
+  res.status(400).json({ error: 'Invalid path' });
 }
 
 // --- Route 1: GET / -- List workspace files as a tree ------------------------
@@ -169,38 +274,13 @@ router.get('/', async (req: AuthRequest, res: Response) => {
     return;
   }
 
-  const search = req.query.search as string | undefined;
+  const search = typeof req.query.search === 'string' ? req.query.search : undefined;
 
   try {
-    let output: string;
-
-    if (search) {
-      output = await execCommand(req.user.id, [
-        'sh', '-c',
-        `find /home/node -maxdepth 2 -name "*${search.replace(/'/g, "'\"'\"'")}*" ` +
-        `-not -path "/home/node/.*" -not -name ".*" | head -50 | while read f; do ` +
-        'printf "%s\t%s\t%s\t%s\n" "$f" "$(stat -c %s "$f" 2>/dev/null)" "$(stat -c %Y "$f" 2>/dev/null)" "$(stat -c %F "$f" 2>/dev/null)"; done'
-      ]);
-    } else {
-      output = await execCommand(req.user.id, [
-        'sh', '-c',
-        'find /home/node -not -path "/home/node" -not -path "/home/node/.*" -not -name ".*" | ' +
-        'while read f; do ' +
-        'printf "%s\t%s\t%s\t%s\n" "$f" "$(stat -c %s "$f" 2>/dev/null)" "$(stat -c %Y "$f" 2>/dev/null)" "$(stat -c %F "$f" 2>/dev/null)"; done'
-      ]);
-    }
-
-    const lines = output.split('\n').filter((l) => l.trim());
-
-    const flat = lines.map((line) => {
-      const [fullPath, size, mtime, type] = line.split('\t');
-      return {
-        path: fullPath.replace('/home/node/', ''),
-        type: (type?.trim() === 'directory' ? 'dir' : 'file') as 'file' | 'dir',
-        size: parseInt(size ?? '0', 10) || 0,
-        modified: (parseInt(mtime ?? '0', 10) || 0) * 1000,
-      };
-    });
+    const userHome = await ensureUserHome(req.user.id);
+    const flat = await collectWorkspaceEntries(userHome, search
+      ? { search, maxDepth: SEARCH_MAX_DEPTH, limit: SEARCH_LIMIT }
+      : undefined);
 
     res.json({ entries: buildTree(flat) });
   } catch (err) {
@@ -224,7 +304,7 @@ router.post('/upload', async (req: AuthRequest, res: Response) => {
     return;
   }
 
-  const safeName = filename.replace(/[^a-zA-Z0-9._-]/g, '_').replace(/\/+/g, '_');
+  const safeName = filename.replace(/[^a-zA-Z0-9._/-]/g, '_').replace(/\/+/g, '/');
   if (safeName.startsWith('.') || safeName.includes('..')) {
     res.status(400).json({ error: 'Invalid filename' });
     return;
@@ -232,12 +312,14 @@ router.post('/upload', async (req: AuthRequest, res: Response) => {
 
   try {
     const fileBuffer = Buffer.from(content, 'base64');
-    const base64Content = fileBuffer.toString('base64');
+    await writeUserFile(req.user.id, safeName, fileBuffer);
 
-    await writeFileViaExec(req.user.id, safeName, base64Content);
-
-    res.status(201).json({ ok: true, name: safeName, path: safeName, size: fileBuffer.length });
+    res.status(201).json({ ok: true, name: safeName.split('/').pop() ?? safeName, path: safeName, size: fileBuffer.length });
   } catch (err) {
+    if (err instanceof Error && err.message === 'Invalid path') {
+      invalidPathResponse(res);
+      return;
+    }
     console.error('Error uploading file:', err);
     res.status(500).json({ error: 'Failed to upload file' });
   }
@@ -258,8 +340,15 @@ router.post('/move', async (req: AuthRequest, res: Response) => {
     return;
   }
 
-  const safeFrom = sanitizePath(from);
-  const safeTo = sanitizePath(to);
+  let safeFrom: string;
+  let safeTo: string;
+  try {
+    safeFrom = resolveUserPath(req.user.id, from).relativePath;
+    safeTo = resolveUserPath(req.user.id, to).relativePath;
+  } catch {
+    invalidPathResponse(res);
+    return;
+  }
 
   if (!safeFrom || !safeTo || safeFrom === safeTo) {
     res.status(400).json({ error: 'Invalid from or to path' });
@@ -295,7 +384,14 @@ router.post('/mkdir', async (req: AuthRequest, res: Response) => {
     return;
   }
 
-  const safePath = sanitizePath(dirPath);
+  let safePath: string;
+  try {
+    safePath = resolveUserPath(req.user.id, dirPath).relativePath;
+  } catch {
+    invalidPathResponse(res);
+    return;
+  }
+
   if (!safePath || safePath.startsWith('.')) {
     res.status(400).json({ error: 'Invalid path' });
     return;
@@ -310,7 +406,7 @@ router.post('/mkdir', async (req: AuthRequest, res: Response) => {
   }
 });
 
-// --- Route 4: GET /<path>/raw -- Raw binary download --------------------------
+// --- Route 4: GET /<path>/raw -- Raw binary download -------------------------
 
 router.get(/^\/(.+)\/raw$/, async (req: AuthRequest, res: Response) => {
   if (!req.user) {
@@ -318,10 +414,11 @@ router.get(/^\/(.+)\/raw$/, async (req: AuthRequest, res: Response) => {
     return;
   }
 
-  const safePath = sanitizePath(req.params[0] as string);
-
-  if (!safePath) {
-    res.status(400).json({ error: 'Path is required' });
+  let safePath: string;
+  try {
+    safePath = resolveUserPath(req.user.id, req.params[0] as string).relativePath;
+  } catch {
+    invalidPathResponse(res);
     return;
   }
 
@@ -333,9 +430,9 @@ router.get(/^\/(.+)\/raw$/, async (req: AuthRequest, res: Response) => {
     const chunks: Buffer[] = [];
     exec.stdout.on('data', (chunk: Buffer) => chunks.push(chunk));
 
-    await new Promise<void>((resolve) => {
-      exec.stdout.on('end', () => { exec.close(); resolve(); });
-      setTimeout(() => { exec.close(); resolve(); }, 30_000);
+    await new Promise<void>((resolvePromise) => {
+      exec.stdout.on('end', () => { exec.close(); resolvePromise(); });
+      setTimeout(() => { exec.close(); resolvePromise(); }, 30_000);
     });
 
     const buffer = Buffer.concat(chunks);
@@ -350,7 +447,7 @@ router.get(/^\/(.+)\/raw$/, async (req: AuthRequest, res: Response) => {
   }
 });
 
-// --- Route 5: GET /<path> -- Read file content --------------------------------
+// --- Route 5: GET /<path> -- Read file content -------------------------------
 
 router.get(/^\/(.+)$/, async (req: AuthRequest, res: Response) => {
   if (!req.user) {
@@ -363,10 +460,11 @@ router.get(/^\/(.+)$/, async (req: AuthRequest, res: Response) => {
     return;
   }
 
-  const safePath = sanitizePath(req.params[0] as string);
-
-  if (!safePath) {
-    res.status(400).json({ error: 'Path is required' });
+  let safePath: string;
+  try {
+    safePath = resolveUserPath(req.user.id, req.params[0] as string).relativePath;
+  } catch {
+    invalidPathResponse(res);
     return;
   }
 
@@ -379,7 +477,7 @@ router.get(/^\/(.+)$/, async (req: AuthRequest, res: Response) => {
   }
 });
 
-// --- Route 6: PUT /<path> -- Create or update a file -------------------------
+// --- Route 6: PUT /<path> -- Create or update a file ------------------------
 
 router.put(/^\/(.+)$/, async (req: AuthRequest, res: Response) => {
   if (!req.user) {
@@ -387,10 +485,11 @@ router.put(/^\/(.+)$/, async (req: AuthRequest, res: Response) => {
     return;
   }
 
-  const safePath = sanitizePath(req.params[0] as string);
-
-  if (!safePath) {
-    res.status(400).json({ error: 'Path is required' });
+  let safePath: string;
+  try {
+    safePath = resolveUserPath(req.user.id, req.params[0] as string).relativePath;
+  } catch {
+    invalidPathResponse(res);
     return;
   }
 
@@ -402,23 +501,20 @@ router.put(/^\/(.+)$/, async (req: AuthRequest, res: Response) => {
 
   try {
     const fileBuffer = Buffer.from(content, 'utf8');
-    const base64Content = fileBuffer.toString('base64');
-
-    const parentDir = safePath.split('/').slice(0, -1).join('/');
-    if (parentDir) {
-      await execCommand(req.user.id, ['mkdir', '-p', `/home/node/${parentDir}`]);
-    }
-
-    await writeFileViaExec(req.user.id, safePath, base64Content);
+    await writeUserFile(req.user.id, safePath, fileBuffer);
 
     res.status(200).json({ ok: true, path: safePath, size: fileBuffer.length });
   } catch (err) {
+    if (err instanceof Error && err.message === 'Invalid path') {
+      invalidPathResponse(res);
+      return;
+    }
     console.error('Error writing file:', err);
     res.status(500).json({ error: 'Failed to write file' });
   }
 });
 
-// --- Route 7: DELETE /<path> ------------------------------------------------
+// --- Route 7: DELETE /<path> -------------------------------------------------
 
 router.delete(/^\/(.+)$/, async (req: AuthRequest, res: Response) => {
   if (!req.user) {
@@ -426,10 +522,11 @@ router.delete(/^\/(.+)$/, async (req: AuthRequest, res: Response) => {
     return;
   }
 
-  const safePath = sanitizePath(req.params[0] as string);
-
-  if (!safePath) {
-    res.status(400).json({ error: 'Path is required' });
+  let safePath: string;
+  try {
+    safePath = resolveUserPath(req.user.id, req.params[0] as string).relativePath;
+  } catch {
+    invalidPathResponse(res);
     return;
   }
 

--- a/apps/gateway/src/files/routes.ts
+++ b/apps/gateway/src/files/routes.ts
@@ -27,6 +27,19 @@ import { verifyToken, AuthRequest } from '../auth/middleware.js';
 const router = Router();
 const SEARCH_LIMIT = 50;
 const SEARCH_MAX_DEPTH = 2;
+const ALLOWED_UPLOAD_CONTENT_TYPES = new Set([
+  'application/json',
+  'application/octet-stream',
+  'application/pdf',
+  'application/xml',
+  'application/yaml',
+  'application/x-yaml',
+  'text/csv',
+  'text/html',
+  'text/markdown',
+  'text/plain',
+  'text/xml',
+]);
 
 router.use(verifyToken);
 
@@ -266,6 +279,17 @@ function invalidPathResponse(res: Response): void {
   res.status(400).json({ error: 'Invalid path' });
 }
 
+function isAllowedUploadContentType(contentType: string): boolean {
+  const normalized = contentType.split(';')[0]?.trim().toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+
+  return normalized.startsWith('text/')
+    || normalized.startsWith('image/')
+    || ALLOWED_UPLOAD_CONTENT_TYPES.has(normalized);
+}
+
 // --- Route 1: GET / -- List workspace files as a tree ------------------------
 
 router.get('/', async (req: AuthRequest, res: Response) => {
@@ -297,10 +321,15 @@ router.post('/upload', async (req: AuthRequest, res: Response) => {
     return;
   }
 
-  const { filename, content } = req.body as { filename?: string; content?: string };
+  const { filename, content, contentType } = req.body as { filename?: string; content?: string; contentType?: string };
 
-  if (!filename || !content) {
-    res.status(400).json({ error: 'filename and content are required' });
+  if (!filename || !content || !contentType) {
+    res.status(400).json({ error: 'filename, content, and contentType are required' });
+    return;
+  }
+
+  if (!isAllowedUploadContentType(contentType)) {
+    res.status(400).json({ error: `Unsupported content type: ${contentType}` });
     return;
   }
 
@@ -314,7 +343,13 @@ router.post('/upload', async (req: AuthRequest, res: Response) => {
     const fileBuffer = Buffer.from(content, 'base64');
     await writeUserFile(req.user.id, safeName, fileBuffer);
 
-    res.status(201).json({ ok: true, name: safeName.split('/').pop() ?? safeName, path: safeName, size: fileBuffer.length });
+    res.status(201).json({
+      ok: true,
+      name: safeName.split('/').pop() ?? safeName,
+      path: safeName,
+      size: fileBuffer.length,
+      contentType: contentType.split(';')[0]?.trim().toLowerCase(),
+    });
   } catch (err) {
     if (err instanceof Error && err.message === 'Invalid path') {
       invalidPathResponse(res);

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -18,6 +18,8 @@ import { runMigrations, closeDb } from '@goldilocks/data';
 import { setupWebSocket } from './agent/websocket.js';
 import { sessionManager } from '@goldilocks/runtime';
 
+CONFIG.validateRequiredSecrets();
+
 // Create app and HTTP server
 export const app = createApp();
 const server = createServer(app);

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -11,7 +11,6 @@
  */
 
 import { createServer } from 'http';
-import { WebSocketServer } from 'ws';
 import { createApp } from './app.js';
 import { CONFIG } from '@goldilocks/config';
 import { runMigrations, closeDb } from '@goldilocks/data';
@@ -25,8 +24,7 @@ export const app = createApp();
 const server = createServer(app);
 
 // WebSocket
-const wss = new WebSocketServer({ server, path: '/ws' });
-setupWebSocket(wss);
+const wss = setupWebSocket(server);
 
 // Graceful shutdown
 let shuttingDown = false;

--- a/apps/gateway/src/logging/audit-logger.ts
+++ b/apps/gateway/src/logging/audit-logger.ts
@@ -1,0 +1,97 @@
+/**
+ * Structured audit logger for security events.
+ *
+ * Writes JSON lines to stdout — the Kubernetes-native pattern where the container
+ * runtime captures stdout and a log shipper forwards to a centralized store.
+ * Each event is a single JSON object on one line.
+ */
+
+import { CONFIG } from '@goldilocks/config';
+
+export type AuditEventType =
+  | 'auth.login.success'
+  | 'auth.login.failure'
+  | 'auth.logout'
+  | 'auth.register.success'
+  | 'auth.register.failure'
+  | 'settings.api-key.store'
+  | 'settings.api-key.delete'
+  | 'settings.update'
+  | 'admin.action';
+
+interface AuditEvent {
+  ts: string;
+  event: AuditEventType;
+  userId?: string;
+  attemptedEmail?: string;
+  ip?: string;
+  userAgent?: string;
+  details?: Record<string, unknown>;
+}
+
+function formatTimestamp(ms: number): string {
+  return new Date(ms).toISOString();
+}
+
+function getClientIp(req: { ip?: string; headers: Record<string, string | undefined> }): string {
+  // Trust X-Forwarded-For only if behind a known proxy (single hop)
+  const forwarded = req.headers['x-forwarded-for'];
+  if (typeof forwarded === 'string' && CONFIG.isProd) {
+    return forwarded.split(',')[0].trim();
+  }
+  return req.ip ?? 'unknown';
+}
+
+/**
+ * Emit a structured audit event to stdout.
+ */
+export function audit(event: AuditEventType, req: { ip?: string; headers: Record<string, string | undefined> }, data?: {
+  userId?: string;
+  attemptedEmail?: string;
+  userAgent?: string;
+  details?: Record<string, unknown>;
+}): void {
+  const entry: AuditEvent = {
+    ts: formatTimestamp(Date.now()),
+    event,
+    ip: getClientIp(req),
+    ...data,
+  };
+
+  // Never log key values — only metadata
+  console.log(JSON.stringify(entry));
+}
+
+/**
+ * Prune expired entries from the failed_auth_attempts table.
+ * Called lazily during login attempts.
+ */
+export function pruneExpiredLockouts(db: { prepare: (sql: string) => { run: (...args: number[]) => void } }): void {
+  db.prepare('DELETE FROM failed_auth_attempts WHERE locked_until IS NOT NULL AND locked_until <= ?').run(Date.now());
+}
+
+/**
+ * Query accounts currently locked or near the lockout threshold.
+ * Useful for monitoring dashboards and alerting.
+ */
+export function getActiveLockouts(db: { prepare: (sql: string) => { all: (...args: number[]) => unknown[] } }): Array<{
+  email: string;
+  attempts: number;
+  lockedUntil: number | null;
+  lastAttempt: number;
+}> {
+  const rows = db.prepare(
+    `SELECT email, attempts, locked_until, last_attempt
+     FROM failed_auth_attempts
+     WHERE locked_until IS NOT NULL AND locked_until > ?
+        OR attempts >= 3
+     ORDER BY last_attempt DESC`
+  ).all(Date.now()) as Array<{ email: string; attempts: number; locked_until: number | null; last_attempt: number }>;
+
+  return rows.map((row) => ({
+    email: row.email,
+    attempts: row.attempts,
+    lockedUntil: row.locked_until,
+    lastAttempt: row.last_attempt,
+  }));
+}

--- a/apps/gateway/src/models/routes.ts
+++ b/apps/gateway/src/models/routes.ts
@@ -13,7 +13,7 @@ router.get('/', verifyToken, async (req: AuthRequest, res: Response) => {
   try {
     const response = await agentServiceFetch('/internal/models', {
       method: 'GET',
-      userId: req.user.id,
+      userToken: req.authToken!,
     });
     const json = await response.json();
     res.status(response.status).json(json);
@@ -32,7 +32,7 @@ router.post('/select', verifyToken, async (req: AuthRequest, res: Response) => {
   try {
     const response = await agentServiceFetch('/internal/models/select', {
       method: 'POST',
-      userId: req.user.id,
+      userToken: req.authToken!,
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(req.body ?? {}),
     });

--- a/apps/gateway/src/settings/routes.ts
+++ b/apps/gateway/src/settings/routes.ts
@@ -1,7 +1,7 @@
 import { Router, Response } from 'express';
 import { getDb } from '@goldilocks/data';
 import { verifyToken, AuthRequest } from '../auth/middleware.js';
-import { encrypt, decrypt } from '@goldilocks/config';
+import { encrypt } from '@goldilocks/config';
 import { getProviders, getModels } from '@mariozechner/pi-ai';
 
 const router = Router();
@@ -75,6 +75,152 @@ const GROUP_LABELS: Record<string, string> = {
   regional: 'Regional',
 };
 
+const ALLOWED_SETTING_KEYS = new Set(['defaultModel', 'defaultFunctional', 'workspaceViewer']);
+const ALLOWED_WORKSPACE_VIEWER_KEYS = new Set([
+  'monacoExtensions',
+  'imageViewerExtensions',
+  'imageBackground',
+  'imageFitMode',
+  'pdfDefaultZoom',
+  'monacoFontSize',
+  'monacoTabSize',
+  'monacoWordWrap',
+  'monacoLineNumbers',
+  'monacoMinimap',
+]);
+
+function normalizeExtension(value: string): string {
+  return value.trim().toLowerCase().replace(/^\./, '');
+}
+
+function normalizeExtensions(values: unknown): string[] {
+  if (!Array.isArray(values) || values.some((value) => typeof value !== 'string')) {
+    throw new Error('workspaceViewer extension lists must be string arrays');
+  }
+
+  return Array.from(new Set(values.map(normalizeExtension).filter(Boolean)));
+}
+
+function parseSettings(raw: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function validateWorkspaceViewerPatch(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('workspaceViewer must be an object');
+  }
+
+  const patch = value as Record<string, unknown>;
+  const normalized: Record<string, unknown> = {};
+
+  for (const key of Object.keys(patch)) {
+    if (!ALLOWED_WORKSPACE_VIEWER_KEYS.has(key)) {
+      throw new Error(`Unknown workspaceViewer setting: ${key}`);
+    }
+  }
+
+  if ('monacoExtensions' in patch) {
+    normalized.monacoExtensions = normalizeExtensions(patch.monacoExtensions);
+  }
+
+  if ('imageViewerExtensions' in patch) {
+    normalized.imageViewerExtensions = normalizeExtensions(patch.imageViewerExtensions);
+  }
+
+  if ('imageBackground' in patch) {
+    if (!['checkered', 'dark', 'light'].includes(String(patch.imageBackground))) {
+      throw new Error('workspaceViewer.imageBackground must be checkered, dark, or light');
+    }
+    normalized.imageBackground = patch.imageBackground;
+  }
+
+  if ('imageFitMode' in patch) {
+    if (!['contain', 'actual'].includes(String(patch.imageFitMode))) {
+      throw new Error('workspaceViewer.imageFitMode must be contain or actual');
+    }
+    normalized.imageFitMode = patch.imageFitMode;
+  }
+
+  if ('pdfDefaultZoom' in patch) {
+    if (![50, 75, 100, 125, 150, 200].includes(Number(patch.pdfDefaultZoom))) {
+      throw new Error('workspaceViewer.pdfDefaultZoom must be one of 50, 75, 100, 125, 150, or 200');
+    }
+    normalized.pdfDefaultZoom = Number(patch.pdfDefaultZoom);
+  }
+
+  if ('monacoFontSize' in patch) {
+    const value = Number(patch.monacoFontSize);
+    if (!Number.isFinite(value)) {
+      throw new Error('workspaceViewer.monacoFontSize must be a number');
+    }
+    normalized.monacoFontSize = Math.min(24, Math.max(10, Math.round(value)));
+  }
+
+  if ('monacoTabSize' in patch) {
+    if (![2, 4, 8].includes(Number(patch.monacoTabSize))) {
+      throw new Error('workspaceViewer.monacoTabSize must be 2, 4, or 8');
+    }
+    normalized.monacoTabSize = Number(patch.monacoTabSize);
+  }
+
+  for (const booleanKey of ['monacoWordWrap', 'monacoLineNumbers', 'monacoMinimap'] as const) {
+    if (booleanKey in patch) {
+      if (typeof patch[booleanKey] !== 'boolean') {
+        throw new Error(`workspaceViewer.${booleanKey} must be a boolean`);
+      }
+      normalized[booleanKey] = patch[booleanKey];
+    }
+  }
+
+  return normalized;
+}
+
+function validateSettingsPatch(updates: unknown, current: Record<string, unknown>): Record<string, unknown> {
+  if (!updates || typeof updates !== 'object' || Array.isArray(updates)) {
+    throw new Error('Request body must be a JSON object');
+  }
+
+  const patch = updates as Record<string, unknown>;
+  const normalized: Record<string, unknown> = {};
+
+  for (const key of Object.keys(patch)) {
+    if (!ALLOWED_SETTING_KEYS.has(key)) {
+      throw new Error(`Unknown setting: ${key}`);
+    }
+  }
+
+  if ('defaultModel' in patch) {
+    if (patch.defaultModel !== null && typeof patch.defaultModel !== 'string') {
+      throw new Error('defaultModel must be a string or null');
+    }
+    normalized.defaultModel = patch.defaultModel;
+  }
+
+  if ('defaultFunctional' in patch) {
+    if (patch.defaultFunctional !== 'PBE' && patch.defaultFunctional !== 'PBEsol') {
+      throw new Error('defaultFunctional must be PBE or PBEsol');
+    }
+    normalized.defaultFunctional = patch.defaultFunctional;
+  }
+
+  if ('workspaceViewer' in patch) {
+    const currentViewer = current.workspaceViewer && typeof current.workspaceViewer === 'object' && !Array.isArray(current.workspaceViewer)
+      ? current.workspaceViewer as Record<string, unknown>
+      : {};
+    normalized.workspaceViewer = {
+      ...currentViewer,
+      ...validateWorkspaceViewerPatch(patch.workspaceViewer),
+    };
+  }
+
+  return normalized;
+}
+
 // GET /api/settings/providers - Returns all built-in Pi providers with metadata
 router.get('/providers', (_req: AuthRequest, res: Response) => {
   const providers = getProviders()
@@ -109,19 +255,13 @@ router.get('/', (req: AuthRequest, res: Response) => {
     return;
   }
 
-  res.json({ settings: JSON.parse(row.settings) });
+  res.json({ settings: parseSettings(row.settings) });
 });
 
 // PATCH /api/settings - Update user settings (merge with existing)
 router.patch('/', (req: AuthRequest, res: Response) => {
   if (!req.user) {
     res.status(401).json({ error: 'Unauthorized' });
-    return;
-  }
-
-  const updates = req.body;
-  if (!updates || typeof updates !== 'object' || Array.isArray(updates)) {
-    res.status(400).json({ error: 'Request body must be a JSON object' });
     return;
   }
 
@@ -135,15 +275,24 @@ router.patch('/', (req: AuthRequest, res: Response) => {
     return;
   }
 
-  const current = JSON.parse(row.settings);
-  const merged = { ...current, ...updates };
+  const current = parseSettings(row.settings);
 
-  db.prepare('UPDATE users SET settings = ? WHERE id = ?').run(
-    JSON.stringify(merged),
-    req.user.id,
-  );
+  try {
+    const normalizedPatch = validateSettingsPatch(req.body, current);
+    const merged = {
+      ...current,
+      ...normalizedPatch,
+    };
 
-  res.json({ settings: merged });
+    db.prepare('UPDATE users SET settings = ? WHERE id = ?').run(
+      JSON.stringify(merged),
+      req.user.id,
+    );
+
+    res.json({ settings: merged });
+  } catch (err) {
+    res.status(400).json({ error: err instanceof Error ? err.message : 'Invalid settings payload' });
+  }
 });
 
 // GET /api/settings/api-keys - List API key metadata (NOT the actual keys)

--- a/apps/gateway/src/settings/routes.ts
+++ b/apps/gateway/src/settings/routes.ts
@@ -1,8 +1,9 @@
 import { Router, Response } from 'express';
 import { getDb } from '@goldilocks/data';
 import { verifyToken, AuthRequest } from '../auth/middleware.js';
-import { encrypt } from '@goldilocks/config';
+import { encrypt, decrypt, generateKeySalt } from '@goldilocks/config';
 import { getProviders, getModels } from '@mariozechner/pi-ai';
+import { audit } from '../logging/audit-logger.js';
 
 const router = Router();
 
@@ -289,6 +290,7 @@ router.patch('/', (req: AuthRequest, res: Response) => {
       req.user.id,
     );
 
+    audit('settings.update', req, { userId: req.user.id, userAgent: req.headers['user-agent'], details: { keys: Object.keys(normalizedPatch) } });
     res.json({ settings: merged });
   } catch (err) {
     res.status(400).json({ error: err instanceof Error ? err.message : 'Invalid settings payload' });
@@ -340,15 +342,25 @@ router.put('/api-key', (req: AuthRequest, res: Response) => {
     return;
   }
 
-  const encryptedKey = encrypt(key);
+  const db = getDb();
+
+  // Ensure user has a key_salt for per-user key derivation
+  let keySalt = (db.prepare('SELECT key_salt FROM users WHERE id = ?').get(req.user.id) as { key_salt: string | null } | undefined)?.key_salt;
+  if (!keySalt) {
+    keySalt = generateKeySalt();
+    db.prepare('UPDATE users SET key_salt = ? WHERE id = ?').run(keySalt, req.user.id);
+  }
+
+  const { encrypted, keyVersion } = encrypt(key, keySalt);
   const now = Date.now();
 
-  const db = getDb();
   db.prepare(
-    `INSERT INTO api_keys (user_id, provider, encrypted_key, created_at)
-     VALUES (?, ?, ?, ?)
-     ON CONFLICT(user_id, provider) DO UPDATE SET encrypted_key = excluded.encrypted_key, created_at = excluded.created_at`,
-  ).run(req.user.id, provider, encryptedKey, now);
+    `INSERT INTO api_keys (user_id, provider, encrypted_key, key_version, created_at)
+     VALUES (?, ?, ?, ?, ?)
+     ON CONFLICT(user_id, provider) DO UPDATE SET encrypted_key = excluded.encrypted_key, key_version = excluded.key_version, created_at = excluded.created_at`,
+  ).run(req.user.id, provider, encrypted, keyVersion, now);
+
+  audit('settings.api-key.store', req, { userId: req.user.id, userAgent: req.headers['user-agent'], details: { provider } });
 
   res.json({ ok: true, provider, createdAt: now });
 });
@@ -379,6 +391,7 @@ router.delete('/api-key/:provider', (req: AuthRequest, res: Response) => {
     return;
   }
 
+  audit('settings.api-key.delete', req, { userId: req.user.id, userAgent: req.headers['user-agent'], details: { provider } });
   res.json({ ok: true });
 });
 

--- a/apps/gateway/src/settings/routes.ts
+++ b/apps/gateway/src/settings/routes.ts
@@ -2,7 +2,7 @@ import { Router, Response } from 'express';
 import { getDb } from '@goldilocks/data';
 import { verifyToken, AuthRequest } from '../auth/middleware.js';
 import { encrypt, decrypt, generateKeySalt } from '@goldilocks/config';
-import { getProviders, getModels } from '@mariozechner/pi-ai';
+import { getProviders, getModels } from '@earendil-works/pi-ai';
 import { audit } from '../logging/audit-logger.js';
 
 const router = Router();

--- a/apps/gateway/test/api/auth.test.ts
+++ b/apps/gateway/test/api/auth.test.ts
@@ -1,4 +1,6 @@
+import jwt from 'jsonwebtoken';
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { CONFIG } from '@goldilocks/config';
 import { createTestServer, type TestUser } from './helpers/test-server.js';
 
 describe('Auth', () => {
@@ -16,7 +18,7 @@ describe('Auth', () => {
 
   // ── Register ───────────────────────────────────────────────────────────────
 
-  it('registers a new user and returns a JWT', async () => {
+  it('registers a new user and sets a session cookie', async () => {
     const email = `new-${Date.now()}@example.com`;
     const res = await fetch(`${server.baseUrl}/api/auth/register`, {
       method: 'POST',
@@ -25,9 +27,25 @@ describe('Auth', () => {
     });
 
     expect(res.status).toBe(201);
-    const json = await res.json() as { token: string; user: { id: string; email: string } };
-    expect(json.token).toBeTruthy();
+    const json = await res.json() as { user: { id: string; email: string } };
+    const setCookie = res.headers.get('set-cookie') ?? '';
+
+    expect(setCookie).toContain(`${CONFIG.sessionCookieName}=`);
+    expect(setCookie).toContain('HttpOnly');
+    expect(setCookie).toContain('SameSite=Strict');
     expect(json.user.email).toBe(email);
+  });
+
+  it('issues JWT claims with iss, aud, and jti', async () => {
+    const claims = jwt.verify(user.token, CONFIG.jwtSecret, {
+      issuer: CONFIG.jwtIssuer,
+      audience: CONFIG.jwtAudience,
+    }) as jwt.JwtPayload & { id: string; email: string; jti: string };
+
+    expect(claims.id).toBe(user.userId);
+    expect(claims.email).toBe(user.email);
+    expect(typeof claims.jti).toBe('string');
+    expect(claims.jti.length).toBeGreaterThan(10);
   });
 
   it('rejects duplicate email', async () => {
@@ -52,7 +70,7 @@ describe('Auth', () => {
 
   // ── Login ─────────────────────────────────────────────────────────────────
 
-  it('logs in with valid credentials and returns a JWT', async () => {
+  it('logs in with valid credentials and sets a session cookie', async () => {
     const res = await fetch(`${server.baseUrl}/api/auth/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -60,8 +78,10 @@ describe('Auth', () => {
     });
 
     expect(res.status).toBe(200);
-    const json = await res.json() as { token: string; user: { id: string; email: string } };
-    expect(json.token).toBeTruthy();
+    const json = await res.json() as { user: { id: string; email: string } };
+    const setCookie = res.headers.get('set-cookie') ?? '';
+
+    expect(setCookie).toContain(`${CONFIG.sessionCookieName}=`);
     expect(json.user.id).toBe(user.userId);
   });
 
@@ -89,9 +109,9 @@ describe('Auth', () => {
 
   // ── GET /me ───────────────────────────────────────────────────────────────
 
-  it('returns the current user profile', async () => {
+  it('returns the current user profile via the session cookie', async () => {
     const res = await fetch(`${server.baseUrl}/api/auth/me`, {
-      headers: { authorization: server.authHeader(user) },
+      headers: { cookie: server.cookieHeader(user) },
     });
 
     expect(res.status).toBe(200);
@@ -99,6 +119,16 @@ describe('Auth', () => {
     expect(json.user.id).toBe(user.userId);
     expect(json.user.email).toBe(user.email);
     expect(json.user.displayName).toBe('Test User');
+  });
+
+  it('still accepts a bearer token during migration fallback', async () => {
+    const res = await fetch(`${server.baseUrl}/api/auth/me`, {
+      headers: { authorization: server.authHeader(user) },
+    });
+
+    expect(res.status).toBe(200);
+    const json = await res.json() as { user: { id: string } };
+    expect(json.user.id).toBe(user.userId);
   });
 
   it('rejects requests without a token', async () => {
@@ -118,5 +148,48 @@ describe('Auth', () => {
       headers: { authorization: 'NotBearer token' },
     });
     expect(res.status).toBe(401);
+  });
+
+  it('refreshes the cookie without returning the raw token', async () => {
+    const res = await fetch(`${server.baseUrl}/api/auth/refresh`, {
+      method: 'POST',
+      headers: { cookie: server.cookieHeader(user) },
+    });
+
+    expect(res.status).toBe(200);
+    const json = await res.json() as { ok: boolean; token?: string };
+    expect(json.ok).toBe(true);
+    expect(json).not.toHaveProperty('token');
+    expect(res.headers.get('set-cookie')).toContain(`${CONFIG.sessionCookieName}=`);
+  });
+
+  it('logout revokes the current token and clears the cookie', async () => {
+    const loginRes = await fetch(`${server.baseUrl}/api/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: user.email, password: 'TestPassword123!' }),
+    });
+    const loginCookie = (loginRes.headers.get('set-cookie') ?? '').split(';')[0];
+    const loginToken = decodeURIComponent(loginCookie.split('=').slice(1).join('='));
+
+    const logoutRes = await fetch(`${server.baseUrl}/api/auth/logout`, {
+      method: 'POST',
+      headers: { cookie: loginCookie },
+    });
+
+    expect(logoutRes.status).toBe(200);
+    const clearedCookie = logoutRes.headers.get('set-cookie') ?? '';
+    expect(clearedCookie).toContain(`${CONFIG.sessionCookieName}=`);
+    expect(clearedCookie.toLowerCase()).toContain('expires=thu, 01 jan 1970');
+
+    const revokedCookieRes = await fetch(`${server.baseUrl}/api/auth/me`, {
+      headers: { cookie: loginCookie },
+    });
+    expect(revokedCookieRes.status).toBe(401);
+
+    const revokedHeaderRes = await fetch(`${server.baseUrl}/api/auth/me`, {
+      headers: { authorization: `Bearer ${loginToken}` },
+    });
+    expect(revokedHeaderRes.status).toBe(401);
   });
 });

--- a/apps/gateway/test/api/auth.test.ts
+++ b/apps/gateway/test/api/auth.test.ts
@@ -1,195 +1,410 @@
 import jwt from 'jsonwebtoken';
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect } from 'vitest';
+import { getDb } from '@goldilocks/data';
 import { CONFIG } from '@goldilocks/config';
-import { createTestServer, type TestUser } from './helpers/test-server.js';
+import { createTestServer } from './helpers/test-server.js';
 
-describe('Auth', () => {
-  let server: Awaited<ReturnType<typeof createTestServer>>;
-  let user: TestUser;
+async function createSessionFixture(overrides?: Partial<{ email: string; password: string; displayName: string }>) {
+  const server = await createTestServer();
+  const user = await server.registerUser(overrides);
+  return { server, user };
+}
 
-  beforeAll(async () => {
-    server = await createTestServer();
-    user = await server.registerUser();
-  });
-
-  afterAll(async () => {
-    await server.stop();
-  });
-
-  // ── Register ───────────────────────────────────────────────────────────────
-
+describe('Auth registration', () => {
   it('registers a new user and sets a session cookie', async () => {
-    const email = `new-${Date.now()}@example.com`;
-    const res = await fetch(`${server.baseUrl}/api/auth/register`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email, password: 'Password123!', displayName: 'New User' }),
-    });
+    const server = await createTestServer();
 
-    expect(res.status).toBe(201);
-    const json = await res.json() as { user: { id: string; email: string } };
-    const setCookie = res.headers.get('set-cookie') ?? '';
+    try {
+      const email = `new-${Date.now()}@example.com`;
+      const res = await fetch(`${server.baseUrl}/api/auth/register`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password: 'Password123!', displayName: 'New User' }),
+      });
 
-    expect(setCookie).toContain(`${CONFIG.sessionCookieName}=`);
-    expect(setCookie).toContain('HttpOnly');
-    expect(setCookie).toContain('SameSite=Strict');
-    expect(json.user.email).toBe(email);
-  });
+      expect(res.status).toBe(201);
+      const json = await res.json() as { user: { id: string; email: string } };
+      const setCookie = res.headers.get('set-cookie') ?? '';
 
-  it('issues JWT claims with iss, aud, and jti', async () => {
-    const claims = jwt.verify(user.token, CONFIG.jwtSecret, {
-      issuer: CONFIG.jwtIssuer,
-      audience: CONFIG.jwtAudience,
-    }) as jwt.JwtPayload & { id: string; email: string; jti: string };
-
-    expect(claims.id).toBe(user.userId);
-    expect(claims.email).toBe(user.email);
-    expect(typeof claims.jti).toBe('string');
-    expect(claims.jti.length).toBeGreaterThan(10);
-  });
+      expect(setCookie).toContain(`${CONFIG.sessionCookieName}=`);
+      expect(setCookie).toContain('HttpOnly');
+      expect(setCookie).toContain('SameSite=Strict');
+      expect(json.user.email).toBe(email);
+    } finally {
+      await server.stop();
+    }
+  }, 15000);
 
   it('rejects duplicate email', async () => {
-    const res = await fetch(`${server.baseUrl}/api/auth/register`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email: user.email, password: 'Password123!', displayName: 'Duplicate' }),
-    });
+    const server = await createTestServer();
 
-    expect(res.status).toBe(409);
+    try {
+      const user = await server.registerUser();
+      const res = await fetch(`${server.baseUrl}/api/auth/register`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: user.email, password: 'Password123!', displayName: 'Duplicate' }),
+      });
+
+      expect(res.status).toBe(409);
+    } finally {
+      await server.stop();
+    }
   });
 
   it('rejects registration with missing fields', async () => {
-    const res = await fetch(`${server.baseUrl}/api/auth/register`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email: 'no-password@example.com' }),
-    });
+    const server = await createTestServer();
 
-    expect(res.status).toBe(400);
+    try {
+      const res = await fetch(`${server.baseUrl}/api/auth/register`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: 'no-password@example.com' }),
+      });
+
+      expect(res.status).toBe(400);
+    } finally {
+      await server.stop();
+    }
   });
 
-  // ── Login ─────────────────────────────────────────────────────────────────
+  it('rate limits registrations to three per hour per IP', async () => {
+    const server = await createTestServer();
+
+    try {
+      for (let i = 0; i < 3; i++) {
+        const res = await fetch(`${server.baseUrl}/api/auth/register`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            email: `rate-limit-${i}-${Date.now()}@example.com`,
+            password: 'Password123!',
+            displayName: 'Rate Limited',
+          }),
+        });
+
+        expect(res.status).toBe(201);
+      }
+
+      const blocked = await fetch(`${server.baseUrl}/api/auth/register`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email: `rate-limit-blocked-${Date.now()}@example.com`,
+          password: 'Password123!',
+          displayName: 'Blocked',
+        }),
+      });
+
+      expect(blocked.status).toBe(429);
+      const json = await blocked.json() as { error: string };
+      expect(json.error).toMatch(/registration/i);
+    } finally {
+      await server.stop();
+    }
+  });
+});
+
+describe('Auth session and lockout flow', () => {
+  it('issues JWT claims with iss, aud, and jti', async () => {
+    const { server, user } = await createSessionFixture();
+
+    try {
+      const claims = jwt.verify(user.token, CONFIG.jwtSecret, {
+        issuer: CONFIG.jwtIssuer,
+        audience: CONFIG.jwtAudience,
+      }) as jwt.JwtPayload & { id: string; email: string; jti: string };
+
+      expect(claims.id).toBe(user.userId);
+      expect(claims.email).toBe(user.email);
+      expect(typeof claims.jti).toBe('string');
+      expect(claims.jti.length).toBeGreaterThan(10);
+    } finally {
+      await server.stop();
+    }
+  });
 
   it('logs in with valid credentials and sets a session cookie', async () => {
-    const res = await fetch(`${server.baseUrl}/api/auth/login`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email: user.email, password: 'TestPassword123!' }),
-    });
+    const { server, user } = await createSessionFixture();
 
-    expect(res.status).toBe(200);
-    const json = await res.json() as { user: { id: string; email: string } };
-    const setCookie = res.headers.get('set-cookie') ?? '';
+    try {
+      const res = await fetch(`${server.baseUrl}/api/auth/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: user.email, password: 'TestPassword123!' }),
+      });
 
-    expect(setCookie).toContain(`${CONFIG.sessionCookieName}=`);
-    expect(json.user.id).toBe(user.userId);
+      expect(res.status).toBe(200);
+      const json = await res.json() as { user: { id: string; email: string } };
+      const setCookie = res.headers.get('set-cookie') ?? '';
+
+      expect(setCookie).toContain(`${CONFIG.sessionCookieName}=`);
+      expect(json.user.id).toBe(user.userId);
+    } finally {
+      await server.stop();
+    }
+  }, 10000);
+
+  it('clears failed auth attempts after a successful login', async () => {
+    const { server, user } = await createSessionFixture();
+
+    try {
+      await fetch(`${server.baseUrl}/api/auth/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: user.email, password: 'WrongPassword!' }),
+      });
+
+      const beforeSuccess = getDb().prepare('SELECT attempts FROM failed_auth_attempts WHERE email = ?').get(user.email) as { attempts: number } | undefined;
+      expect(beforeSuccess?.attempts).toBe(1);
+
+      const success = await fetch(`${server.baseUrl}/api/auth/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: user.email, password: 'TestPassword123!' }),
+      });
+
+      expect(success.status).toBe(200);
+
+      const afterSuccess = getDb().prepare('SELECT attempts FROM failed_auth_attempts WHERE email = ?').get(user.email);
+      expect(afterSuccess).toBeUndefined();
+    } finally {
+      await server.stop();
+    }
+  }, 10000);
+
+  it('locks an account after five failed attempts and rejects further attempts immediately', async () => {
+    const { server } = await createSessionFixture();
+    const email = `lockout-${Date.now()}@example.com`;
+    await server.registerUser({ email, password: 'Lockout123!' });
+
+    try {
+      for (let i = 1; i <= 4; i++) {
+        const res = await fetch(`${server.baseUrl}/api/auth/login`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email, password: 'wrong-password' }),
+        });
+
+        expect(res.status).toBe(401);
+      }
+
+      const locked = await fetch(`${server.baseUrl}/api/auth/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password: 'wrong-password' }),
+      });
+
+      expect(locked.status).toBe(429);
+      const lockedJson = await locked.json() as { error: string };
+      expect(lockedJson.error).toMatch(/temporarily locked/i);
+
+      const lockedAgain = await fetch(`${server.baseUrl}/api/auth/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password: 'Lockout123!' }),
+      });
+
+      expect(lockedAgain.status).toBe(429);
+    } finally {
+      await server.stop();
+    }
+  }, 10000);
+
+  it('doubles the lockout duration on the next failure cycle', async () => {
+    const { server } = await createSessionFixture();
+    const email = `backoff-${Date.now()}@example.com`;
+    await server.registerUser({ email, password: 'Backoff123!' });
+
+    try {
+      for (let i = 0; i < 5; i++) {
+        await fetch(`${server.baseUrl}/api/auth/login`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email, password: 'wrong-password' }),
+        });
+      }
+
+      const firstCycle = getDb().prepare(
+        'SELECT attempts, locked_until FROM failed_auth_attempts WHERE email = ?'
+      ).get(email) as { attempts: number; locked_until: number };
+
+      getDb().prepare(
+        'UPDATE failed_auth_attempts SET locked_until = ?, last_attempt = ? WHERE email = ?'
+      ).run(Date.now() - 1, Date.now(), email);
+
+      for (let i = 0; i < 5; i++) {
+        await fetch(`${server.baseUrl}/api/auth/login`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email, password: 'still-wrong' }),
+        });
+      }
+
+      const secondCycle = getDb().prepare(
+        'SELECT attempts, locked_until FROM failed_auth_attempts WHERE email = ?'
+      ).get(email) as { attempts: number; locked_until: number };
+
+      expect(firstCycle.attempts).toBe(5);
+      expect(secondCycle.attempts).toBe(10);
+
+      const firstDuration = firstCycle.locked_until - Date.now();
+      const secondDuration = secondCycle.locked_until - Date.now();
+      expect(secondDuration).toBeGreaterThan(firstDuration + (10 * 60 * 1000));
+    } finally {
+      await server.stop();
+    }
+  }, 15000);
+
+  it('rejects unknown email until lockout triggers', async () => {
+    const { server } = await createSessionFixture();
+
+    try {
+      for (let i = 0; i < 4; i++) {
+        const res = await fetch(`${server.baseUrl}/api/auth/login`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email: 'nobody@example.com', password: 'Anything!' }),
+        });
+
+        expect(res.status).toBe(401);
+      }
+
+      const locked = await fetch(`${server.baseUrl}/api/auth/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: 'nobody@example.com', password: 'Anything!' }),
+      });
+
+      expect(locked.status).toBe(429);
+    } finally {
+      await server.stop();
+    }
   });
-
-  it('rejects invalid password', async () => {
-    const res = await fetch(`${server.baseUrl}/api/auth/login`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email: user.email, password: 'WrongPassword!' }),
-    });
-
-    expect(res.status).toBe(401);
-    const json = await res.json() as { error: string };
-    expect(json.error.toLowerCase()).toMatch(/password|credential/i);
-  });
-
-  it('rejects unknown email', async () => {
-    const res = await fetch(`${server.baseUrl}/api/auth/login`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email: 'nobody@example.com', password: 'Anything!' }),
-    });
-
-    expect(res.status).toBe(401);
-  });
-
-  // ── GET /me ───────────────────────────────────────────────────────────────
 
   it('returns the current user profile via the session cookie', async () => {
-    const res = await fetch(`${server.baseUrl}/api/auth/me`, {
-      headers: { cookie: server.cookieHeader(user) },
-    });
+    const { server, user } = await createSessionFixture();
 
-    expect(res.status).toBe(200);
-    const json = await res.json() as { user: { id: string; email: string; displayName: string } };
-    expect(json.user.id).toBe(user.userId);
-    expect(json.user.email).toBe(user.email);
-    expect(json.user.displayName).toBe('Test User');
+    try {
+      const res = await fetch(`${server.baseUrl}/api/auth/me`, {
+        headers: { cookie: server.cookieHeader(user) },
+      });
+
+      expect(res.status).toBe(200);
+      const json = await res.json() as { user: { id: string; email: string; displayName: string } };
+      expect(json.user.id).toBe(user.userId);
+      expect(json.user.email).toBe(user.email);
+      expect(json.user.displayName).toBe('Test User');
+    } finally {
+      await server.stop();
+    }
   });
 
   it('still accepts a bearer token during migration fallback', async () => {
-    const res = await fetch(`${server.baseUrl}/api/auth/me`, {
-      headers: { authorization: server.authHeader(user) },
-    });
+    const { server, user } = await createSessionFixture();
 
-    expect(res.status).toBe(200);
-    const json = await res.json() as { user: { id: string } };
-    expect(json.user.id).toBe(user.userId);
+    try {
+      const res = await fetch(`${server.baseUrl}/api/auth/me`, {
+        headers: { authorization: server.authHeader(user) },
+      });
+
+      expect(res.status).toBe(200);
+      const json = await res.json() as { user: { id: string } };
+      expect(json.user.id).toBe(user.userId);
+    } finally {
+      await server.stop();
+    }
   });
 
   it('rejects requests without a token', async () => {
-    const res = await fetch(`${server.baseUrl}/api/auth/me`);
-    expect(res.status).toBe(401);
+    const { server } = await createSessionFixture();
+
+    try {
+      const res = await fetch(`${server.baseUrl}/api/auth/me`);
+      expect(res.status).toBe(401);
+    } finally {
+      await server.stop();
+    }
   });
 
   it('rejects requests with an invalid token', async () => {
-    const res = await fetch(`${server.baseUrl}/api/auth/me`, {
-      headers: { authorization: 'Bearer not-a-real-token' },
-    });
-    expect(res.status).toBe(401);
+    const { server } = await createSessionFixture();
+
+    try {
+      const res = await fetch(`${server.baseUrl}/api/auth/me`, {
+        headers: { authorization: 'Bearer not-a-real-token' },
+      });
+      expect(res.status).toBe(401);
+    } finally {
+      await server.stop();
+    }
   });
 
   it('rejects requests with a malformed Authorization header', async () => {
-    const res = await fetch(`${server.baseUrl}/api/auth/me`, {
-      headers: { authorization: 'NotBearer token' },
-    });
-    expect(res.status).toBe(401);
+    const { server } = await createSessionFixture();
+
+    try {
+      const res = await fetch(`${server.baseUrl}/api/auth/me`, {
+        headers: { authorization: 'NotBearer token' },
+      });
+      expect(res.status).toBe(401);
+    } finally {
+      await server.stop();
+    }
   });
 
   it('refreshes the cookie without returning the raw token', async () => {
-    const res = await fetch(`${server.baseUrl}/api/auth/refresh`, {
-      method: 'POST',
-      headers: { cookie: server.cookieHeader(user) },
-    });
+    const { server, user } = await createSessionFixture();
 
-    expect(res.status).toBe(200);
-    const json = await res.json() as { ok: boolean; token?: string };
-    expect(json.ok).toBe(true);
-    expect(json).not.toHaveProperty('token');
-    expect(res.headers.get('set-cookie')).toContain(`${CONFIG.sessionCookieName}=`);
+    try {
+      const res = await fetch(`${server.baseUrl}/api/auth/refresh`, {
+        method: 'POST',
+        headers: { cookie: server.cookieHeader(user) },
+      });
+
+      expect(res.status).toBe(200);
+      const json = await res.json() as { ok: boolean; token?: string };
+      expect(json.ok).toBe(true);
+      expect(json).not.toHaveProperty('token');
+      expect(res.headers.get('set-cookie')).toContain(`${CONFIG.sessionCookieName}=`);
+    } finally {
+      await server.stop();
+    }
   });
 
   it('logout revokes the current token and clears the cookie', async () => {
-    const loginRes = await fetch(`${server.baseUrl}/api/auth/login`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email: user.email, password: 'TestPassword123!' }),
-    });
-    const loginCookie = (loginRes.headers.get('set-cookie') ?? '').split(';')[0];
-    const loginToken = decodeURIComponent(loginCookie.split('=').slice(1).join('='));
+    const { server, user } = await createSessionFixture();
 
-    const logoutRes = await fetch(`${server.baseUrl}/api/auth/logout`, {
-      method: 'POST',
-      headers: { cookie: loginCookie },
-    });
+    try {
+      const loginRes = await fetch(`${server.baseUrl}/api/auth/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: user.email, password: 'TestPassword123!' }),
+      });
+      const loginCookie = (loginRes.headers.get('set-cookie') ?? '').split(';')[0];
+      const loginToken = decodeURIComponent(loginCookie.split('=').slice(1).join('='));
 
-    expect(logoutRes.status).toBe(200);
-    const clearedCookie = logoutRes.headers.get('set-cookie') ?? '';
-    expect(clearedCookie).toContain(`${CONFIG.sessionCookieName}=`);
-    expect(clearedCookie.toLowerCase()).toContain('expires=thu, 01 jan 1970');
+      const logoutRes = await fetch(`${server.baseUrl}/api/auth/logout`, {
+        method: 'POST',
+        headers: { cookie: loginCookie },
+      });
 
-    const revokedCookieRes = await fetch(`${server.baseUrl}/api/auth/me`, {
-      headers: { cookie: loginCookie },
-    });
-    expect(revokedCookieRes.status).toBe(401);
+      expect(logoutRes.status).toBe(200);
+      const clearedCookie = logoutRes.headers.get('set-cookie') ?? '';
+      expect(clearedCookie).toContain(`${CONFIG.sessionCookieName}=`);
+      expect(clearedCookie.toLowerCase()).toContain('expires=thu, 01 jan 1970');
 
-    const revokedHeaderRes = await fetch(`${server.baseUrl}/api/auth/me`, {
-      headers: { authorization: `Bearer ${loginToken}` },
-    });
-    expect(revokedHeaderRes.status).toBe(401);
+      const revokedCookieRes = await fetch(`${server.baseUrl}/api/auth/me`, {
+        headers: { cookie: loginCookie },
+      });
+      expect(revokedCookieRes.status).toBe(401);
+
+      const revokedHeaderRes = await fetch(`${server.baseUrl}/api/auth/me`, {
+        headers: { authorization: `Bearer ${loginToken}` },
+      });
+      expect(revokedHeaderRes.status).toBe(401);
+    } finally {
+      await server.stop();
+    }
   });
 });

--- a/apps/gateway/test/api/files.test.ts
+++ b/apps/gateway/test/api/files.test.ts
@@ -200,7 +200,7 @@ describe('Files', () => {
 
     const res = await fetch(`${server.baseUrl}/api/files/upload`, {
       method: 'POST', headers: authHeaders(user),
-      body: JSON.stringify({ filename: 'uploaded.txt', content: b64 }),
+      body: JSON.stringify({ filename: 'uploaded.txt', content: b64, contentType: 'text/plain' }),
     });
 
     expect(res.status).toBe(201);
@@ -216,7 +216,7 @@ describe('Files', () => {
 
     const uploadRes = await fetch(`${server.baseUrl}/api/files/upload`, {
       method: 'POST', headers: authHeaders(user),
-      body: JSON.stringify({ filename, content: Buffer.from(content).toString('base64') }),
+      body: JSON.stringify({ filename, content: Buffer.from(content).toString('base64'), contentType: 'text/plain' }),
     });
     expect(uploadRes.status).toBe(201);
 
@@ -231,7 +231,7 @@ describe('Files', () => {
   it('rejects upload without filename', async () => {
     const res = await fetch(`${server.baseUrl}/api/files/upload`, {
       method: 'POST', headers: authHeaders(user),
-      body: JSON.stringify({ content: Buffer.from('hello').toString('base64') }),
+      body: JSON.stringify({ content: Buffer.from('hello').toString('base64'), contentType: 'text/plain' }),
     });
 
     expect(res.status).toBe(400);
@@ -246,10 +246,60 @@ describe('Files', () => {
     expect(res.status).toBe(400);
   });
 
+  it('rejects upload without contentType', async () => {
+    const res = await fetch(`${server.baseUrl}/api/files/upload`, {
+      method: 'POST', headers: authHeaders(user),
+      body: JSON.stringify({ filename: 'no-type.txt', content: Buffer.from('hello').toString('base64') }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects upload with a disallowed content type', async () => {
+    const res = await fetch(`${server.baseUrl}/api/files/upload`, {
+      method: 'POST', headers: authHeaders(user),
+      body: JSON.stringify({
+        filename: 'malware.exe',
+        content: Buffer.from('definitely-not-safe').toString('base64'),
+        contentType: 'application/x-msdownload',
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    const json = await res.json() as { error: string };
+    expect(json.error).toMatch(/unsupported content type/i);
+  });
+
+  it('rejects oversized file payloads with 413', async () => {
+    const tinyLimitServer = await createTestServer({ env: { FILE_UPLOAD_MAX_BYTES: '64' } });
+    const limitedUser = await tinyLimitServer.registerUser();
+
+    try {
+      const res = await fetch(`${tinyLimitServer.baseUrl}/api/files/upload`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          authorization: tinyLimitServer.authHeader(limitedUser),
+        },
+        body: JSON.stringify({
+          filename: 'too-large.txt',
+          content: Buffer.from('x'.repeat(256)).toString('base64'),
+          contentType: 'text/plain',
+        }),
+      });
+
+      expect(res.status).toBe(413);
+      const json = await res.json() as { error: string };
+      expect(json.error).toMatch(/exceeds limit/i);
+    } finally {
+      await tinyLimitServer.stop();
+    }
+  });
+
   it('rejects hidden filenames', async () => {
     const res = await fetch(`${server.baseUrl}/api/files/upload`, {
       method: 'POST', headers: authHeaders(user),
-      body: JSON.stringify({ filename: '.env', content: Buffer.from('SECRET=123').toString('base64') }),
+      body: JSON.stringify({ filename: '.env', content: Buffer.from('SECRET=123').toString('base64'), contentType: 'text/plain' }),
     });
 
     expect(res.status).toBe(400);
@@ -383,7 +433,7 @@ describe('Files', () => {
     // Upload via the upload route (base64, preserves raw bytes)
     await fetch(`${server.baseUrl}/api/files/upload`, {
       method: 'POST', headers: authHeaders(user),
-      body: JSON.stringify({ filename: path, content: originalBytes.toString('base64') }),
+      body: JSON.stringify({ filename: path, content: originalBytes.toString('base64'), contentType: 'application/octet-stream' }),
     });
 
     const res = await fetch(`${server.baseUrl}/api/files/${path}/raw`, {

--- a/apps/gateway/test/api/files.test.ts
+++ b/apps/gateway/test/api/files.test.ts
@@ -37,7 +37,6 @@ describe('Files', () => {
   });
 
   it('searches files by query — only matching files appear', async () => {
-    // Write two files with different names
     await fetch(`${server.baseUrl}/api/files/searchable-foo.txt`, {
       method: 'PUT', headers: authHeaders(user),
       body: JSON.stringify({ content: 'foo content' }),
@@ -53,12 +52,27 @@ describe('Files', () => {
 
     expect(res.status).toBe(200);
     const json = await res.json() as { entries: { name: string; path: string }[] };
-    // Should find only the -foo file, not the -bar file
     const paths = json.entries.map(e => e.path ?? e.name);
     const hasFoo = paths.some(p => p.includes('foo'));
     const hasBar = paths.some(p => p.includes('bar'));
     expect(hasFoo).toBe(true);
     expect(hasBar).toBe(false);
+  });
+
+  it('treats shell metacharacters in search literally', async () => {
+    await fetch(`${server.baseUrl}/api/files/literal-$(whoami).txt`, {
+      method: 'PUT', headers: authHeaders(user),
+      body: JSON.stringify({ content: 'literal search target' }),
+    });
+
+    const res = await fetch(`${server.baseUrl}/api/files?search=$(whoami)`, {
+      headers: { authorization: server.authHeader(user) },
+    });
+
+    expect(res.status).toBe(200);
+    const json = await res.json() as { entries: { path: string }[] };
+    const paths = json.entries.map((entry) => entry.path);
+    expect(paths).toContain('literal-$(whoami).txt');
   });
 
   // ── PUT /api/files/:path — create file ──────────────────────────────────
@@ -125,6 +139,24 @@ describe('Files', () => {
     expect(json.content).toBe('File content here');
   });
 
+  it('writes shell metacharacters literally via PUT', async () => {
+    const path = `literal-put-${Date.now()}.txt`;
+    const content = '$(whoami); `uname -a` | cat && echo haunted';
+
+    const writeRes = await fetch(`${server.baseUrl}/api/files/${path}`, {
+      method: 'PUT', headers: authHeaders(user),
+      body: JSON.stringify({ content }),
+    });
+    expect(writeRes.status).toBe(200);
+
+    const readRes = await fetch(`${server.baseUrl}/api/files/${path}`, {
+      headers: { authorization: server.authHeader(user) },
+    });
+    expect(readRes.status).toBe(200);
+    const json = await readRes.json() as { content: string };
+    expect(json.content).toBe(content);
+  });
+
   it('returns 404 for a non-existent file', async () => {
     const res = await fetch(`${server.baseUrl}/api/files/nonexistent-file.xyz`, {
       headers: { authorization: server.authHeader(user) },
@@ -176,6 +208,24 @@ describe('Files', () => {
     expect(json.ok).toBe(true);
     expect(json.name).toBe('uploaded.txt');
     expect(json.size).toBe(content.length);
+  });
+
+  it('uploads shell metacharacters literally', async () => {
+    const filename = 'uploaded-literal.txt';
+    const content = '$(whoami) ; `pwd` | cat';
+
+    const uploadRes = await fetch(`${server.baseUrl}/api/files/upload`, {
+      method: 'POST', headers: authHeaders(user),
+      body: JSON.stringify({ filename, content: Buffer.from(content).toString('base64') }),
+    });
+    expect(uploadRes.status).toBe(201);
+
+    const readRes = await fetch(`${server.baseUrl}/api/files/${filename}`, {
+      headers: { authorization: server.authHeader(user) },
+    });
+    expect(readRes.status).toBe(200);
+    const json = await readRes.json() as { content: string };
+    expect(json.content).toBe(content);
   });
 
   it('rejects upload without filename', async () => {

--- a/apps/gateway/test/api/helpers/test-server.ts
+++ b/apps/gateway/test/api/helpers/test-server.ts
@@ -237,11 +237,18 @@ async function createTestServer(): Promise<TestServer> {
   process.env.WORKSPACE_ROOT = workspaceRoot;
   process.env.JWT_SECRET = 'test-jwt-not-for-prod';
   process.env.ENCRYPTION_KEY = 'test-encryption-key-32bytes!!';
+  process.env.AGENT_SERVICE_SHARED_SECRET = 'test-agent-shared-secret';
   process.env.NODE_ENV = 'test';
 
   const { sessionManager } = await import('@goldilocks/runtime');
 
   const stubPodManager = {
+    getUserHomeHostPath(userId: string) {
+      const base = userDir(workspaceRoot, userId);
+      mkdirSync(base, { recursive: true });
+      return base;
+    },
+
     async ensurePod(_userId: string) { /* no-op */ },
 
     async execInPod(userId: string, command: string[]) {

--- a/apps/gateway/test/api/helpers/test-server.ts
+++ b/apps/gateway/test/api/helpers/test-server.ts
@@ -40,6 +40,10 @@ export interface TestServer {
   cookieHeader: (user: TestUser) => string;
 }
 
+interface TestServerOptions {
+  env?: Record<string, string | undefined>;
+}
+
 /**
  * Create a stream that emits `data` events with Buffer content, then `end`.
  * If content is null, emits an `error` event instead (simulates command failure
@@ -229,19 +233,30 @@ function parseCommand(command: string[]): {
   return { op: 'unknown' };
 }
 
-async function createTestServer(): Promise<TestServer> {
+async function createTestServer(options: TestServerOptions = {}): Promise<TestServer> {
   const testId = randomUUID().slice(0, 8);
   const dataDir = `/tmp/goldilocks-test-${testId}`;
   const workspaceRoot = `${dataDir}/workspaces`;
   mkdirSync(workspaceRoot, { recursive: true });
 
-  process.env.DATA_DIR = dataDir;
-  process.env.WORKSPACE_ROOT = workspaceRoot;
-  process.env.JWT_SECRET = 'test-jwt-not-for-prod';
-  process.env.ENCRYPTION_KEY = 'test-encryption-key-32bytes!!';
-  process.env.AGENT_SERVICE_SHARED_SECRET = 'test-agent-shared-secret';
-  process.env.NODE_ENV = 'test';
-  process.env.FRONTEND_URL = 'http://localhost:5173';
+  const nextEnv: Record<string, string> = {
+    DATA_DIR: dataDir,
+    WORKSPACE_ROOT: workspaceRoot,
+    JWT_SECRET: 'test-jwt-not-for-prod',
+    ENCRYPTION_KEY: 'test-encryption-key-32bytes!!',
+    AGENT_SERVICE_SHARED_SECRET: 'test-agent-shared-secret',
+    NODE_ENV: 'test',
+    FRONTEND_URL: 'http://localhost:5173',
+    ...Object.fromEntries(
+      Object.entries(options.env ?? {}).filter(([, value]): value is string => value !== undefined)
+    ),
+  };
+
+  const previousEnv = new Map<string, string | undefined>();
+  for (const [key, value] of Object.entries(nextEnv)) {
+    previousEnv.set(key, process.env[key]);
+    process.env[key] = value;
+  }
 
   const { sessionManager } = await import('@goldilocks/runtime');
 
@@ -407,6 +422,13 @@ async function createTestServer(): Promise<TestServer> {
             server.close(async () => {
               const { closeDb } = await import('@goldilocks/data');
               closeDb();
+              for (const [key, value] of previousEnv.entries()) {
+                if (value === undefined) {
+                  delete process.env[key];
+                } else {
+                  process.env[key] = value;
+                }
+              }
               try { rmSync(dataDir, { recursive: true, force: true }); } catch { /* ignore */ }
               res();
             });

--- a/apps/gateway/test/api/helpers/test-server.ts
+++ b/apps/gateway/test/api/helpers/test-server.ts
@@ -26,6 +26,7 @@ import { EventEmitter } from 'events';
 
 export interface TestUser {
   token: string;
+  cookie: string;
   userId: string;
   email: string;
 }
@@ -36,6 +37,7 @@ export interface TestServer {
   stop: () => Promise<void>;
   registerUser: (overrides?: Partial<{ email: string; password: string; displayName: string }>) => Promise<TestUser>;
   authHeader: (user: TestUser) => string;
+  cookieHeader: (user: TestUser) => string;
 }
 
 /**
@@ -239,6 +241,7 @@ async function createTestServer(): Promise<TestServer> {
   process.env.ENCRYPTION_KEY = 'test-encryption-key-32bytes!!';
   process.env.AGENT_SERVICE_SHARED_SECRET = 'test-agent-shared-secret';
   process.env.NODE_ENV = 'test';
+  process.env.FRONTEND_URL = 'http://localhost:5173';
 
   const { sessionManager } = await import('@goldilocks/runtime');
 
@@ -425,12 +428,23 @@ async function createTestServer(): Promise<TestServer> {
             throw new Error(`Register failed: ${res.status} ${await res.text()}`);
           }
 
-          const json = await res.json() as { token: string; user: { id: string } };
-          return { token: json.token, userId: json.user.id, email };
+          const json = await res.json() as { user: { id: string } };
+          const setCookie = res.headers.get('set-cookie');
+          if (!setCookie) {
+            throw new Error('Register response missing session cookie');
+          }
+
+          const cookie = setCookie.split(';')[0];
+          const cookieValue = cookie.split('=').slice(1).join('=');
+          return { token: decodeURIComponent(cookieValue), cookie, userId: json.user.id, email };
         },
 
         authHeader(user: TestUser) {
           return `Bearer ${user.token}`;
+        },
+
+        cookieHeader(user: TestUser) {
+          return user.cookie;
         },
       });
     });

--- a/apps/gateway/test/api/settings.test.ts
+++ b/apps/gateway/test/api/settings.test.ts
@@ -85,6 +85,36 @@ describe('Settings', () => {
     expect(json.settings.workspaceViewer.monacoExtensions).toContain('ts');
   });
 
+  it('rejects unknown settings keys', async () => {
+    const res = await fetch(`${server.baseUrl}/api/settings`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        authorization: server.authHeader(user),
+      },
+      body: JSON.stringify({ isAdmin: true }),
+    });
+
+    expect(res.status).toBe(400);
+    const json = await res.json() as { error: string };
+    expect(json.error).toContain('Unknown setting: isAdmin');
+  });
+
+  it('rejects invalid workspaceViewer payloads', async () => {
+    const res = await fetch(`${server.baseUrl}/api/settings`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        authorization: server.authHeader(user),
+      },
+      body: JSON.stringify({ workspaceViewer: { monacoTabSize: 3 } }),
+    });
+
+    expect(res.status).toBe(400);
+    const json = await res.json() as { error: string };
+    expect(json.error).toMatch(/monacoTabSize/i);
+  });
+
   it('rejects unauthenticated PATCH', async () => {
     const res = await fetch(`${server.baseUrl}/api/settings`, {
       method: 'PATCH',

--- a/apps/gateway/test/api/wave4-hardening.test.ts
+++ b/apps/gateway/test/api/wave4-hardening.test.ts
@@ -1,0 +1,433 @@
+import jwt from 'jsonwebtoken';
+import { describe, it, expect } from 'vitest';
+import { getDb } from '@goldilocks/data';
+import { CONFIG } from '@goldilocks/config';
+import { createTestServer } from './helpers/test-server.js';
+
+async function createSessionFixture(overrides?: Partial<{ email: string; password: string; displayName: string }>) {
+  const server = await createTestServer();
+  const user = await server.registerUser(overrides);
+  return { server, user };
+}
+
+describe('P7: Admin role and metrics protection', () => {
+  it('new users get role=user by default', async () => {
+    const { server, user } = await createSessionFixture();
+    try {
+      const res = await fetch(`${server.baseUrl}/api/auth/me`, {
+        headers: { cookie: server.cookieHeader(user) },
+      });
+      const json = await res.json() as { user: { role: string } };
+      expect(json.user.role).toBe('user');
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it('JWT payload includes the role claim', async () => {
+    const { server, user } = await createSessionFixture();
+    try {
+      const claims = jwt.verify(user.token, CONFIG.jwtSecret, {
+        issuer: CONFIG.jwtIssuer,
+        audience: CONFIG.jwtAudience,
+      }) as jwt.JwtPayload & { role: string };
+
+      expect(claims.role).toBe('user');
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it('ADMIN_EMAILS env var promotes matching users to admin on register', async () => {
+    const server = await createTestServer({
+      env: { ADMIN_EMAILS: 'admin-test@example.com' },
+    });
+    try {
+      const user = await server.registerUser({
+        email: 'admin-test@example.com',
+        password: 'AdminPassword123!',
+        displayName: 'Admin User',
+      });
+
+      const claims = jwt.verify(user.token, CONFIG.jwtSecret, {
+        issuer: CONFIG.jwtIssuer,
+        audience: CONFIG.jwtAudience,
+      }) as jwt.JwtPayload & { role: string };
+
+      expect(claims.role).toBe('admin');
+
+      const res = await fetch(`${server.baseUrl}/api/auth/me`, {
+        headers: { cookie: server.cookieHeader(user) },
+      });
+      const json = await res.json() as { user: { role: string } };
+      expect(json.user.role).toBe('admin');
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it('ADMIN_EMAILS auto-promotion on login for existing user', async () => {
+    // Register without ADMIN_EMAILS set
+    const server = await createTestServer();
+    const user = await server.registerUser({
+      email: 'promote-me@example.com',
+      password: 'PromotePassword123!',
+    });
+
+    try {
+      // Verify they start as 'user'
+      const meBefore = await fetch(`${server.baseUrl}/api/auth/me`, {
+        headers: { cookie: server.cookieHeader(user) },
+      });
+      const jsonBefore = await meBefore.json() as { user: { role: string } };
+      expect(jsonBefore.user.role).toBe('user');
+
+      // Set ADMIN_EMAILS and log in again
+      process.env.ADMIN_EMAILS = 'promote-me@example.com';
+      try {
+        const loginRes = await fetch(`${server.baseUrl}/api/auth/login`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email: 'promote-me@example.com', password: 'PromotePassword123!' }),
+        });
+
+        expect(loginRes.status).toBe(200);
+        const loginCookie = (loginRes.headers.get('set-cookie') ?? '').split(';')[0];
+
+        const meAfter = await fetch(`${server.baseUrl}/api/auth/me`, {
+          headers: { cookie: loginCookie },
+        });
+        const jsonAfter = await meAfter.json() as { user: { role: string } };
+        expect(jsonAfter.user.role).toBe('admin');
+      } finally {
+        delete process.env.ADMIN_EMAILS;
+      }
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it('/api/metrics returns 401 for unauthenticated requests', async () => {
+    const { server } = await createSessionFixture();
+    try {
+      const res = await fetch(`${server.baseUrl}/api/metrics`);
+      expect(res.status).toBe(401);
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it('/api/metrics returns 403 for regular users', async () => {
+    const { server, user } = await createSessionFixture();
+    try {
+      const res = await fetch(`${server.baseUrl}/api/metrics`, {
+        headers: { cookie: server.cookieHeader(user) },
+      });
+      expect(res.status).toBe(403);
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it('/api/metrics returns 200 for admin users', async () => {
+    const server = await createTestServer({
+      env: { ADMIN_EMAILS: 'metrics-admin@example.com' },
+    });
+    try {
+      const user = await server.registerUser({
+        email: 'metrics-admin@example.com',
+        password: 'MetricsAdmin123!',
+        displayName: 'Metrics Admin',
+      });
+
+      const res = await fetch(`${server.baseUrl}/api/metrics`, {
+        headers: { cookie: server.cookieHeader(user) },
+      });
+      expect(res.status).toBe(200);
+      const json = await res.json() as { relay: object };
+      expect(json).toHaveProperty('relay');
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it('login response includes role in user object', async () => {
+    const { server, user } = await createSessionFixture();
+    try {
+      const res = await fetch(`${server.baseUrl}/api/auth/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: user.email, password: 'TestPassword123!' }),
+      });
+      const json = await res.json() as { user: { role: string } };
+      expect(json.user.role).toBe('user');
+    } finally {
+      await server.stop();
+    }
+  });
+});
+
+describe('P8: Per-user key derivation and encryption versioning', () => {
+  it('stores API keys with per-user key_salt', async () => {
+    const { server, user } = await createSessionFixture();
+    try {
+      // Store a key
+      const storeRes = await fetch(`${server.baseUrl}/api/settings/api-key`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          cookie: server.cookieHeader(user),
+        },
+        body: JSON.stringify({ provider: 'openai', key: 'sk-test-key-123' }),
+      });
+      expect(storeRes.status).toBe(200);
+
+      // Verify key_salt was created for this user
+      const db = getDb();
+      const row = db.prepare('SELECT key_salt FROM users WHERE id = ?').get(user.userId) as { key_salt: string | null };
+      expect(row.key_salt).toBeTruthy();
+      expect(row.key_salt!.length).toBe(64); // 32 bytes hex
+
+      // Verify key_version is 2
+      const keyRow = db.prepare('SELECT key_version FROM api_keys WHERE user_id = ? AND provider = ?').get(user.userId, 'openai') as { key_version: number };
+      expect(keyRow.key_version).toBe(2);
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it('different users get different key_salts', async () => {
+    const server = await createTestServer();
+    try {
+      const user1 = await server.registerUser({ email: `salt1-${Date.now()}@example.com` });
+      const user2 = await server.registerUser({ email: `salt2-${Date.now()}@example.com` });
+
+      // Store keys to trigger salt generation
+      await fetch(`${server.baseUrl}/api/settings/api-key`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', cookie: server.cookieHeader(user1) },
+        body: JSON.stringify({ provider: 'openai', key: 'sk-key-1' }),
+      });
+      await fetch(`${server.baseUrl}/api/settings/api-key`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', cookie: server.cookieHeader(user2) },
+        body: JSON.stringify({ provider: 'openai', key: 'sk-key-2' }),
+      });
+
+      const db = getDb();
+      const salt1 = (db.prepare('SELECT key_salt FROM users WHERE id = ?').get(user1.userId) as { key_salt: string }).key_salt;
+      const salt2 = (db.prepare('SELECT key_salt FROM users WHERE id = ?').get(user2.userId) as { key_salt: string }).key_salt;
+
+      expect(salt1).not.toBe(salt2);
+    } finally {
+      await server.stop();
+    }
+  });
+});
+
+describe('P9: Audit trail', () => {
+  it('emits structured auth event on successful login', async () => {
+    const { server, user } = await createSessionFixture();
+    try {
+      // Clear any previous logs
+      const logs: string[] = [];
+      const origLog = console.log;
+      console.log = (...args: unknown[]) => {
+        const msg = args.map(String).join(' ');
+        if (msg.includes('"event"')) logs.push(msg);
+        origLog(...args);
+      };
+
+      try {
+        await fetch(`${server.baseUrl}/api/auth/login`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email: user.email, password: 'TestPassword123!' }),
+        });
+
+        const loginLog = logs.find(l => l.includes('auth.login.success'));
+        expect(loginLog).toBeTruthy();
+        const parsed = JSON.parse(loginLog!);
+        expect(parsed.event).toBe('auth.login.success');
+        expect(parsed.userId).toBe(user.userId);
+        expect(parsed.ts).toBeTruthy();
+      } finally {
+        console.log = origLog;
+      }
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it('emits structured auth event on failed login', async () => {
+    const server = await createTestServer();
+    try {
+      const logs: string[] = [];
+      const origLog = console.log;
+      console.log = (...args: unknown[]) => {
+        const msg = args.map(String).join(' ');
+        if (msg.includes('"event"')) logs.push(msg);
+        origLog(...args);
+      };
+
+      try {
+        await fetch(`${server.baseUrl}/api/auth/login`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email: 'nonexistent@example.com', password: 'wrong' }),
+        });
+
+        const failLog = logs.find(l => l.includes('auth.login.failure'));
+        expect(failLog).toBeTruthy();
+        const parsed = JSON.parse(failLog!);
+        expect(parsed.event).toBe('auth.login.failure');
+        expect(parsed.attemptedEmail).toBe('nonexistent@example.com');
+      } finally {
+        console.log = origLog;
+      }
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it('emits structured event on logout', async () => {
+    const { server, user } = await createSessionFixture();
+    try {
+      const logs: string[] = [];
+      const origLog = console.log;
+      console.log = (...args: unknown[]) => {
+        const msg = args.map(String).join(' ');
+        if (msg.includes('"event"')) logs.push(msg);
+        origLog(...args);
+      };
+
+      try {
+        await fetch(`${server.baseUrl}/api/auth/logout`, {
+          method: 'POST',
+          headers: { cookie: server.cookieHeader(user) },
+        });
+
+        const logoutLog = logs.find(l => l.includes('auth.logout'));
+        expect(logoutLog).toBeTruthy();
+        const parsed = JSON.parse(logoutLog!);
+        expect(parsed.event).toBe('auth.logout');
+      } finally {
+        console.log = origLog;
+      }
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it('emits structured event on API key store', async () => {
+    const { server, user } = await createSessionFixture();
+    try {
+      const logs: string[] = [];
+      const origLog = console.log;
+      console.log = (...args: unknown[]) => {
+        const msg = args.map(String).join(' ');
+        if (msg.includes('"event"')) logs.push(msg);
+        origLog(...args);
+      };
+
+      try {
+        await fetch(`${server.baseUrl}/api/settings/api-key`, {
+          method: 'PUT',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: server.cookieHeader(user),
+          },
+          body: JSON.stringify({ provider: 'anthropic', key: 'sk-ant-test-key' }),
+        });
+
+        const storeLog = logs.find(l => l.includes('settings.api-key.store'));
+        expect(storeLog).toBeTruthy();
+        const parsed = JSON.parse(storeLog!);
+        expect(parsed.event).toBe('settings.api-key.store');
+        expect(parsed.details?.provider).toBe('anthropic');
+        // Never log key values
+        expect(storeLog).not.toContain('sk-ant-test-key');
+      } finally {
+        console.log = origLog;
+      }
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it('emits structured event on API key delete', async () => {
+    const { server, user } = await createSessionFixture();
+    try {
+      // Store a key first
+      await fetch(`${server.baseUrl}/api/settings/api-key`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          cookie: server.cookieHeader(user),
+        },
+        body: JSON.stringify({ provider: 'openai', key: 'sk-test-delete' }),
+      });
+
+      const logs: string[] = [];
+      const origLog = console.log;
+      console.log = (...args: unknown[]) => {
+        const msg = args.map(String).join(' ');
+        if (msg.includes('"event"')) logs.push(msg);
+        origLog(...args);
+      };
+
+      try {
+        await fetch(`${server.baseUrl}/api/settings/api-key/openai`, {
+          method: 'DELETE',
+          headers: { cookie: server.cookieHeader(user) },
+        });
+
+        const deleteLog = logs.find(l => l.includes('settings.api-key.delete'));
+        expect(deleteLog).toBeTruthy();
+        const parsed = JSON.parse(deleteLog!);
+        expect(parsed.event).toBe('settings.api-key.delete');
+        expect(parsed.details?.provider).toBe('openai');
+      } finally {
+        console.log = origLog;
+      }
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it('emits admin.action event on metrics access', async () => {
+    const server = await createTestServer({
+      env: { ADMIN_EMAILS: 'audit-admin@example.com' },
+    });
+    try {
+      const user = await server.registerUser({
+        email: 'audit-admin@example.com',
+        password: 'AuditAdmin123!',
+      });
+
+      const logs: string[] = [];
+      const origLog = console.log;
+      console.log = (...args: unknown[]) => {
+        const msg = args.map(String).join(' ');
+        if (msg.includes('"event"')) logs.push(msg);
+        origLog(...args);
+      };
+
+      try {
+        await fetch(`${server.baseUrl}/api/metrics`, {
+          headers: { cookie: server.cookieHeader(user) },
+        });
+
+        const adminLog = logs.find(l => l.includes('admin.action'));
+        expect(adminLog).toBeTruthy();
+        const parsed = JSON.parse(adminLog!);
+        expect(parsed.event).toBe('admin.action');
+        expect(parsed.details?.action).toBe('metrics');
+      } finally {
+        console.log = origLog;
+      }
+    } finally {
+      await server.stop();
+    }
+  });
+});

--- a/apps/gateway/test/app-security.test.ts
+++ b/apps/gateway/test/app-security.test.ts
@@ -1,0 +1,70 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { buildReadinessFailureResponse, getRateLimitKey } from '../src/app.js';
+import { createTestServer, type TestUser } from './api/helpers/test-server.js';
+
+describe('Gateway security middleware', () => {
+  let server: Awaited<ReturnType<typeof createTestServer>>;
+  let user: TestUser;
+
+  beforeAll(async () => {
+    server = await createTestServer();
+    user = await server.registerUser();
+  });
+
+  afterAll(async () => {
+    await server.stop();
+  });
+
+  it('keys rate limits by authenticated user id when a valid token is present', () => {
+    expect(getRateLimitKey({
+      ip: '127.0.0.1',
+      headers: { authorization: server.authHeader(user) },
+    } as never)).toBe(user.userId);
+
+    expect(getRateLimitKey({
+      ip: '127.0.0.1',
+      headers: { cookie: server.cookieHeader(user) },
+      cookies: { 'goldilocks-session': user.token },
+    } as never)).toBe(user.userId);
+  });
+
+  it('falls back to IP bucketing when the token is invalid', () => {
+    const unauthenticatedKey = getRateLimitKey({
+      ip: '127.0.0.1',
+      headers: {},
+    } as never);
+
+    const invalidTokenKey = getRateLimitKey({
+      ip: '127.0.0.1',
+      headers: { authorization: 'Bearer definitely-not-valid' },
+    } as never);
+
+    expect(invalidTokenKey).toBe(unauthenticatedKey);
+    expect(invalidTokenKey).not.toBe(user.userId);
+  });
+
+  it('sanitizes readiness failures', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    try {
+      const response = buildReadinessFailureResponse(new Error('sqlite exploded in a dramatic fashion'));
+      expect(response).toEqual({
+        status: 'degraded',
+        error: 'Service unavailable',
+      });
+      expect(errorSpy).toHaveBeenCalled();
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it('sets helmet security headers on API responses', async () => {
+    const res = await fetch(`${server.baseUrl}/api/health`);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('x-content-type-options')).toBe('nosniff');
+    expect(res.headers.get('x-frame-options')).toBe('SAMEORIGIN');
+    expect(res.headers.get('content-security-policy')).toContain("default-src 'self'");
+    expect(res.headers.get('referrer-policy')).toBeTruthy();
+  });
+});

--- a/apps/gateway/test/security-wave1.test.ts
+++ b/apps/gateway/test/security-wave1.test.ts
@@ -1,0 +1,59 @@
+import { readFileSync, readdirSync } from 'fs';
+import { join, resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { describe, expect, it } from 'vitest';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '../../..');
+const gatewayEntry = resolve(repoRoot, 'apps/gateway/src/index.ts');
+const agentServiceEntry = resolve(repoRoot, 'apps/agent-service/src/index.ts');
+const gatewaySourceRoot = resolve(repoRoot, 'apps/gateway/src');
+
+function readGatewaySourceFiles(dir: string): string[] {
+  const files: string[] = [];
+  const entries = readdirSync(dir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isSymbolicLink()) {
+      continue;
+    }
+    if (entry.isDirectory()) {
+      files.push(...readGatewaySourceFiles(fullPath));
+      continue;
+    }
+    if (fullPath.endsWith('.ts')) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+describe('Wave 1 startup secret guards', () => {
+  it('gateway validates required secrets at startup', () => {
+    const source = readFileSync(gatewayEntry, 'utf8');
+    expect(source).toContain('CONFIG.validateRequiredSecrets();');
+  });
+
+  it('agent-service validates required secrets at startup', () => {
+    const source = readFileSync(agentServiceEntry, 'utf8');
+    expect(source).toContain('CONFIG.validateRequiredSecrets();');
+  });
+});
+
+describe('Wave 1 shell interpolation regression guard', () => {
+  it('gateway source contains no sh -c command invocations', () => {
+    const files = readGatewaySourceFiles(gatewaySourceRoot);
+    const offenders: string[] = [];
+
+    for (const file of files) {
+      const source = readFileSync(file, 'utf8');
+      if (/['"]sh['"]\s*,\s*['"]-c['"]/.test(source)) {
+        offenders.push(file.replace(`${repoRoot}/`, ''));
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/apps/gateway/test/setup.ts
+++ b/apps/gateway/test/setup.ts
@@ -24,6 +24,7 @@ process.env.JWT_SECRET = 'test-jwt-not-for-prod';
 process.env.ENCRYPTION_KEY = 'test-encryption-key-32bytes!!';
 process.env.AGENT_SERVICE_SHARED_SECRET = 'test-agent-shared-secret';
 process.env.NODE_ENV = 'test';
+process.env.FRONTEND_URL = 'http://localhost:5173';
 
 afterAll(() => {
   try {

--- a/apps/gateway/test/setup.ts
+++ b/apps/gateway/test/setup.ts
@@ -22,6 +22,7 @@ process.env.DATA_DIR = testDataDir;
 process.env.WORKSPACE_ROOT = workspaceRoot;
 process.env.JWT_SECRET = 'test-jwt-not-for-prod';
 process.env.ENCRYPTION_KEY = 'test-encryption-key-32bytes!!';
+process.env.AGENT_SERVICE_SHARED_SECRET = 'test-agent-shared-secret';
 process.env.NODE_ENV = 'test';
 
 afterAll(() => {

--- a/apps/gateway/test/smoke-test.sh
+++ b/apps/gateway/test/smoke-test.sh
@@ -123,12 +123,15 @@ req_no_auth() {
     2>/dev/null
 }
 
-register_and_get_token() {
+register_and_capture_session() {
   local email=$1
   local password=$2
-  req_no_auth POST /api/auth/register \
+  local cookie_jar=$3
+  curl -s -c "$cookie_jar" -X POST \
+    -H 'Content-Type: application/json' \
     -d "{\"email\":\"$email\",\"password\":\"$password\",\"displayName\":\"Smoke Test\"}" \
-    | jq -r '.token // empty'
+    "$BASE/api/auth/register" \
+    2>/dev/null
 }
 
 # ── Health ──────────────────────────────────────────────────────────────────
@@ -150,16 +153,18 @@ note "Auth"
 EMAIL="smoke-$(date +%s)@example.com"
 PASSWORD="SmokeTest123!"
 
-TOKEN=$(register_and_get_token "$EMAIL" "$PASSWORD")
+COOKIE_JAR=$(mktemp)
+REGISTER=$(register_and_capture_session "$EMAIL" "$PASSWORD" "$COOKIE_JAR")
+TOKEN=$(awk '$6 == "goldilocks-session" { print $7 }' "$COOKIE_JAR" | tail -n1)
 if [[ -n "$TOKEN" && "$TOKEN" != "empty" ]]; then
-  pass "register → JWT token"
+  pass "register → session cookie"
 else
-  fail "register failed"
+  fail "register failed: $REGISTER"
   TOKEN=""
 fi
 
 if [[ -n "$TOKEN" ]]; then
-  ME=$(curl -s "$BASE/api/auth/me" -H "Authorization: Bearer $TOKEN" 2>/dev/null) || true
+  ME=$(curl -s -b "$COOKIE_JAR" "$BASE/api/auth/me" 2>/dev/null) || true
   if echo "$ME" | jq -r '.user.email' 2>/dev/null | grep -q "$EMAIL"; then
     pass "GET /api/auth/me → correct user"
   else
@@ -182,16 +187,15 @@ note "Conversations"
 if [[ -z "$TOKEN" ]]; then
   skip "auth failed, skipping conversations"
 else
-  CONV=$(curl -s -X POST "$BASE/api/conversations" \
+  CONV=$(curl -s -b "$COOKIE_JAR" -X POST "$BASE/api/conversations" \
     -H 'Content-Type: application/json' \
-    -H "Authorization: Bearer $TOKEN" \
     -d '{"title":"Smoke Test Conv"}' 2>/dev/null) || true
   CONV_ID=$(echo "$CONV" | jq -r '.conversation.id // empty' 2>/dev/null) || true
 
   if [[ -n "$CONV_ID" && "$CONV_ID" != "empty" ]]; then
     pass "create conversation → $CONV_ID"
 
-    CONVS=$(curl -s "$BASE/api/conversations" -H "Authorization: Bearer $TOKEN" 2>/dev/null) || true
+    CONVS=$(curl -s -b "$COOKIE_JAR" "$BASE/api/conversations" 2>/dev/null) || true
     COUNT=$(echo "$CONVS" | jq '.conversations | length' 2>/dev/null) || COUNT=0
     if [[ "$COUNT" -ge 1 ]]; then
       pass "list conversations → $COUNT found"
@@ -199,9 +203,8 @@ else
       fail "list conversations returned $COUNT"
     fi
 
-    RENAMED=$(curl -s -X PATCH "$BASE/api/conversations/$CONV_ID" \
+    RENAMED=$(curl -s -b "$COOKIE_JAR" -X PATCH "$BASE/api/conversations/$CONV_ID" \
       -H 'Content-Type: application/json' \
-      -H "Authorization: Bearer $TOKEN" \
       -d '{"title":"Renamed by Smoke Test"}' 2>/dev/null) || true
     if echo "$RENAMED" | jq -r '.conversation.title' 2>/dev/null | grep -q "Renamed by Smoke Test"; then
       pass "rename conversation"
@@ -209,8 +212,7 @@ else
       fail "rename failed: $RENAMED"
     fi
 
-    DELETED=$(curl -s -X DELETE "$BASE/api/conversations/$CONV_ID" \
-      -H "Authorization: Bearer $TOKEN" 2>/dev/null) || true
+    DELETED=$(curl -s -b "$COOKIE_JAR" -X DELETE "$BASE/api/conversations/$CONV_ID" 2>/dev/null) || true
     if echo "$DELETED" | jq -r '.ok' 2>/dev/null | grep -q 'true'; then
       pass "delete conversation"
     else
@@ -235,16 +237,15 @@ note "Settings"
 if [[ -z "$TOKEN" ]]; then
   skip "auth failed, skipping settings"
 else
-  GET=$(curl -s "$BASE/api/settings" -H "Authorization: Bearer $TOKEN" 2>/dev/null) || true
+  GET=$(curl -s -b "$COOKIE_JAR" "$BASE/api/settings" 2>/dev/null) || true
   if echo "$GET" | jq -r '.settings' >/dev/null 2>&1; then
     pass "GET /api/settings → { settings: {...} }"
   else
     fail "GET settings failed: $GET"
   fi
 
-  PATCH=$(curl -s -X PATCH "$BASE/api/settings" \
+  PATCH=$(curl -s -b "$COOKIE_JAR" -X PATCH "$BASE/api/settings" \
     -H 'Content-Type: application/json' \
-    -H "Authorization: Bearer $TOKEN" \
     -d '{"defaultModel":"claude-sonnet-4-20250514"}' 2>/dev/null) || true
   if echo "$PATCH" | jq -r '.settings.defaultModel' 2>/dev/null | grep -q 'claude-sonnet'; then
     pass "PATCH /api/settings → merge works"
@@ -252,7 +253,7 @@ else
     fail "PATCH settings failed: $PATCH"
   fi
 
-  KEYS=$(curl -s "$BASE/api/settings/api-keys" -H "Authorization: Bearer $TOKEN" 2>/dev/null) || true
+  KEYS=$(curl -s -b "$COOKIE_JAR" "$BASE/api/settings/api-keys" 2>/dev/null) || true
   if echo "$KEYS" | jq -r '.apiKeys' >/dev/null 2>&1; then
     pass "GET /api/settings/api-keys → key list returned"
   else

--- a/apps/gateway/test/smoke-test.sh
+++ b/apps/gateway/test/smoke-test.sh
@@ -71,6 +71,7 @@ mkdir -p "$DATA_DIR" "$WORKSPACE_ROOT"
 export PORT DATA_DIR WORKSPACE_ROOT
 export JWT_SECRET='test-secret-for-smoke-test'
 export ENCRYPTION_KEY='test-encryption-key-32bytes!!'
+export AGENT_SERVICE_SHARED_SECRET='test-agent-shared-secret'
 export NODE_ENV='test'
 export K8S_NAMESPACE='smoke-test'  # prevents real k8s lookups
 

--- a/apps/gateway/test/websocket-auth.test.ts
+++ b/apps/gateway/test/websocket-auth.test.ts
@@ -1,0 +1,86 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { IncomingMessage } from 'http';
+import { closeDb, runMigrations } from '@goldilocks/data';
+import { CONFIG } from '@goldilocks/config';
+import {
+  authenticateWebSocketUpgrade,
+} from '../src/agent/websocket.js';
+import {
+  generateToken,
+  revokeToken,
+  verifySignedToken,
+} from '../src/auth/middleware.js';
+
+function makeUpgradeRequest(overrides: Partial<IncomingMessage['headers']> = {}): IncomingMessage {
+  return {
+    headers: {
+      host: 'localhost:3000',
+      origin: 'http://localhost:5173',
+      ...overrides,
+    },
+  } as IncomingMessage;
+}
+
+describe('gateway websocket upgrade auth', () => {
+  beforeAll(() => {
+    runMigrations();
+  });
+
+  afterAll(() => {
+    closeDb();
+  });
+
+  it('accepts upgrade requests from the allowed origin with a valid session cookie', () => {
+    const token = generateToken({ id: 'user-1', email: 'user@example.com' });
+    const req = makeUpgradeRequest({
+      cookie: `${CONFIG.sessionCookieName}=${encodeURIComponent(token)}`,
+    });
+
+    const result = authenticateWebSocketUpgrade(req);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.user.id).toBe('user-1');
+    expect(result.token).toBe(token);
+  });
+
+  it('rejects websocket upgrades from disallowed origins', () => {
+    const token = generateToken({ id: 'user-1', email: 'user@example.com' });
+    const req = makeUpgradeRequest({
+      origin: 'https://evil.example',
+      cookie: `${CONFIG.sessionCookieName}=${encodeURIComponent(token)}`,
+    });
+
+    const result = authenticateWebSocketUpgrade(req);
+    expect(result).toEqual({
+      ok: false,
+      status: 403,
+      error: 'WebSocket origin not allowed',
+    });
+  });
+
+  it('rejects websocket upgrades without a session cookie', () => {
+    const result = authenticateWebSocketUpgrade(makeUpgradeRequest());
+    expect(result).toEqual({
+      ok: false,
+      status: 401,
+      error: 'Missing session cookie',
+    });
+  });
+
+  it('rejects revoked websocket tokens', () => {
+    const token = generateToken({ id: 'user-2', email: 'revoked@example.com' });
+    const claims = verifySignedToken(token);
+    revokeToken(claims);
+
+    const req = makeUpgradeRequest({
+      cookie: `${CONFIG.sessionCookieName}=${encodeURIComponent(token)}`,
+    });
+
+    const result = authenticateWebSocketUpgrade(req);
+    expect(result).toEqual({
+      ok: false,
+      status: 401,
+      error: 'Invalid, expired, or revoked token',
+    });
+  });
+});

--- a/apps/gateway/test/websocket-auth.test.ts
+++ b/apps/gateway/test/websocket-auth.test.ts
@@ -31,7 +31,7 @@ describe('gateway websocket upgrade auth', () => {
   });
 
   it('accepts upgrade requests from the allowed origin with a valid session cookie', () => {
-    const token = generateToken({ id: 'user-1', email: 'user@example.com' });
+    const token = generateToken({ id: 'user-1', email: 'user@example.com', role: 'user' });
     const req = makeUpgradeRequest({
       cookie: `${CONFIG.sessionCookieName}=${encodeURIComponent(token)}`,
     });
@@ -44,7 +44,7 @@ describe('gateway websocket upgrade auth', () => {
   });
 
   it('rejects websocket upgrades from disallowed origins', () => {
-    const token = generateToken({ id: 'user-1', email: 'user@example.com' });
+    const token = generateToken({ id: 'user-1', email: 'user@example.com', role: 'user' });
     const req = makeUpgradeRequest({
       origin: 'https://evil.example',
       cookie: `${CONFIG.sessionCookieName}=${encodeURIComponent(token)}`,
@@ -68,7 +68,7 @@ describe('gateway websocket upgrade auth', () => {
   });
 
   it('rejects revoked websocket tokens', () => {
-    const token = generateToken({ id: 'user-2', email: 'revoked@example.com' });
+    const token = generateToken({ id: 'user-2', email: 'revoked@example.com', role: 'user' });
     const claims = verifySignedToken(token);
     revokeToken(claims);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -110,6 +110,7 @@
         "cors": "^2.8.5",
         "express": "^5.1.0",
         "express-rate-limit": "^8.3.2",
+        "helmet": "^8.1.0",
         "jsonwebtoken": "^9.0.2",
         "uuid": "^11.1.0",
         "ws": "^8.18.2"
@@ -8668,6 +8669,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/highlight.js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,10 +51,12 @@
         "@goldilocks/data": "file:../../packages/data",
         "@goldilocks/runtime": "file:../../packages/runtime",
         "express": "^5.1.0",
+        "jsonwebtoken": "^9.0.3",
         "ws": "^8.18.2"
       },
       "devDependencies": {
         "@types/express": "^5.0.2",
+        "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^22.15.3",
         "@types/ws": "^8.18.1",
         "tsx": "^4.19.4",
@@ -104,6 +106,7 @@
         "@goldilocks/runtime": "file:../../packages/runtime",
         "@mariozechner/pi-ai": "^0.64.0",
         "bcrypt": "^5.1.1",
+        "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "express": "^5.1.0",
         "express-rate-limit": "^8.3.2",
@@ -113,6 +116,7 @@
       },
       "devDependencies": {
         "@types/bcrypt": "^5.0.2",
+        "@types/cookie-parser": "^1.4.10",
         "@types/cors": "^2.8.17",
         "@types/express": "^5.0.2",
         "@types/jsonwebtoken": "^9.0.10",
@@ -5136,6 +5140,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookie-parser": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.10.tgz",
+      "integrity": "sha512-B4xqkqfZ8Wek+rCOeRxsjMS9OgvzebEzzLYw7NHYuvzb7IdxOkI0ZHGgeEBX4PUM7QGVvNSK60T3OvWj3YfBRg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/cors": {
       "version": "2.8.19",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
@@ -6854,6 +6868,25 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
     },
     "node_modules/cookie-signature": {
       "version": "1.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,27 +21,6 @@
         "node": ">=20.0.0"
       }
     },
-    "agent-service": {
-      "name": "goldilocks-agent-service",
-      "version": "0.1.0",
-      "extraneous": true,
-      "dependencies": {
-        "@kubernetes/client-node": "^1.4.0",
-        "@mariozechner/pi-coding-agent": "^0.64.0",
-        "better-sqlite3": "^11.9.1",
-        "dotenv": "^16.5.0",
-        "express": "^5.1.0",
-        "ws": "^8.18.2"
-      },
-      "devDependencies": {
-        "@types/better-sqlite3": "^7.6.12",
-        "@types/express": "^5.0.2",
-        "@types/node": "^22.15.3",
-        "@types/ws": "^8.18.1",
-        "tsx": "^4.19.4",
-        "typescript": "^5.8.3"
-      }
-    },
     "apps/agent-service": {
       "name": "@goldilocks/agent-service",
       "version": "0.1.0",
@@ -100,11 +79,11 @@
       "name": "@goldilocks/gateway",
       "version": "0.1.0",
       "dependencies": {
+        "@earendil-works/pi-ai": "^0.75.5",
         "@goldilocks/config": "file:../../packages/config",
         "@goldilocks/contracts": "file:../../packages/contracts",
         "@goldilocks/data": "file:../../packages/data",
         "@goldilocks/runtime": "file:../../packages/runtime",
-        "@mariozechner/pi-ai": "^0.64.0",
         "bcrypt": "^5.1.1",
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
@@ -128,37 +107,17 @@
         "typescript": "^5.8.3"
       }
     },
-    "frontend": {
-      "name": "goldilocks-frontend",
-      "version": "0.1.0",
-      "extraneous": true,
-      "dependencies": {
-        "@milkdown/kit": "^7.20.0",
-        "@milkdown/react": "^7.20.0",
-        "@monaco-editor/react": "^4.7.0",
-        "@prosemirror-adapter/react": "^0.5.3",
-        "3dmol": "^2.5.4",
-        "clsx": "^2.1.1",
-        "lucide-react": "^0.511.0",
-        "marked": "^15.0.12",
-        "mermaid": "^11.13.0",
-        "monaco-editor": "^0.55.1",
-        "pdfjs-dist": "^5.6.205",
-        "react": "^19.1.0",
-        "react-dom": "^19.1.0",
-        "react-router-dom": "^7.5.0",
-        "zustand": "^5.0.3"
-      },
-      "devDependencies": {
-        "@tailwindcss/postcss": "^4.2.2",
-        "@types/react": "^19.1.2",
-        "@types/react-dom": "^19.1.2",
-        "@vitejs/plugin-react": "^4.4.1",
-        "autoprefixer": "^10.4.21",
-        "postcss": "^8.5.3",
-        "tailwindcss": "^4.1.4",
-        "typescript": "^5.8.3",
-        "vite": "^6.3.4"
+    "apps/gateway/node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -188,9 +147,9 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.73.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.73.0.tgz",
-      "integrity": "sha512-URURVzhxXGJDGUGFunIOtBlSl7KWvZiAAKY/ttTkZAkXT9bTPqdk2eK0b8qqSxXpikh3QKPnPYpiyX98zf5ebw==",
+      "version": "0.91.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "^3.1.1"
@@ -236,44 +195,6 @@
         "tslib": "^2.6.2"
       }
     },
-    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-crypto/sha256-js": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
@@ -308,96 +229,25 @@
         "tslib": "^2.6.2"
       }
     },
-    "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/client-bedrock-runtime": {
-      "version": "3.1021.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1021.0.tgz",
-      "integrity": "sha512-FqAZq9ewaprev+BAUgUNeQKACVVEbGw8V3SZTKv0hEy5Ed5yhJhNuOL9G0QiUtdG6rX6NujGZjO5xBgKcvMLxQ==",
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
+      "integrity": "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/credential-provider-node": "^3.972.29",
-        "@aws-sdk/eventstream-handler-node": "^3.972.12",
-        "@aws-sdk/middleware-eventstream": "^3.972.8",
-        "@aws-sdk/middleware-host-header": "^3.972.8",
-        "@aws-sdk/middleware-logger": "^3.972.8",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.9",
-        "@aws-sdk/middleware-user-agent": "^3.972.28",
-        "@aws-sdk/middleware-websocket": "^3.972.14",
-        "@aws-sdk/region-config-resolver": "^3.972.10",
-        "@aws-sdk/token-providers": "3.1021.0",
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/util-endpoints": "^3.996.5",
-        "@aws-sdk/util-user-agent-browser": "^3.972.8",
-        "@aws-sdk/util-user-agent-node": "^3.973.14",
-        "@smithy/config-resolver": "^4.4.13",
-        "@smithy/core": "^3.23.13",
-        "@smithy/eventstream-serde-browser": "^4.2.12",
-        "@smithy/eventstream-serde-config-resolver": "^4.3.12",
-        "@smithy/eventstream-serde-node": "^4.2.12",
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/hash-node": "^4.2.12",
-        "@smithy/invalid-dependency": "^4.2.12",
-        "@smithy/middleware-content-length": "^4.2.12",
-        "@smithy/middleware-endpoint": "^4.4.28",
-        "@smithy/middleware-retry": "^4.4.46",
-        "@smithy/middleware-serde": "^4.2.16",
-        "@smithy/middleware-stack": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/node-http-handler": "^4.5.1",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.8",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.44",
-        "@smithy/util-defaults-mode-node": "^4.2.48",
-        "@smithy/util-endpoints": "^3.3.3",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-retry": "^4.2.13",
-        "@smithy/util-stream": "^4.5.21",
-        "@smithy/util-utf8": "^4.2.2",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/credential-provider-node": "^3.972.42",
+        "@aws-sdk/eventstream-handler-node": "^3.972.16",
+        "@aws-sdk/middleware-eventstream": "^3.972.12",
+        "@aws-sdk/middleware-websocket": "^3.972.19",
+        "@aws-sdk/token-providers": "3.1048.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -405,23 +255,18 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.973.26",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.26.tgz",
-      "integrity": "sha512-A/E6n2W42ruU+sfWk+mMUOyVXbsSgGrY3MJ9/0Az5qUdG67y8I6HYzzoAa+e/lzxxl1uCYmEL6BTMi9ZiZnplQ==",
+      "version": "3.974.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.13.tgz",
+      "integrity": "sha512-+Y5/4tHki0uYgyx8eun146DegRVQBpdKGK5RbV0FTKJPpaKTchvqVxrrRFK6Wk0JksO4iAZKw3eqxGEIwtO98w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/xml-builder": "^3.972.16",
-        "@smithy/core": "^3.23.13",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/signature-v4": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.8",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-utf8": "^4.2.2",
+        "@aws-sdk/types": "^3.973.9",
+        "@aws-sdk/xml-builder": "^3.972.25",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.3",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.2",
+        "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -429,15 +274,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.24",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.24.tgz",
-      "integrity": "sha512-FWg8uFmT6vQM7VuzELzwVo5bzExGaKHdubn0StjgrcU5FvuLExUe+k06kn/40uKv59rYzhez8eFNM4yYE/Yb/w==",
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.39.tgz",
+      "integrity": "sha512-29wX9zpAvEt1vcj0psha+y6ygBHy2V/S72mp6e7q0KARLWXq+pwE/lR6qGkwknQvruh52lXvlqZIga8Hdxkucw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.974.13",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -445,20 +290,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.26",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.26.tgz",
-      "integrity": "sha512-CY4ppZ+qHYqcXqBVi//sdHST1QK3KzOEiLtpLsc9W2k2vfZPKExGaQIsOwcyvjpjUEolotitmd3mUNY56IwDEA==",
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.41.tgz",
+      "integrity": "sha512-IA3CQTjtJkb6u1H4mE4936c8OPBMa9Jggtwe8U2Mqw/vvb/tZ5Ebd0mcZcX0uKWQhOyYo/+qNIwkV5Xh+FeJJA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/node-http-handler": "^4.5.1",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.8",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-stream": "^4.5.21",
+        "@aws-sdk/core": "^3.974.13",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.3",
+        "@smithy/fetch-http-handler": "^5.4.3",
+        "@smithy/node-http-handler": "^4.7.3",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -466,24 +308,23 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.28",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.28.tgz",
-      "integrity": "sha512-wXYvq3+uQcZV7k+bE4yDXCTBdzWTU9x/nMiKBfzInmv6yYK1veMK0AKvRfRBd72nGWYKcL6AxwiPg9z/pYlgpw==",
+      "version": "3.972.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.43.tgz",
+      "integrity": "sha512-4mzII+3mZEVXXE1xzrLQrCJL7/r62A63bA6SVzZoNL5rqCJghpf+xgGltVrIBBs0n+mOZBKrQl2tRREtvZ5l6A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/credential-provider-env": "^3.972.24",
-        "@aws-sdk/credential-provider-http": "^3.972.26",
-        "@aws-sdk/credential-provider-login": "^3.972.28",
-        "@aws-sdk/credential-provider-process": "^3.972.24",
-        "@aws-sdk/credential-provider-sso": "^3.972.28",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.28",
-        "@aws-sdk/nested-clients": "^3.996.18",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/credential-provider-imds": "^4.2.12",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.974.13",
+        "@aws-sdk/credential-provider-env": "^3.972.39",
+        "@aws-sdk/credential-provider-http": "^3.972.41",
+        "@aws-sdk/credential-provider-login": "^3.972.43",
+        "@aws-sdk/credential-provider-process": "^3.972.39",
+        "@aws-sdk/credential-provider-sso": "^3.972.43",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.43",
+        "@aws-sdk/nested-clients": "^3.997.11",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.3",
+        "@smithy/credential-provider-imds": "^4.3.2",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -491,18 +332,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.28",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.28.tgz",
-      "integrity": "sha512-ZSTfO6jqUTCysbdBPtEX5OUR//3rbD0lN7jO3sQeS2Gjr/Y+DT6SbIJ0oT2cemNw3UzKu97sNONd1CwNMthuZQ==",
+      "version": "3.972.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.43.tgz",
+      "integrity": "sha512-HG7kQCwXtbv3oBV61Ins0oNX8KKyvrMqqRkb6ZiAfQHbMuHaiNaEb2KnpKLPkNpqImSBK82UkVE/kaY6IfWikA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/nested-clients": "^3.996.18",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.974.13",
+        "@aws-sdk/nested-clients": "^3.997.11",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -510,22 +349,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.29.tgz",
-      "integrity": "sha512-clSzDcvndpFJAggLDnDb36sPdlZYyEs5Zm6zgZjjUhwsJgSWiWKwFIXUVBcbruidNyBdbpOv2tNDL9sX8y3/0g==",
+      "version": "3.972.44",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.44.tgz",
+      "integrity": "sha512-sDaBIT0yrNNIPfvlsiTCmANm07zKju+ipWODjEXgZlsjMeIJR3LVp7RDyAOzUoAsTbDfYKDWp+i5WrFiQP6rmQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.24",
-        "@aws-sdk/credential-provider-http": "^3.972.26",
-        "@aws-sdk/credential-provider-ini": "^3.972.28",
-        "@aws-sdk/credential-provider-process": "^3.972.24",
-        "@aws-sdk/credential-provider-sso": "^3.972.28",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.28",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/credential-provider-imds": "^4.2.12",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/credential-provider-env": "^3.972.39",
+        "@aws-sdk/credential-provider-http": "^3.972.41",
+        "@aws-sdk/credential-provider-ini": "^3.972.43",
+        "@aws-sdk/credential-provider-process": "^3.972.39",
+        "@aws-sdk/credential-provider-sso": "^3.972.43",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.43",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.3",
+        "@smithy/credential-provider-imds": "^4.3.2",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -533,16 +371,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.24",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.24.tgz",
-      "integrity": "sha512-Q2k/XLrFXhEztPHqj4SLCNID3hEPdlhh1CDLBpNnM+1L8fq7P+yON9/9M1IGN/dA5W45v44ylERfXtDAlmMNmw==",
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.39.tgz",
+      "integrity": "sha512-2k/amBifLd75eXNwgvPw/2lKYSQ3NhvHQgkVKVjfUq13/eJ3JRtHmznuFenn74OK3sSfp4SMy1YB2w+UVXoKqA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.974.13",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -550,18 +387,34 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.28",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.28.tgz",
-      "integrity": "sha512-IoUlmKMLEITFn1SiCTjPfR6KrE799FBo5baWyk/5Ppar2yXZoUdaRqZzJzK6TcJxx450M8m8DbpddRVYlp5R/A==",
+      "version": "3.972.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.43.tgz",
+      "integrity": "sha512-LPc3+Y4vhH1T4x6CMqwCM6hk5+SRf/Lwmgm8INm95wxTtIRHcMwQUVkDzWu4Iw/RSncxYM2BC01OrYbxOPZvyg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/nested-clients": "^3.996.18",
-        "@aws-sdk/token-providers": "3.1021.0",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.974.13",
+        "@aws-sdk/nested-clients": "^3.997.11",
+        "@aws-sdk/token-providers": "3.1052.0",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1052.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1052.0.tgz",
+      "integrity": "sha512-QqZNB3so7UIDxZtroc85TQaLVxdZRFm0eWM1CSR2N+b06as9TOrilvrlTZuj3guYlxMs6yLOgGxnklJ5qMYtTw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.13",
+        "@aws-sdk/nested-clients": "^3.997.11",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -569,17 +422,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.28",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.28.tgz",
-      "integrity": "sha512-d+6h0SD8GGERzKe27v5rOzNGKOl0D+l0bWJdqrxH8WSQzHzjsQFIAPgIeOTUwBHVsKKwtSxc91K/SWax6XgswQ==",
+      "version": "3.972.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.43.tgz",
+      "integrity": "sha512-wQtL34lUD/09VXjwAUo2T+I3aEXRDxMB3DKmTJL/Zj0Gi6sLDTrVhae1XVt01yzkquOWajI/sZW72JGDZ1ciTw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/nested-clients": "^3.996.18",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.974.13",
+        "@aws-sdk/nested-clients": "^3.997.11",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -587,14 +439,14 @@
       }
     },
     "node_modules/@aws-sdk/eventstream-handler-node": {
-      "version": "3.972.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.12.tgz",
-      "integrity": "sha512-ruyc/MNR6e+cUrGCth7fLQ12RXBZDy/bV06tgqB9Z5n/0SN/C0m6bsQEV8FF9zPI6VSAOaRd0rNgmpYVnGawrQ==",
+      "version": "3.972.17",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.17.tgz",
+      "integrity": "sha512-WFwdNcjchKZr7jKYgGimUZO8sSKQF/le7GGqgeCzz/lHozInE6b0gFJ1YMr8NaIeAoWJwgtrF7RE4/qMgosAdQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/eventstream-codec": "^4.2.12",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -602,78 +454,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-eventstream": {
-      "version": "3.972.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.8.tgz",
-      "integrity": "sha512-r+oP+tbCxgqXVC3pu3MUVePgSY0ILMjA+aEwOosS77m3/DRbtvHrHwqvMcw+cjANMeGzJ+i0ar+n77KXpRA8RQ==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.13.tgz",
+      "integrity": "sha512-ECfsw7mf6G/sxNbKbGE3/h1xeIArY/yRI1IjDGYkLgDIankh+aDOtDRSr40LVlIHGL9+jEH1cVuxmbJ8NLL/1A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.8.tgz",
-      "integrity": "sha512-wAr2REfKsqoKQ+OkNqvOShnBoh+nkPurDKW7uAeVSu6kUECnWlSJiPvnoqxGlfousEY/v9LfS9sNc46hjSYDIQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.8.tgz",
-      "integrity": "sha512-CWl5UCM57WUFaFi5kB7IBY1UmOeLvNZAZ2/OZ5l20ldiJ3TiIz1pC65gYj8X0BCPWkeR1E32mpsCk1L1I4n+lA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.9.tgz",
-      "integrity": "sha512-/Wt5+CT8dpTFQxEJ9iGy/UGrXr7p2wlIOEHvIr/YcHYByzoLjrqkYqXdJjd9UIgWjv7eqV2HnFJen93UTuwfTQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.972.28",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.28.tgz",
-      "integrity": "sha512-cfWZFlVh7Va9lRay4PN2A9ARFzaBYcA097InT5M2CdRS05ECF5yaz86jET8Wsl2WcyKYEvVr/QNmKtYtafUHtQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/util-endpoints": "^3.996.5",
-        "@smithy/core": "^3.23.13",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-retry": "^4.2.13",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -681,22 +469,17 @@
       }
     },
     "node_modules/@aws-sdk/middleware-websocket": {
-      "version": "3.972.14",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.14.tgz",
-      "integrity": "sha512-qnfDlIHjm6DrTYNvWOUbnZdVKgtoKbO/Qzj+C0Wp5Y7VUrsvBRQtGKxD+hc+mRTS4N0kBJ6iZ3+zxm4N1OSyjg==",
+      "version": "3.972.21",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.21.tgz",
+      "integrity": "sha512-yr+5+C7v9R55sAJ89A55Wrm7wIKPVn5cm6J3Hztnd5s/iwEUKxyJqCnIxJu4fVXgG9XBQD1Jc4rsWC1ozahJjA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/util-format-url": "^3.972.8",
-        "@smithy/eventstream-codec": "^4.2.12",
-        "@smithy/eventstream-serde-browser": "^4.2.12",
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/signature-v4": "^5.3.12",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-hex-encoding": "^4.2.2",
-        "@smithy/util-utf8": "^4.2.2",
+        "@aws-sdk/core": "^3.974.13",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.3",
+        "@smithy/fetch-http-handler": "^5.4.3",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -704,64 +487,36 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.996.18",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.18.tgz",
-      "integrity": "sha512-c7ZSIXrESxHKx2Mcopgd8AlzZgoXMr20fkx5ViPWPOLBvmyhw9VwJx/Govg8Ef/IhEon5R9l53Z8fdYSEmp6VA==",
+      "version": "3.997.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.11.tgz",
+      "integrity": "sha512-nWXXJ1r/r8N2Gw1pWolRgED38/A9A8DHR2ETWIv220zh4PZHcybbR4hUVWWktmNXTRHzDJwRluapHn0rZxuoqA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/middleware-host-header": "^3.972.8",
-        "@aws-sdk/middleware-logger": "^3.972.8",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.9",
-        "@aws-sdk/middleware-user-agent": "^3.972.28",
-        "@aws-sdk/region-config-resolver": "^3.972.10",
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/util-endpoints": "^3.996.5",
-        "@aws-sdk/util-user-agent-browser": "^3.972.8",
-        "@aws-sdk/util-user-agent-node": "^3.973.14",
-        "@smithy/config-resolver": "^4.4.13",
-        "@smithy/core": "^3.23.13",
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/hash-node": "^4.2.12",
-        "@smithy/invalid-dependency": "^4.2.12",
-        "@smithy/middleware-content-length": "^4.2.12",
-        "@smithy/middleware-endpoint": "^4.4.28",
-        "@smithy/middleware-retry": "^4.4.46",
-        "@smithy/middleware-serde": "^4.2.16",
-        "@smithy/middleware-stack": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/node-http-handler": "^4.5.1",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.8",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.44",
-        "@smithy/util-defaults-mode-node": "^4.2.48",
-        "@smithy/util-endpoints": "^3.3.3",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-retry": "^4.2.13",
-        "@smithy/util-utf8": "^4.2.2",
+        "@aws-sdk/core": "^3.974.13",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.28",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.3",
+        "@smithy/fetch-http-handler": "^5.4.3",
+        "@smithy/node-http-handler": "^4.7.3",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.10.tgz",
-      "integrity": "sha512-1dq9ToC6e070QvnVhhbAs3bb5r6cQ10gTVc6cyRV5uvQe7P138TV2uG2i6+Yok4bAkVAcx5AqkTEBUvWEtBlsQ==",
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.28",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.28.tgz",
+      "integrity": "sha512-qs9z5LqXO/CZC2Lg9SGKpoLU8Rhi+m2pFKZqfO9pytX1clc0katqtsDNupJxFy0xT9wsZSPzM2v1y+/H/zfp5Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/config-resolver": "^4.4.13",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.3",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -769,17 +524,16 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1021.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1021.0.tgz",
-      "integrity": "sha512-TKY6h9spUk3OLs5v1oAgW9mAeBE3LAGNBwJokLy96wwmd4W2v/tYlXseProyed9ValDj2u1jK/4Rg1T+1NXyJA==",
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
+      "integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/nested-clients": "^3.996.18",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -787,43 +541,12 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.6.tgz",
-      "integrity": "sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==",
+      "version": "3.973.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
+      "integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.5.tgz",
-      "integrity": "sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-endpoints": "^3.3.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-format-url": {
-      "version": "3.972.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.8.tgz",
-      "integrity": "sha512-J6DS9oocrgxM8xlUTTmQOuwRF6rnAGEujAN9SAzllcrQmwn5iJ58ogxy3SEhD0Q7JZvlA5jvIXBkpQRqEqlE9A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/querystring-builder": "^4.2.12",
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -842,51 +565,15 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.8.tgz",
-      "integrity": "sha512-B3KGXJviV2u6Cdw2SDY2aDhoJkVfY/Q/Trwk2CMSkikE1Oi6gRzxhvhIfiRpHfmIsAhV4EA54TVEX8K6CbHbkA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/types": "^4.13.1",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.973.14",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.14.tgz",
-      "integrity": "sha512-vNSB/DYaPOyujVZBg/zUznH9QC142MaTHVmaFlF7uzzfg3CgT9f/l4C0Yi+vU/tbBhxVcXVB90Oohk5+o+ZbWw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/middleware-user-agent": "^3.972.28",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-config-provider": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.16",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.16.tgz",
-      "integrity": "sha512-iu2pyvaqmeatIJLURLqx9D+4jKAdTH20ntzB6BFwjyN7V960r4jK32mx0Zf7YbtOYAbmbtQfDNuL60ONinyw7A==",
+      "version": "3.972.25",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.25.tgz",
+      "integrity": "sha512-GH+Kjz4nPKWKHnsiQpnhP1MJdTGIcK4rAka6tzakgjjUkVgNsmPeEbbRAf09SzS1hjGu6duGHCBsxYke0BhHjQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
-        "fast-xml-parser": "5.5.8",
+        "@nodable/entities": "2.1.0",
+        "@smithy/types": "^4.14.2",
+        "fast-xml-parser": "5.7.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -903,13 +590,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -918,9 +605,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -928,21 +615,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -959,14 +646,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -976,14 +663,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -993,9 +680,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1003,29 +690,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1035,9 +722,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
-      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1045,27 +732,27 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1073,26 +760,26 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1102,13 +789,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx-self": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
-      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1118,13 +805,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx-source": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
-      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1134,42 +821,42 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
-      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -1177,26 +864,16 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@borewit/text-codec": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
-      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/@braintree/sanitize-url": {
@@ -1205,49 +882,16 @@
       "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
       "license": "MIT"
     },
-    "node_modules/@chevrotain/cst-dts-gen": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.1.2.tgz",
-      "integrity": "sha512-XTsjvDVB5nDZBQB8o0o/0ozNelQtn2KrUVteIHSlPd2VAV2utEb6JzyCJaJ8tGxACR4RiBNWy5uYUHX2eji88Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@chevrotain/gast": "11.1.2",
-        "@chevrotain/types": "11.1.2",
-        "lodash-es": "4.17.23"
-      }
-    },
-    "node_modules/@chevrotain/gast": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.1.2.tgz",
-      "integrity": "sha512-Z9zfXR5jNZb1Hlsd/p+4XWeUFugrHirq36bKzPWDSIacV+GPSVXdk+ahVWZTwjhNwofAWg/sZg58fyucKSQx5g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@chevrotain/types": "11.1.2",
-        "lodash-es": "4.17.23"
-      }
-    },
-    "node_modules/@chevrotain/regexp-to-ast": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-11.1.2.tgz",
-      "integrity": "sha512-nMU3Uj8naWer7xpZTYJdxbAs6RIv/dxYzkYU8GSwgUtcAAlzjcPfX1w+RKRcYG8POlzMeayOQ/znfwxEGo5ulw==",
-      "license": "Apache-2.0"
-    },
     "node_modules/@chevrotain/types": {
       "version": "11.1.2",
       "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
       "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
       "license": "Apache-2.0"
     },
-    "node_modules/@chevrotain/utils": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.1.2.tgz",
-      "integrity": "sha512-4mudFAQ6H+MqBTfqLmU7G1ZwRzCLfJEooL/fsF6rCX5eePMbGhoy5n4g+G4vlh2muDcsCTJtL+uKbOzWxs5LHA==",
-      "license": "Apache-2.0"
-    },
     "node_modules/@codemirror/autocomplete": {
-      "version": "6.20.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.1.tgz",
-      "integrity": "sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==",
+      "version": "6.20.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.2.tgz",
+      "integrity": "sha512-G5FPkgIiLjOgZMjqVjvuKQ1rGPtHogLldJr33eFJdVLtmwY+giGrlv/ewljLz6b9BSQLkjxuwBc6g6omDM+YxQ==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/language": "^6.0.0",
@@ -1361,13 +1005,16 @@
       }
     },
     "node_modules/@codemirror/lang-jinja": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-jinja/-/lang-jinja-6.0.0.tgz",
-      "integrity": "sha512-47MFmRcR8UAxd8DReVgj7WJN1WSAMT7OJnewwugZM4XiHWkOjgJQqvEM1NpMj9ALMPyxmlziEI1opH9IaEvmaw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-jinja/-/lang-jinja-6.0.1.tgz",
+      "integrity": "sha512-P5kyHLObzjtbGj16h+hyvZTxJhSjBEeSx4wMjbnAf3b0uwTy2+F0zGjMZL4PQOm/mh2eGZ5xUDVZXgwP783Nsw==",
       "license": "MIT",
       "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
         "@codemirror/lang-html": "^6.0.0",
         "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
         "@lezer/common": "^1.2.0",
         "@lezer/highlight": "^1.2.0",
         "@lezer/lr": "^1.4.0"
@@ -1591,29 +1238,29 @@
       }
     },
     "node_modules/@codemirror/legacy-modes": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/legacy-modes/-/legacy-modes-6.5.2.tgz",
-      "integrity": "sha512-/jJbwSTazlQEDOQw2FJ8LEEKVS72pU0lx6oM54kGpL8t/NJ2Jda3CZ4pcltiKTdqYSRk3ug1B3pil1gsjA6+8Q==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/legacy-modes/-/legacy-modes-6.5.3.tgz",
+      "integrity": "sha512-xCsmIzH78MyWkib9jlPaaun57XNkfbMIhagfaZVd0iLTqlpw3jXaIcbZm72MTmmn64eTZpBVNjbyYh+QXnxRsg==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/language": "^6.0.0"
       }
     },
     "node_modules/@codemirror/lint": {
-      "version": "6.9.5",
-      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.5.tgz",
-      "integrity": "sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==",
+      "version": "6.9.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.6.tgz",
+      "integrity": "sha512-6Kp7r6XfCi/D/5sdXieMfg9pJU1bUEx96WITuLU6ESaKizCz0QHFMjY/TaFSbigDdEAIgi93itLBIUETP4oK+A==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.35.0",
+        "@codemirror/view": "^6.42.0",
         "crelt": "^1.0.5"
       }
     },
     "node_modules/@codemirror/search": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.6.0.tgz",
-      "integrity": "sha512-koFuNXcDvyyotWcgOnZGmY7LZqEOXZaaxD/j6n18TCLx2/9HieZJ5H6hs1g8FiRxBD0DNfs0nXn17g872RmYdw==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.7.0.tgz",
+      "integrity": "sha512-ZvGm99wc/s2cITtMT15LFdn8aH/aS+V+DqyGq/N5ZlV5vWtH+nILvC2nw0zX7ByNoHHDZ2IxxdW38O0tc5nVHg==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/state": "^6.0.0",
@@ -1643,9 +1290,9 @@
       }
     },
     "node_modules/@codemirror/view": {
-      "version": "6.41.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.41.0.tgz",
-      "integrity": "sha512-6H/qadXsVuDY219Yljhohglve8xf4B8xJkVOEWfA5uiYKiTFppjqsvsfR5iPA0RbvRBoOyTZpbLIxe9+0UR8xA==",
+      "version": "6.43.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.0.tgz",
+      "integrity": "sha512-V7ZCLQO3Jus9hzh2jVCCPW3mO4IBMr43O37PqSUYautJSnnJF41YlgLw21x0fLJTYvJ+Vkm6Gp+qKGH9pltgXA==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/state": "^6.6.0",
@@ -1654,10 +1301,1833 @@
         "w3c-keyname": "^2.2.4"
       }
     },
+    "node_modules/@earendil-works/pi-agent-core": {
+      "version": "0.75.5",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.75.5.tgz",
+      "integrity": "sha512-LHygOgsW2pgXKb3IkXkOAeZPovHr9VF+EixgXVsDNuB4jmhEOXgshy/zksZ7slkUAx10OQ9W1Ed/2jsnhd1NqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/pi-ai": "^0.75.5",
+        "ignore": "7.0.5",
+        "typebox": "1.1.38",
+        "yaml": "2.9.0"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-ai": {
+      "version": "0.75.5",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.75.5.tgz",
+      "integrity": "sha512-zf1F5kXk1pqZeFShXOqq9ibUk8QdtRoLCDPAjO+hj44e3EUs9/GFO2qnhTC5+JA2uwVCx+WCNe1PiCjlBYWm5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": "0.91.1",
+        "@aws-sdk/client-bedrock-runtime": "3.1048.0",
+        "@google/genai": "1.52.0",
+        "@mistralai/mistralai": "2.2.1",
+        "@smithy/node-http-handler": "4.7.3",
+        "http-proxy-agent": "7.0.2",
+        "https-proxy-agent": "7.0.6",
+        "openai": "6.26.0",
+        "partial-json": "0.1.7",
+        "typebox": "1.1.38"
+      },
+      "bin": {
+        "pi-ai": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent": {
+      "version": "0.75.5",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.75.5.tgz",
+      "integrity": "sha512-O3CCQDYy28D4uwtP6zZkdEwzHN6X22v49Sb0+SZTC7x37V/YfmogrWPiaFoWeoc2hmdKhSATI7ZAK5bQbJG5NA==",
+      "hasShrinkwrap": true,
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/pi-agent-core": "^0.75.5",
+        "@earendil-works/pi-ai": "^0.75.5",
+        "@earendil-works/pi-tui": "^0.75.5",
+        "@silvia-odwyer/photon-node": "0.3.4",
+        "chalk": "5.6.2",
+        "cross-spawn": "7.0.6",
+        "diff": "8.0.4",
+        "glob": "13.0.6",
+        "highlight.js": "10.7.3",
+        "hosted-git-info": "9.0.3",
+        "ignore": "7.0.5",
+        "jiti": "2.7.0",
+        "minimatch": "10.2.5",
+        "proper-lockfile": "4.1.2",
+        "typebox": "1.1.38",
+        "undici": "8.3.0",
+        "yaml": "2.9.0"
+      },
+      "bin": {
+        "pi": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      },
+      "optionalDependencies": {
+        "@mariozechner/clipboard": "0.3.6"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@anthropic-ai/sdk": {
+      "version": "0.91.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/client-bedrock-runtime": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
+      "integrity": "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/credential-provider-node": "^3.972.42",
+        "@aws-sdk/eventstream-handler-node": "^3.972.16",
+        "@aws-sdk/middleware-eventstream": "^3.972.12",
+        "@aws-sdk/middleware-websocket": "^3.972.19",
+        "@aws-sdk/token-providers": "3.1048.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/core": {
+      "version": "3.974.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.11.tgz",
+      "integrity": "sha512-QpnINq5FZH6EOaDEkmHdT7eUunbvD27pDNQypaWjFyYz7Zl1q3UCMQErBZxpmfGfI7MvI2TlK8KTkgNpv8b1ug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/xml-builder": "^3.972.24",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.37.tgz",
+      "integrity": "sha512-/jpPvEh6f7ntmIzf7dNxoNX6Q8vt8UpesCjbW6mFfk4V1NW6bIy9qxcQ6WbA8As5yQhsZOe+xeNd4xHX8kdY2Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.39.tgz",
+      "integrity": "sha512-pIgTpisWyWg7X1bUbzSjuUYosYTD0Ghz2M0hkSTmb3a6i3qV3uU+NYJPI/E2XSC0HcsZh5rsLPzeXrkb2DS0Cg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.41.tgz",
+      "integrity": "sha512-u2tyjaxJJzW8UtW4SM1ZcPMDwO6y+kV+llvou+Adts0FAKyzes5jG4izQN+KX3yE8ZROpS5y1LJ//xL2iSf76w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/credential-provider-env": "^3.972.37",
+        "@aws-sdk/credential-provider-http": "^3.972.39",
+        "@aws-sdk/credential-provider-login": "^3.972.41",
+        "@aws-sdk/credential-provider-process": "^3.972.37",
+        "@aws-sdk/credential-provider-sso": "^3.972.41",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.41",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/credential-provider-imds": "^4.3.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.41.tgz",
+      "integrity": "sha512-0LBitxXiAiaE5nlFPfpNIww/8FRY/I7WIndWsc9GmNFOM7cE1wNpVNQEGEk9Outg5l8xl+3vybxFyUy4l9q/LQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.42.tgz",
+      "integrity": "sha512-D4oon2zbqqsWOJUM99Gm3/ZyJ0IJvTXVN3PyloGb3kQEyI36fjCZheZj422lAgTWWd6TSHgiImLt3RIaLdv3dQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.37",
+        "@aws-sdk/credential-provider-http": "^3.972.39",
+        "@aws-sdk/credential-provider-ini": "^3.972.41",
+        "@aws-sdk/credential-provider-process": "^3.972.37",
+        "@aws-sdk/credential-provider-sso": "^3.972.41",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.41",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/credential-provider-imds": "^4.3.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.37.tgz",
+      "integrity": "sha512-7nVaHBUaWIddASYfVaA9O4D5ZVjewU3sCol9WqZPGfW0nR+0WqE0xHZnD/U2L33PlOB8KNXGKZ6wOES/QijKzg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.41.tgz",
+      "integrity": "sha512-IOWAWEHe5LkjSKkkUUX9ciV6Y1scHTsnfEkdt5yyC4Slrc7AGbkLPrpntjqh18ksJAMOaVhoBsO8p2WyTcY2wQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/token-providers": "3.1048.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.41.tgz",
+      "integrity": "sha512-mbACk9Yypa8nm4iGZLs0PofOXEcTDOUw6wDnsPXNDNSd2WNXs1tSo+6nc/fh0jLYdfVZThhBL98PHW4aXFsG5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.16.tgz",
+      "integrity": "sha512-yedpPgKftqjU5SlPFHfqWpOw6xSCRieWRG1euWOlXn4WJxt2VX92VprCa2PpSOXjVCAeK6dTjW9eJRXVig9yGA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.12.tgz",
+      "integrity": "sha512-tHTHHCHNrq6XklQvlzHBDJG4Iuhh7NVPRdtmvP+nHFA+5sxPlIDzlAHHgfoYHGvT3NXP1yVP/L5c3opUn6T3Qg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/middleware-websocket": {
+      "version": "3.972.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.19.tgz",
+      "integrity": "sha512-mkEhOGYozqKQkbFaVrjwr0faiwwZza1v5/jSY6Tucm3bD+uKTazIUH/4Yo6aMnQD2ua2W9cMP6s8mvwTcjtqHw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.9.tgz",
+      "integrity": "sha512-jPR3rnmRI4hWYyzfmTGBr7NblMp8QYYeflHXba1H6+7CGrWVqWKQzaXFQ4qbExqPRsXN3T3L3JxFhr6aouXUGQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.27",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.27.tgz",
+      "integrity": "sha512-0Phbz4t6HI3D3skxvG2uI+VWU034/nSIw1T8d+FPzzQG9EQTrw94o9mOKO2Gv3n3Oc8P7JD7RAUxkoneLWv5Eg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
+      "integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/types": {
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.24.tgz",
+      "integrity": "sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@nodable/entities": "2.1.0",
+        "@smithy/types": "^4.14.1",
+        "fast-xml-parser": "5.7.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
+      "version": "0.75.5",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.75.5.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/pi-ai": "^0.75.5",
+        "ignore": "7.0.5",
+        "typebox": "1.1.38",
+        "yaml": "2.9.0"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
+      "version": "0.75.5",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.75.5.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": "0.91.1",
+        "@aws-sdk/client-bedrock-runtime": "3.1048.0",
+        "@google/genai": "1.52.0",
+        "@mistralai/mistralai": "2.2.1",
+        "@smithy/node-http-handler": "4.7.3",
+        "http-proxy-agent": "7.0.2",
+        "https-proxy-agent": "7.0.6",
+        "openai": "6.26.0",
+        "partial-json": "0.1.7",
+        "typebox": "1.1.38"
+      },
+      "bin": {
+        "pi-ai": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
+      "version": "0.75.5",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.75.5.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "1.6.0",
+        "marked": "15.0.12"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@google/genai": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+      "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.6.tgz",
+      "integrity": "sha512-MXdtr+6+ntlIVHdrZYuZNQydu6o8yZswFJ2Ln81j2O/Y9B/LDHvEaIm95xWNPkjGTWriSOeLnQJRFs6dYb60bg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@mariozechner/clipboard-darwin-arm64": "0.3.6",
+        "@mariozechner/clipboard-darwin-universal": "0.3.6",
+        "@mariozechner/clipboard-darwin-x64": "0.3.6",
+        "@mariozechner/clipboard-linux-arm64-gnu": "0.3.6",
+        "@mariozechner/clipboard-linux-arm64-musl": "0.3.6",
+        "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.6",
+        "@mariozechner/clipboard-linux-x64-gnu": "0.3.6",
+        "@mariozechner/clipboard-linux-x64-musl": "0.3.6",
+        "@mariozechner/clipboard-win32-arm64-msvc": "0.3.6",
+        "@mariozechner/clipboard-win32-x64-msvc": "0.3.6"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-arm64": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.6.tgz",
+      "integrity": "sha512-HjaisYCAbHi/1+N1yDAQHc8ZXGffufIUT5NSOSVR3f3AuMDusxTtnbK8tZ7JFDkShua1oNGZoNwQHsc8MPtE0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-universal": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.6.tgz",
+      "integrity": "sha512-8BWtPjOtJOJoykml3w0fx0zRrfWP31mXrJwfoA7xzNprkZw1uolCNfgmjDiVBseoKjp16EGITz7bN+61qn8dWA==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-x64": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.6.tgz",
+      "integrity": "sha512-p9syiZD1kU4I+1ya7f7g+zD1GiUvR8fdlRlNmgsZNWlyjtc8rlV2EjTLd/35x1LsdBq020GVvtzp0ZmPgBI09Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-arm64-gnu": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.6.tgz",
+      "integrity": "sha512-5JFf5rGofrm+V29HNF+wLthXphHdQpMbKDUYJ5tML6/Z5DLlLOV/9Ak4kDPtYyZ+Dzf+kAusE0VsFg4+tfP1IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-arm64-musl": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.6.tgz",
+      "integrity": "sha512-JlVjxxw0GbGC0djXYWRIqyteO3J1KZ/QG3udlEFaOD5TLOM1FnmXXAPDQBqr+aBVr720ef9K00dirYnJ0LDCtw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-riscv64-gnu": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.6.tgz",
+      "integrity": "sha512-4t8BUi5zZ+L77otFQVnVSlaTyAX4TVk9EqQm4syMrEQp96trFEHEwwNHcNEBGzYv5+K7mxay50TthYkz47OWzQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-x64-gnu": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.6.tgz",
+      "integrity": "sha512-trtPwcNLW37irwQCJLtCxLw757jjJZk3TSnY/MU9bhtWtA3K9b/eLW0e4RGhUXDoFRds9opNWWaUDuFLa8dm0w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-x64-musl": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.6.tgz",
+      "integrity": "sha512-WfnzIvOCCWQiN0MmltCEo6cLceUDbYe+I7xyFZjaps5A+2Op/M2CY7Rey+C4ucQhrvmpoHmTSFgY9ODWk7snoA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-win32-arm64-msvc": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.6.tgz",
+      "integrity": "sha512-+8+1aHYsBPUjmW3otmWlg+Hijt0iJvoBBs5e0mxFeUd4gDaKMB8Bn6x7c6KVtscg7E5j5NFXnwQqNSIAO4p8zQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-win32-x64-msvc": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.6.tgz",
+      "integrity": "sha512-S4xfPmERC8ZkiLHe3vekZCjdDwNEETCuvCgQK2kP6/TnvmUkq1y2Pk+DjM4t8uh9KMX9bH4zs5ePcKa8GTXmfg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mistralai/mistralai": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.1.tgz",
+      "integrity": "sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-to-json-schema": "^3.25.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/inquire": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@silvia-odwyer/photon-node": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
+      "integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/core": {
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.3.tgz",
+      "integrity": "sha512-Ep/7tPamGY8mgESE3LyLKtxJyy6U52WWAqr/3wial47Sj4u3PiIF73AOGI27UyLy9duTkhZbgzodOfLV4TduZg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/credential-provider-imds": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.3.tgz",
+      "integrity": "sha512-I2Bti0DKFo2IJyN28ijCsx51BAumEYR4/1yZ1FXyBygy9MqbnMqCev4JPth/MbpRfBSRAX35hITSnAdJRo1u5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/fetch-http-handler": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.3.tgz",
+      "integrity": "sha512-F+DRf8IJazRJgYog2A/yJK7eYVc0rqTlRzO+5ZxjJd4WkZoKz0IJRncf7G6t1pdVT3kryJcwuTFhN1c5m6N47A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/node-http-handler": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+      "integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/signature-v4": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.3.tgz",
+      "integrity": "sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/types": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
+      "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-parser": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/google-auth-library": {
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/hosted-git-info": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+      "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^11.1.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/lru-cache": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.4.0.tgz",
+      "integrity": "sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/marked": {
+      "version": "15.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/openai": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
+      "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/p-retry/node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/partial-json": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
+      "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/proper-lockfile/node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/protobufjs": {
+      "version": "7.5.9",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.9.tgz",
+      "integrity": "sha512-Od4muIm3HW1AouyHF5lONOf1FWo3hY1NbFDoy191X9GzhpgW1clCoaFjfVs2rKJNFYpTNJbje4cbAIDBZJ63ZA==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/strnum": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/typebox": {
+      "version": "1.1.38",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
+      "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/undici": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.3.0.tgz",
+      "integrity": "sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
-      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
       "cpu": [
         "ppc64"
       ],
@@ -1667,14 +3137,15 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
-      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
       "cpu": [
         "arm"
       ],
@@ -1684,14 +3155,15 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
-      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
       "cpu": [
         "arm64"
       ],
@@ -1701,14 +3173,15 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
-      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
       "cpu": [
         "x64"
       ],
@@ -1718,14 +3191,15 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
-      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
       "cpu": [
         "arm64"
       ],
@@ -1735,14 +3209,15 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
-      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
       "cpu": [
         "x64"
       ],
@@ -1752,14 +3227,15 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
       "cpu": [
         "arm64"
       ],
@@ -1769,14 +3245,15 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
-      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
       "cpu": [
         "x64"
       ],
@@ -1786,14 +3263,15 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
-      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
       "cpu": [
         "arm"
       ],
@@ -1803,14 +3281,15 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
-      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
       "cpu": [
         "arm64"
       ],
@@ -1820,14 +3299,15 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
-      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
       "cpu": [
         "ia32"
       ],
@@ -1837,14 +3317,15 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
-      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
       "cpu": [
         "loong64"
       ],
@@ -1854,14 +3335,15 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
-      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
       "cpu": [
         "mips64el"
       ],
@@ -1871,14 +3353,15 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
-      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
       "cpu": [
         "ppc64"
       ],
@@ -1888,14 +3371,15 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
-      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
       "cpu": [
         "riscv64"
       ],
@@ -1905,14 +3389,15 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
-      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
       "cpu": [
         "s390x"
       ],
@@ -1922,14 +3407,15 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
-      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
       "cpu": [
         "x64"
       ],
@@ -1939,14 +3425,15 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
       "cpu": [
         "arm64"
       ],
@@ -1956,14 +3443,15 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
-      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
       "cpu": [
         "x64"
       ],
@@ -1973,14 +3461,15 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
       "cpu": [
         "arm64"
       ],
@@ -1990,14 +3479,15 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
-      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
       "cpu": [
         "x64"
       ],
@@ -2007,14 +3497,15 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
-      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
       "cpu": [
         "arm64"
       ],
@@ -2024,14 +3515,15 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
-      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
       "cpu": [
         "x64"
       ],
@@ -2041,14 +3533,15 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
-      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
       "cpu": [
         "arm64"
       ],
@@ -2058,14 +3551,15 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
-      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
       "cpu": [
         "ia32"
       ],
@@ -2075,14 +3569,15 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
-      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
       "cpu": [
         "x64"
       ],
@@ -2092,6 +3587,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2150,9 +3646,10 @@
       "link": true
     },
     "node_modules/@google/genai": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.47.0.tgz",
-      "integrity": "sha512-0VV7AaXm5rQu3oRHNZNEubRAOL2lv5u+YA72eWnDwcOx3B1jFRbvtgL4drRHlocRHOnludvr3xmbQGbR+/RQAQ==",
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+      "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "google-auth-library": "^10.3.0",
@@ -2179,14 +3676,14 @@
       "license": "MIT"
     },
     "node_modules/@iconify/utils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.0.tgz",
-      "integrity": "sha512-Zlzem1ZXhI1iHeeERabLNzBHdOa4VhQbqAcOQaMKuTuyZCpwKbC2R4Dd0Zo3g9EAc+Y4fiarO8HIHRAth7+skw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.3.tgz",
+      "integrity": "sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw==",
       "license": "MIT",
       "dependencies": {
         "@antfu/install-pkg": "^1.1.0",
         "@iconify/types": "^2.0.0",
-        "mlly": "^1.8.0"
+        "import-meta-resolve": "^4.2.0"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -2287,38 +3784,12 @@
       }
     },
     "node_modules/@kubernetes/client-node/node_modules/@types/node": {
-      "version": "24.12.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
-      "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
+      "version": "24.12.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
-      }
-    },
-    "node_modules/@kubernetes/client-node/node_modules/tar-fs": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
-      "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0",
-        "tar-stream": "^3.1.5"
-      },
-      "optionalDependencies": {
-        "bare-fs": "^4.0.1",
-        "bare-path": "^3.0.0"
-      }
-    },
-    "node_modules/@kubernetes/client-node/node_modules/tar-stream": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz",
-      "integrity": "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==",
-      "license": "MIT",
-      "dependencies": {
-        "b4a": "^1.6.4",
-        "bare-fs": "^4.5.5",
-        "fast-fifo": "^1.2.0",
-        "streamx": "^2.15.0"
       }
     },
     "node_modules/@kubernetes/client-node/node_modules/undici-types": {
@@ -2328,9 +3799,9 @@
       "license": "MIT"
     },
     "node_modules/@lezer/common": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.1.tgz",
-      "integrity": "sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+      "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
       "license": "MIT"
     },
     "node_modules/@lezer/cpp": {
@@ -2420,9 +3891,9 @@
       }
     },
     "node_modules/@lezer/lr": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.8.tgz",
-      "integrity": "sha512-bPWa0Pgx69ylNlMlPvBPryqeLYQjyJjqPx+Aupm5zydLIF3NE+6MMLT8Yi23Bd9cif9VS00aUebn+6fDIGBcDA==",
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.10.tgz",
+      "integrity": "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==",
       "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.0.0"
@@ -2524,10 +3995,35 @@
         "node-pre-gyp": "bin/node-pre-gyp"
       }
     },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/@mapbox/node-pre-gyp/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -2542,443 +4038,32 @@
       "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
       "license": "MIT"
     },
-    "node_modules/@mariozechner/clipboard": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.2.tgz",
-      "integrity": "sha512-IHQpksNjo7EAtGuHFU+tbWDp5LarH3HU/8WiB9O70ZEoBPHOg0/6afwSLK0QyNMMmx4Bpi/zl6+DcBXe95nWYA==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 10"
-      },
-      "optionalDependencies": {
-        "@mariozechner/clipboard-darwin-arm64": "0.3.2",
-        "@mariozechner/clipboard-darwin-universal": "0.3.2",
-        "@mariozechner/clipboard-darwin-x64": "0.3.2",
-        "@mariozechner/clipboard-linux-arm64-gnu": "0.3.2",
-        "@mariozechner/clipboard-linux-arm64-musl": "0.3.2",
-        "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.2",
-        "@mariozechner/clipboard-linux-x64-gnu": "0.3.2",
-        "@mariozechner/clipboard-linux-x64-musl": "0.3.2",
-        "@mariozechner/clipboard-win32-arm64-msvc": "0.3.2",
-        "@mariozechner/clipboard-win32-x64-msvc": "0.3.2"
-      }
-    },
-    "node_modules/@mariozechner/clipboard-darwin-arm64": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.2.tgz",
-      "integrity": "sha512-uBf6K7Je1ihsgvmWxA8UCGCeI+nbRVRXoarZdLjl6slz94Zs1tNKFZqx7aCI5O1i3e0B6ja82zZ06BWrl0MCVw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@mariozechner/clipboard-darwin-universal": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.2.tgz",
-      "integrity": "sha512-mxSheKTW2U9LsBdXy0SdmdCAE5HqNS9QUmpNHLnfJ+SsbFKALjEZc5oRrVMXxGQSirDvYf5bjmRyT0QYYonnlg==",
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@mariozechner/clipboard-darwin-x64": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.2.tgz",
-      "integrity": "sha512-U1BcVEoidvwIp95+HJswSW+xr28EQiHR7rZjH6pn8Sja5yO4Yoe3yCN0Zm8Lo72BbSOK/fTSq0je7CJpaPCspg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@mariozechner/clipboard-linux-arm64-gnu": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.2.tgz",
-      "integrity": "sha512-BsinwG3yWTIjdgNCxsFlip7LkfwPk+ruw/aFCXHUg/fb5XC/Ksp+YMQ7u0LUtiKzIv/7LMXgZInJQH6gxbAaqQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@mariozechner/clipboard-linux-arm64-musl": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.2.tgz",
-      "integrity": "sha512-0/Gi5Xq2V6goXBop19ePoHvXsmJD9SzFlO3S+d6+T2b+BlPcpOu3Oa0wTjl+cZrLAAEzA86aPNBI+VVAFDFPKw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@mariozechner/clipboard-linux-riscv64-gnu": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.2.tgz",
-      "integrity": "sha512-2AFFiXB24qf0zOZsxI1GJGb9wQGlOJyN6UwoXqmKS3dpQi/l6ix30IzDDA4c4ZcCcx4D+9HLYXhC1w7Sov8pXA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@mariozechner/clipboard-linux-x64-gnu": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.2.tgz",
-      "integrity": "sha512-v6fVnsn7WMGg73Dab8QMwyFce7tzGfgEixKgzLP8f1GJqkJZi5zO4k4FOHzSgUufgLil63gnxvMpjWkgfeQN7A==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@mariozechner/clipboard-linux-x64-musl": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.2.tgz",
-      "integrity": "sha512-xVUtnoMQ8v2JVyfJLKKXACA6avdnchdbBkTsZs8BgJQo29qwCp5NIHAUO8gbJ40iaEGToW5RlmVk2M9V0HsHEw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@mariozechner/clipboard-win32-arm64-msvc": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.2.tgz",
-      "integrity": "sha512-AEgg95TNi8TGgak2wSXZkXKCvAUTjWoU1Pqb0ON7JHrX78p616XUFNTJohtIon3e0w6k0pYPZeCuqRCza/Tqeg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@mariozechner/clipboard-win32-x64-msvc": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.2.tgz",
-      "integrity": "sha512-tGRuYpZwDOD7HBrCpyRuhGnHHSCknELvqwKKUG4JSfSB7JIU7LKRh6zx6fMUOQd8uISK35TjFg5UcNih+vJhFA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@mariozechner/jiti": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/@mariozechner/jiti/-/jiti-2.6.5.tgz",
-      "integrity": "sha512-faGUlTcXka5l7rv0lP3K3vGW/ejRuOS24RR2aSFWREUQqzjgdsuWNo/IiPqL3kWRGt6Ahl2+qcDAwtdeWeuGUw==",
-      "license": "MIT",
-      "dependencies": {
-        "std-env": "^3.10.0",
-        "yoctocolors": "^2.1.2"
-      },
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "node_modules/@mariozechner/pi-agent-core": {
-      "version": "0.64.0",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.64.0.tgz",
-      "integrity": "sha512-IN/sIxWOD0v1OFVXHB605SGiZhO5XdEWG5dO8EAV08n3jz/p12o4OuYGvhGXmHhU28WXa/FGWC+FO5xiIih8Uw==",
-      "license": "MIT",
-      "dependencies": {
-        "@mariozechner/pi-ai": "^0.64.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@mariozechner/pi-ai": {
-      "version": "0.64.0",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.64.0.tgz",
-      "integrity": "sha512-Z/Jnf+JSVDPLRcxJsa8XhYTJKIqKekNueaCpBLGQHgizL1F9RQ1Rur3rIfZpfXkt2cLu/AIPtOs223ueuoWaWg==",
-      "license": "MIT",
-      "dependencies": {
-        "@anthropic-ai/sdk": "^0.73.0",
-        "@aws-sdk/client-bedrock-runtime": "^3.983.0",
-        "@google/genai": "^1.40.0",
-        "@mistralai/mistralai": "1.14.1",
-        "@sinclair/typebox": "^0.34.41",
-        "ajv": "^8.17.1",
-        "ajv-formats": "^3.0.1",
-        "chalk": "^5.6.2",
-        "openai": "6.26.0",
-        "partial-json": "^0.1.7",
-        "proxy-agent": "^6.5.0",
-        "undici": "^7.19.1",
-        "zod-to-json-schema": "^3.24.6"
-      },
-      "bin": {
-        "pi-ai": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@mariozechner/pi-ai/node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@mariozechner/pi-coding-agent": {
-      "version": "0.64.0",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.64.0.tgz",
-      "integrity": "sha512-Q4tcqSqFGQtOgCtRyIp1D80Nv2if13Q2pfbnrOlaT/mix90mLcZGML9jKVnT1jGSy5GMYudU1HsS7cx53kxb0g==",
-      "license": "MIT",
-      "dependencies": {
-        "@mariozechner/jiti": "^2.6.2",
-        "@mariozechner/pi-agent-core": "^0.64.0",
-        "@mariozechner/pi-ai": "^0.64.0",
-        "@mariozechner/pi-tui": "^0.64.0",
-        "@silvia-odwyer/photon-node": "^0.3.4",
-        "ajv": "^8.17.1",
-        "chalk": "^5.5.0",
-        "cli-highlight": "^2.1.11",
-        "diff": "^8.0.2",
-        "extract-zip": "^2.0.1",
-        "file-type": "^21.1.1",
-        "glob": "^13.0.1",
-        "hosted-git-info": "^9.0.2",
-        "ignore": "^7.0.5",
-        "marked": "^15.0.12",
-        "minimatch": "^10.2.3",
-        "proper-lockfile": "^4.1.2",
-        "strip-ansi": "^7.1.0",
-        "undici": "^7.19.1",
-        "yaml": "^2.8.2"
-      },
-      "bin": {
-        "pi": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=20.6.0"
-      },
-      "optionalDependencies": {
-        "@mariozechner/clipboard": "^0.3.2"
-      }
-    },
-    "node_modules/@mariozechner/pi-coding-agent/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/@mariozechner/pi-coding-agent/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@mariozechner/pi-coding-agent/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@mariozechner/pi-coding-agent/node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@mariozechner/pi-coding-agent/node_modules/glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@mariozechner/pi-coding-agent/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@mariozechner/pi-coding-agent/node_modules/minipass": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/@mariozechner/pi-coding-agent/node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/@mariozechner/pi-tui": {
-      "version": "0.64.0",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.64.0.tgz",
-      "integrity": "sha512-W1qLry9MAuN/V3YJmMv/BJa0VaYv721NkXPg/DGItdqWxuDc+1VdNbyAnRwxblNkIpXVUWL26x64BlyFXpxmkg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mime-types": "^2.1.4",
-        "chalk": "^5.5.0",
-        "get-east-asian-width": "^1.3.0",
-        "marked": "^15.0.12",
-        "mime-types": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "optionalDependencies": {
-        "koffi": "^2.9.0"
-      }
-    },
-    "node_modules/@mariozechner/pi-tui/node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
     "node_modules/@mermaid-js/parser": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.0.1.tgz",
-      "integrity": "sha512-opmV19kN1JsK0T6HhhokHpcVkqKpF+x2pPDKKM2ThHtZAB5F4PROopk0amuVYK5qMrIA4erzpNm8gmPNJgMDxQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.1.tgz",
+      "integrity": "sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==",
       "license": "MIT",
       "dependencies": {
-        "langium": "^4.0.0"
+        "@chevrotain/types": "~11.1.1"
       }
     },
     "node_modules/@milkdown/components": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/@milkdown/components/-/components-7.20.0.tgz",
-      "integrity": "sha512-Qn91/oZugGjf17ARE51nbEsH4YklZQaomRSsfxOAtIcwGEJe5osq+zhhKGtgAYFfUb6rU3W86Pe4XDlXN6vFjg==",
+      "version": "7.21.1",
+      "resolved": "https://registry.npmjs.org/@milkdown/components/-/components-7.21.1.tgz",
+      "integrity": "sha512-wyU/PPWfMJEbchiFnCHmgz5mMfcwp5ZbkWrbplJSak/H/zpDg46jAL7k7TZwvyb1YHF1P63BL26P8A3B6igUDQ==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.5.1",
-        "@milkdown/core": "7.20.0",
-        "@milkdown/ctx": "7.20.0",
-        "@milkdown/exception": "7.20.0",
-        "@milkdown/plugin-tooltip": "7.20.0",
-        "@milkdown/preset-commonmark": "7.20.0",
-        "@milkdown/preset-gfm": "7.20.0",
-        "@milkdown/prose": "7.20.0",
-        "@milkdown/transformer": "7.20.0",
-        "@milkdown/utils": "7.20.0",
+        "@milkdown/core": "7.21.1",
+        "@milkdown/ctx": "7.21.1",
+        "@milkdown/exception": "7.21.1",
+        "@milkdown/plugin-diff": "7.21.1",
+        "@milkdown/plugin-tooltip": "7.21.1",
+        "@milkdown/preset-commonmark": "7.21.1",
+        "@milkdown/preset-gfm": "7.21.1",
+        "@milkdown/prose": "7.21.1",
+        "@milkdown/transformer": "7.21.1",
+        "@milkdown/utils": "7.21.1",
         "@types/lodash-es": "^4.17.12",
         "clsx": "^2.0.0",
         "dompurify": "^3.2.5",
@@ -2993,43 +4078,25 @@
         "@codemirror/view": "^6"
       }
     },
-    "node_modules/@milkdown/components/node_modules/nanoid": {
-      "version": "5.1.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.7.tgz",
-      "integrity": "sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.js"
-      },
-      "engines": {
-        "node": "^18 || >=20"
-      }
-    },
     "node_modules/@milkdown/core": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/@milkdown/core/-/core-7.20.0.tgz",
-      "integrity": "sha512-X9LaUcIR4Y2oiY2J5tslavlPVOwIB3X8/9z1bOeBjlIPtr+urbkY7YEX86EeLV9LyRQ3+t+jXaLMCIjW1wsV6w==",
+      "version": "7.21.1",
+      "resolved": "https://registry.npmjs.org/@milkdown/core/-/core-7.21.1.tgz",
+      "integrity": "sha512-hMWEarN+bgDpXdk/NDOFZERKWbenzVx2KzyGsVSeYtTQwlGTsL1eBzFvr9+RbCta74M48d41zG1aatuZNUWZ1A==",
       "license": "MIT",
       "dependencies": {
-        "@milkdown/ctx": "7.20.0",
-        "@milkdown/exception": "7.20.0",
-        "@milkdown/prose": "7.20.0",
-        "@milkdown/transformer": "7.20.0",
+        "@milkdown/ctx": "7.21.1",
+        "@milkdown/exception": "7.21.1",
+        "@milkdown/prose": "7.21.1",
+        "@milkdown/transformer": "7.21.1",
         "remark-parse": "^11.0.0",
         "remark-stringify": "^11.0.0",
         "unified": "^11.0.3"
       }
     },
     "node_modules/@milkdown/crepe": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/@milkdown/crepe/-/crepe-7.20.0.tgz",
-      "integrity": "sha512-KT+oFF6Q7mI41z01c9v/wUUCyQ2f908TgOsa6mwi25yuxnxQxISZFCjRvlh0sc9p9D3CrMeuJWGCN6DialQdig==",
+      "version": "7.21.1",
+      "resolved": "https://registry.npmjs.org/@milkdown/crepe/-/crepe-7.21.1.tgz",
+      "integrity": "sha512-95liVYrjdbUmfCdSrNi08+ZvvaPBqAQdOIi9E92chvt4gec+uDlzLrRYS5n5XXQYfDT1U9+637r46xPFIU0RjA==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/commands": "^6.2.4",
@@ -3038,10 +4105,11 @@
         "@codemirror/state": "^6.4.1",
         "@codemirror/theme-one-dark": "^6.1.2",
         "@codemirror/view": "^6.16.0",
-        "@milkdown/kit": "7.20.0",
+        "@milkdown/kit": "7.21.1",
         "@types/lodash-es": "^4.17.12",
         "clsx": "^2.0.0",
         "codemirror": "^6.0.1",
+        "dompurify": "^3.2.5",
         "katex": "^0.16.0",
         "lodash-es": "^4.17.21",
         "prosemirror-virtual-cursor": "^0.4.2",
@@ -3051,214 +4119,243 @@
       }
     },
     "node_modules/@milkdown/ctx": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/@milkdown/ctx/-/ctx-7.20.0.tgz",
-      "integrity": "sha512-LUK4xdsUngY2xCCvPTyHPifjAknJ5rE6VBjgsP+LySIUKeFUrhqzo/zz2vaOODKzm3DBMIhpZAoW3MAqxoMGIQ==",
+      "version": "7.21.1",
+      "resolved": "https://registry.npmjs.org/@milkdown/ctx/-/ctx-7.21.1.tgz",
+      "integrity": "sha512-Ickz/qJNgtX2Wvx1/U/paoa4ZzhlFDMx87r8Rv/ocz3neIBk5hKD4Bxuz78UEXtTDr68IPmVYGHog1fETXGU4Q==",
       "license": "MIT",
       "dependencies": {
-        "@milkdown/exception": "7.20.0"
+        "@milkdown/exception": "7.21.1"
       }
     },
     "node_modules/@milkdown/exception": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/@milkdown/exception/-/exception-7.20.0.tgz",
-      "integrity": "sha512-u8EL7rbqgrWrPpkDhrxUYXauw2DO52JUQmuokrUZvqezmflo7pgIDCr+Rk6AQslzB4Xw+n9eYik5rXX3RXC7Qg==",
+      "version": "7.21.1",
+      "resolved": "https://registry.npmjs.org/@milkdown/exception/-/exception-7.21.1.tgz",
+      "integrity": "sha512-j56qCj11VKrTjfrlm8sehvgpdNNwCNg3ZjeEk8+nDHsDomse0f+TO2HXeeP3Y/xKnLgMcpKyh7K9ATx4itnJpA==",
       "license": "MIT"
     },
     "node_modules/@milkdown/kit": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/@milkdown/kit/-/kit-7.20.0.tgz",
-      "integrity": "sha512-X74KMa0tcDAAMOE9aFtBRN+RCdD/HMXor5YN18e7d0pe4a65MGFklUGlcg1U6zEfeMMYeC3msNvMKLMwk3O5RA==",
+      "version": "7.21.1",
+      "resolved": "https://registry.npmjs.org/@milkdown/kit/-/kit-7.21.1.tgz",
+      "integrity": "sha512-2sN0QqPiHxY7PomhRlh1V+A68BqPUwulaltoqbVSkMFI85KB/Ifd1l4MnEBiTYw8RpCGqMOF8D3qbGUJrXVDpA==",
       "license": "MIT",
       "dependencies": {
-        "@milkdown/components": "7.20.0",
-        "@milkdown/core": "7.20.0",
-        "@milkdown/ctx": "7.20.0",
-        "@milkdown/plugin-block": "7.20.0",
-        "@milkdown/plugin-clipboard": "7.20.0",
-        "@milkdown/plugin-cursor": "7.20.0",
-        "@milkdown/plugin-history": "7.20.0",
-        "@milkdown/plugin-indent": "7.20.0",
-        "@milkdown/plugin-listener": "7.20.0",
-        "@milkdown/plugin-slash": "7.20.0",
-        "@milkdown/plugin-tooltip": "7.20.0",
-        "@milkdown/plugin-trailing": "7.20.0",
-        "@milkdown/plugin-upload": "7.20.0",
-        "@milkdown/preset-commonmark": "7.20.0",
-        "@milkdown/preset-gfm": "7.20.0",
-        "@milkdown/prose": "7.20.0",
-        "@milkdown/transformer": "7.20.0",
-        "@milkdown/utils": "7.20.0"
+        "@milkdown/components": "7.21.1",
+        "@milkdown/core": "7.21.1",
+        "@milkdown/ctx": "7.21.1",
+        "@milkdown/exception": "7.21.1",
+        "@milkdown/plugin-block": "7.21.1",
+        "@milkdown/plugin-clipboard": "7.21.1",
+        "@milkdown/plugin-cursor": "7.21.1",
+        "@milkdown/plugin-diff": "7.21.1",
+        "@milkdown/plugin-history": "7.21.1",
+        "@milkdown/plugin-indent": "7.21.1",
+        "@milkdown/plugin-listener": "7.21.1",
+        "@milkdown/plugin-slash": "7.21.1",
+        "@milkdown/plugin-streaming": "7.21.1",
+        "@milkdown/plugin-tooltip": "7.21.1",
+        "@milkdown/plugin-trailing": "7.21.1",
+        "@milkdown/plugin-upload": "7.21.1",
+        "@milkdown/preset-commonmark": "7.21.1",
+        "@milkdown/preset-gfm": "7.21.1",
+        "@milkdown/prose": "7.21.1",
+        "@milkdown/transformer": "7.21.1",
+        "@milkdown/utils": "7.21.1"
       }
     },
     "node_modules/@milkdown/plugin-block": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/@milkdown/plugin-block/-/plugin-block-7.20.0.tgz",
-      "integrity": "sha512-jIXfzJ8Zje+6+9ZwQuVmNeYE8KfzqL9YJ/YdMvWQIEiKhy2x9pZMAkkufgmUlq1aouxOV+gk5fX+ovxzEzfSrA==",
+      "version": "7.21.1",
+      "resolved": "https://registry.npmjs.org/@milkdown/plugin-block/-/plugin-block-7.21.1.tgz",
+      "integrity": "sha512-FnDxBBoaBZ2OQUU81xZSv8BoaeBfiA0jYo1xjVR1kqqFUNSe4iXXr/O2MB3YdA657uRbwKROgfjgtuxHbS+a8Q==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.5.1",
-        "@milkdown/core": "7.20.0",
-        "@milkdown/ctx": "7.20.0",
-        "@milkdown/prose": "7.20.0",
-        "@milkdown/utils": "7.20.0",
+        "@milkdown/core": "7.21.1",
+        "@milkdown/ctx": "7.21.1",
+        "@milkdown/prose": "7.21.1",
+        "@milkdown/utils": "7.21.1",
         "@types/lodash-es": "^4.17.12",
         "lodash-es": "^4.17.21"
       }
     },
     "node_modules/@milkdown/plugin-clipboard": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/@milkdown/plugin-clipboard/-/plugin-clipboard-7.20.0.tgz",
-      "integrity": "sha512-PyokNvwgWcO6/I/0LxDRnATpnxvs5upFRlp6eO8PhjwBFZftCIU6D15Wg4JAxwW7Y0NyTWfViWjc9TwiBd6KOQ==",
+      "version": "7.21.1",
+      "resolved": "https://registry.npmjs.org/@milkdown/plugin-clipboard/-/plugin-clipboard-7.21.1.tgz",
+      "integrity": "sha512-I9khT0KH4fglclXkEmkjQQRFw8uFmPI9GAHONaA4gZDLf7n9iP/lEyFXiU6ILFybwHwZPZET8XGSwbWhe5Z0Tg==",
       "license": "MIT",
       "dependencies": {
-        "@milkdown/core": "7.20.0",
-        "@milkdown/ctx": "7.20.0",
-        "@milkdown/prose": "7.20.0",
-        "@milkdown/utils": "7.20.0"
+        "@milkdown/core": "7.21.1",
+        "@milkdown/ctx": "7.21.1",
+        "@milkdown/prose": "7.21.1",
+        "@milkdown/utils": "7.21.1"
       }
     },
     "node_modules/@milkdown/plugin-cursor": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/@milkdown/plugin-cursor/-/plugin-cursor-7.20.0.tgz",
-      "integrity": "sha512-goCPwUARBzGV6Hvnr3P57Bj5TnyFjYIfDFLvgWTIlsm/dR2Wr4Syy4HDOtaKO9YL/VtZ8gtiZVgeo0vhc4CzMA==",
+      "version": "7.21.1",
+      "resolved": "https://registry.npmjs.org/@milkdown/plugin-cursor/-/plugin-cursor-7.21.1.tgz",
+      "integrity": "sha512-ClbLoZjJ43v61+ROsKVT1b9QZe1pIGGputpmS6JdDvrAnX4vvfSKpDWGNmpuq7skn8F8yCQoKCdlAWNQop1J+w==",
       "license": "MIT",
       "dependencies": {
-        "@milkdown/ctx": "7.20.0",
-        "@milkdown/prose": "7.20.0",
-        "@milkdown/utils": "7.20.0",
+        "@milkdown/ctx": "7.21.1",
+        "@milkdown/prose": "7.21.1",
+        "@milkdown/utils": "7.21.1",
         "prosemirror-drop-indicator": "^0.1.0"
       }
     },
-    "node_modules/@milkdown/plugin-history": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/@milkdown/plugin-history/-/plugin-history-7.20.0.tgz",
-      "integrity": "sha512-lqOYQBrxKj4px/i0Cav3zRkCArwnkv8o7fGMh3NtnUXMLSE7/xojK5GFPS4EaS/UKK7/+i1oV2+HRA6+6Ezy7w==",
+    "node_modules/@milkdown/plugin-diff": {
+      "version": "7.21.1",
+      "resolved": "https://registry.npmjs.org/@milkdown/plugin-diff/-/plugin-diff-7.21.1.tgz",
+      "integrity": "sha512-2tczMl6l+R34dAJ1FeolfrsT8uBeFlhvz0tP1LC3OiHPlBlNaKtibngNvZuMqaxCeoR/9dadIPIAL7d4CC4Rfg==",
       "license": "MIT",
       "dependencies": {
-        "@milkdown/core": "7.20.0",
-        "@milkdown/ctx": "7.20.0",
-        "@milkdown/prose": "7.20.0",
-        "@milkdown/utils": "7.20.0"
+        "@milkdown/core": "7.21.1",
+        "@milkdown/ctx": "7.21.1",
+        "@milkdown/prose": "7.21.1",
+        "@milkdown/transformer": "7.21.1",
+        "@milkdown/utils": "7.21.1"
+      }
+    },
+    "node_modules/@milkdown/plugin-history": {
+      "version": "7.21.1",
+      "resolved": "https://registry.npmjs.org/@milkdown/plugin-history/-/plugin-history-7.21.1.tgz",
+      "integrity": "sha512-b/Sdqx5/7veSAcGEphwPkqgLVyFW+2SIpHpWHVO7X8OhaOsfTPU08FvvGxbv6u54JwF9gDcoNp7sJ/9wBh2qog==",
+      "license": "MIT",
+      "dependencies": {
+        "@milkdown/core": "7.21.1",
+        "@milkdown/ctx": "7.21.1",
+        "@milkdown/prose": "7.21.1",
+        "@milkdown/utils": "7.21.1"
       }
     },
     "node_modules/@milkdown/plugin-indent": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/@milkdown/plugin-indent/-/plugin-indent-7.20.0.tgz",
-      "integrity": "sha512-KfdIztQMuHv4Rx1JmSQe2vooN4+Zm7MhjQkNolGyiI7BPZbu855hVIC/s96x3Dk04tkbb+M/i9MJhxCazxfd6Q==",
+      "version": "7.21.1",
+      "resolved": "https://registry.npmjs.org/@milkdown/plugin-indent/-/plugin-indent-7.21.1.tgz",
+      "integrity": "sha512-UrH3xCy0cjep57TWYAF1n6EXhVySNko2gmDQw+3ZstRFHcCaBbDriLywxLpUiBkI3KHIwpmkD+imGMt8qiDhnA==",
       "license": "MIT",
       "dependencies": {
-        "@milkdown/ctx": "7.20.0",
-        "@milkdown/prose": "7.20.0",
-        "@milkdown/utils": "7.20.0"
+        "@milkdown/ctx": "7.21.1",
+        "@milkdown/prose": "7.21.1",
+        "@milkdown/utils": "7.21.1"
       }
     },
     "node_modules/@milkdown/plugin-listener": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/@milkdown/plugin-listener/-/plugin-listener-7.20.0.tgz",
-      "integrity": "sha512-Sj+B63JfM3NVVS3uGXTPkoz8xx8MQYrR28pI9AaqX5q60tvCvOJw9E1ODvSsBEjeqnN4kablDthIugLlBhOlwQ==",
+      "version": "7.21.1",
+      "resolved": "https://registry.npmjs.org/@milkdown/plugin-listener/-/plugin-listener-7.21.1.tgz",
+      "integrity": "sha512-XDK1ouod1bYQWSqAvTWzMUfOZjbljGnbpgVPz8PmTI19sbJ5HkJ3xOwMHbpAxgB+RSvOLDaiURzhqdsHWl146w==",
       "license": "MIT",
       "dependencies": {
-        "@milkdown/core": "7.20.0",
-        "@milkdown/ctx": "7.20.0",
-        "@milkdown/prose": "7.20.0",
+        "@milkdown/core": "7.21.1",
+        "@milkdown/ctx": "7.21.1",
+        "@milkdown/prose": "7.21.1",
         "@types/lodash-es": "^4.17.12",
         "lodash-es": "^4.17.21"
       }
     },
     "node_modules/@milkdown/plugin-slash": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/@milkdown/plugin-slash/-/plugin-slash-7.20.0.tgz",
-      "integrity": "sha512-Qm3/ZxkGYd5XN+J/X91lGGu7SBzuQBOTOLjuJdg4qDBZmdEHlGojB+5BhCSAMB3WGyCpQQGbSqKOelUrXtj68w==",
+      "version": "7.21.1",
+      "resolved": "https://registry.npmjs.org/@milkdown/plugin-slash/-/plugin-slash-7.21.1.tgz",
+      "integrity": "sha512-/5n9zaQm4I9YRhvWh4tUwlklGM8qYLL9LzQKZ3nbFaXd3uQ2vCrsTjsLKbxy9q/a7C6APmLcDmPD0pYGIeWtMg==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.5.1",
-        "@milkdown/ctx": "7.20.0",
-        "@milkdown/prose": "7.20.0",
-        "@milkdown/utils": "7.20.0",
+        "@milkdown/ctx": "7.21.1",
+        "@milkdown/prose": "7.21.1",
+        "@milkdown/utils": "7.21.1",
         "@types/lodash-es": "^4.17.12",
         "lodash-es": "^4.17.21"
       }
     },
+    "node_modules/@milkdown/plugin-streaming": {
+      "version": "7.21.1",
+      "resolved": "https://registry.npmjs.org/@milkdown/plugin-streaming/-/plugin-streaming-7.21.1.tgz",
+      "integrity": "sha512-GPGJrf2ju3bciv6GsHMzbtG9o7zBx6+RiuBbMYqV99K1/k9SIwMWt4OkKeyadCJrb4wWNmx5jdS2LysQuiA90A==",
+      "license": "MIT",
+      "dependencies": {
+        "@milkdown/core": "7.21.1",
+        "@milkdown/ctx": "7.21.1",
+        "@milkdown/plugin-diff": "7.21.1",
+        "@milkdown/prose": "7.21.1",
+        "@milkdown/utils": "7.21.1"
+      }
+    },
     "node_modules/@milkdown/plugin-tooltip": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/@milkdown/plugin-tooltip/-/plugin-tooltip-7.20.0.tgz",
-      "integrity": "sha512-BVaXorpmA6ZAS3+xv0rgrtjV1h2K39G5Z9Wun4RxT1YXJTTbzIuFQ3hwBAGLjLMwTsosp7YhRLaMJJAC0jEY5Q==",
+      "version": "7.21.1",
+      "resolved": "https://registry.npmjs.org/@milkdown/plugin-tooltip/-/plugin-tooltip-7.21.1.tgz",
+      "integrity": "sha512-Dtvyb3IBpavEnp865zD46Js6LI0ySYbDJvZBRH5YEjoVa9QtH3E+XpqR1t1og8c3v/uum7BTE1Cv6a3Hri1j6g==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.5.1",
-        "@milkdown/ctx": "7.20.0",
-        "@milkdown/prose": "7.20.0",
-        "@milkdown/utils": "7.20.0",
+        "@milkdown/ctx": "7.21.1",
+        "@milkdown/prose": "7.21.1",
+        "@milkdown/utils": "7.21.1",
         "@types/lodash-es": "^4.17.12",
         "lodash-es": "^4.17.21"
       }
     },
     "node_modules/@milkdown/plugin-trailing": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/@milkdown/plugin-trailing/-/plugin-trailing-7.20.0.tgz",
-      "integrity": "sha512-AxDeMSAZfj0Er7RYLvLRf6FKdQtLVmotxML6Se6zgqIa++bFeIXCU22/FC+9r/6d1eUtraTva9ez5K2qPy8qig==",
+      "version": "7.21.1",
+      "resolved": "https://registry.npmjs.org/@milkdown/plugin-trailing/-/plugin-trailing-7.21.1.tgz",
+      "integrity": "sha512-m5j4gG0gOewbU1l0CaBMFq6/jlwBgMZ+/SW+qFrks0cFIuvpKfDS5Kh+LR4vLMF5DjFj1yyUf/mDH0WG7EXA9g==",
       "license": "MIT",
       "dependencies": {
-        "@milkdown/ctx": "7.20.0",
-        "@milkdown/prose": "7.20.0",
-        "@milkdown/utils": "7.20.0"
+        "@milkdown/ctx": "7.21.1",
+        "@milkdown/prose": "7.21.1",
+        "@milkdown/utils": "7.21.1"
       }
     },
     "node_modules/@milkdown/plugin-upload": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/@milkdown/plugin-upload/-/plugin-upload-7.20.0.tgz",
-      "integrity": "sha512-g3UQrD2zfpm86r3BcBDfOdEAyQHhay1nf5wUQgNf4zn6IgRttfEF8tosQsL1B/WBnZB05hH5scLWo4DR2bFhUw==",
+      "version": "7.21.1",
+      "resolved": "https://registry.npmjs.org/@milkdown/plugin-upload/-/plugin-upload-7.21.1.tgz",
+      "integrity": "sha512-FMkJfdPWVh3olHo6J57+CcsTwl9dSwLd3chG4lnX8jcLr7/RfjVTOsunTQGh7TtURfPn0TWuJQOimwxdSSot/Q==",
       "license": "MIT",
       "dependencies": {
-        "@milkdown/core": "7.20.0",
-        "@milkdown/ctx": "7.20.0",
-        "@milkdown/exception": "7.20.0",
-        "@milkdown/prose": "7.20.0",
-        "@milkdown/utils": "7.20.0"
+        "@milkdown/core": "7.21.1",
+        "@milkdown/ctx": "7.21.1",
+        "@milkdown/exception": "7.21.1",
+        "@milkdown/prose": "7.21.1",
+        "@milkdown/utils": "7.21.1"
       }
     },
     "node_modules/@milkdown/preset-commonmark": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/@milkdown/preset-commonmark/-/preset-commonmark-7.20.0.tgz",
-      "integrity": "sha512-+mPcONXfdjaXdx8JMxDIOT3PWHfy5vewK8iY8j8bUiYD8Iw7YfyWTUh9JHOf4vmOpiKGCJd7+iz7e93u95bQRw==",
+      "version": "7.21.1",
+      "resolved": "https://registry.npmjs.org/@milkdown/preset-commonmark/-/preset-commonmark-7.21.1.tgz",
+      "integrity": "sha512-7RjUaFoT7khUbr6ambpeOjPCl4uAkAb3s56YG/NL31tx0d8F6KTbDNbE3Z5GPljSNnp8rZl+eov01qpCNWstlQ==",
       "license": "MIT",
       "dependencies": {
-        "@milkdown/core": "7.20.0",
-        "@milkdown/ctx": "7.20.0",
-        "@milkdown/exception": "7.20.0",
-        "@milkdown/prose": "7.20.0",
-        "@milkdown/transformer": "7.20.0",
-        "@milkdown/utils": "7.20.0",
+        "@milkdown/core": "7.21.1",
+        "@milkdown/ctx": "7.21.1",
+        "@milkdown/exception": "7.21.1",
+        "@milkdown/prose": "7.21.1",
+        "@milkdown/transformer": "7.21.1",
+        "@milkdown/utils": "7.21.1",
         "remark-inline-links": "^7.0.0",
         "unist-util-visit": "^5.0.0",
         "unist-util-visit-parents": "^6.0.1"
       }
     },
     "node_modules/@milkdown/preset-gfm": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/@milkdown/preset-gfm/-/preset-gfm-7.20.0.tgz",
-      "integrity": "sha512-ulErTWDqrGYYqto4kQO9dPTMRp+q44pdRTPW4MTeiSO7eJ6JIBUKSqtCm1zf7MX6nZPaPhuscmg5CU2moXOwxQ==",
+      "version": "7.21.1",
+      "resolved": "https://registry.npmjs.org/@milkdown/preset-gfm/-/preset-gfm-7.21.1.tgz",
+      "integrity": "sha512-ZkwV2vdoGVdnL1GWt3umlPAedgIMuRLzy7Eith2YCdHfhr6JL2T6xNJYcdl2J/tYWCTj6k4Mv1kgCOXtq9rXlA==",
       "license": "MIT",
       "dependencies": {
-        "@milkdown/core": "7.20.0",
-        "@milkdown/ctx": "7.20.0",
-        "@milkdown/exception": "7.20.0",
-        "@milkdown/preset-commonmark": "7.20.0",
-        "@milkdown/prose": "7.20.0",
-        "@milkdown/transformer": "7.20.0",
-        "@milkdown/utils": "7.20.0",
+        "@milkdown/core": "7.21.1",
+        "@milkdown/ctx": "7.21.1",
+        "@milkdown/exception": "7.21.1",
+        "@milkdown/preset-commonmark": "7.21.1",
+        "@milkdown/prose": "7.21.1",
+        "@milkdown/transformer": "7.21.1",
+        "@milkdown/utils": "7.21.1",
         "prosemirror-safari-ime-span": "^1.0.1",
         "remark-gfm": "^4.0.1"
       }
     },
     "node_modules/@milkdown/prose": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/@milkdown/prose/-/prose-7.20.0.tgz",
-      "integrity": "sha512-Qe6jmKcXsjOfpk8duDFdkLCEo5044L8HSyKVn7ewAe7XJJPUM6bPQaP130UAznq75/+TiKxFCzurcrBO3LzNRg==",
+      "version": "7.21.1",
+      "resolved": "https://registry.npmjs.org/@milkdown/prose/-/prose-7.21.1.tgz",
+      "integrity": "sha512-qkRXnCsjsOSMt7CZvLdB1EqH6wdHymo9deI3JE5kP3lbai1iTR86lZqKkc3bRJBRq7ecI00PIXSG8vlN3R1doQ==",
       "license": "MIT",
       "dependencies": {
-        "@milkdown/exception": "7.20.0",
+        "@milkdown/exception": "7.21.1",
         "prosemirror-changeset": "^2.3.1",
         "prosemirror-commands": "^1.7.1",
         "prosemirror-dropcursor": "^1.8.2",
@@ -3275,13 +4372,13 @@
       }
     },
     "node_modules/@milkdown/react": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/@milkdown/react/-/react-7.20.0.tgz",
-      "integrity": "sha512-uuMuMfTmp2SZJtmKhX+tmVkJNasKnzxlYoHtUwjxuZcy90cWQVYpGXnmwpFgjcXY38lMLsAOLx2jjXrqe7ZOuQ==",
+      "version": "7.21.1",
+      "resolved": "https://registry.npmjs.org/@milkdown/react/-/react-7.21.1.tgz",
+      "integrity": "sha512-BTAWBPKhrOsTageB2YgdI2HAkDRnL3FkpL2kBSwi03OYGAQZZ+clCndU4+qfu3/3Rz6VCC5gmKURXKfddPiZHQ==",
       "license": "MIT",
       "dependencies": {
-        "@milkdown/crepe": "7.20.0",
-        "@milkdown/kit": "7.20.0"
+        "@milkdown/crepe": "7.21.1",
+        "@milkdown/kit": "7.21.1"
       },
       "peerDependencies": {
         "react": "*",
@@ -3289,57 +4386,40 @@
       }
     },
     "node_modules/@milkdown/transformer": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/@milkdown/transformer/-/transformer-7.20.0.tgz",
-      "integrity": "sha512-h7KGFr1o5AYwc+hEfnA3Dldo4jRrYOB/7KExaqelcjUz++KYI/9LXMOsV7CpgjtLI3Xtf2IIRTZND1+p2nsOaw==",
+      "version": "7.21.1",
+      "resolved": "https://registry.npmjs.org/@milkdown/transformer/-/transformer-7.21.1.tgz",
+      "integrity": "sha512-pI8uUVyy557s+F/NvyIoUKr3w4Imy2GXEZpFC6LX0/o0hWrQGlq18Lp02NCnhcMvlPtL25LiLVNB6+C/ksgfTg==",
       "license": "MIT",
       "dependencies": {
-        "@milkdown/exception": "7.20.0",
-        "@milkdown/prose": "7.20.0",
+        "@milkdown/exception": "7.21.1",
+        "@milkdown/prose": "7.21.1",
         "remark": "^15.0.1",
         "unified": "^11.0.3"
       }
     },
     "node_modules/@milkdown/utils": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/@milkdown/utils/-/utils-7.20.0.tgz",
-      "integrity": "sha512-ciEhtLKhIW/Kaz/NRE5DUXVoMCdenn7S4mClrO7sZ/nXtmObnk3okJzSDnamQoDOcLOIbpOu1V3E1Btkvc5x9w==",
+      "version": "7.21.1",
+      "resolved": "https://registry.npmjs.org/@milkdown/utils/-/utils-7.21.1.tgz",
+      "integrity": "sha512-BQzsziiPLyXhsiKnQnqqOsN7YY3nF2qk5vdx3MkxTuGAEC6t7wGJDLG+c0+4f73KBKxCMAuPNEGx5Q191/amXQ==",
       "license": "MIT",
       "dependencies": {
-        "@milkdown/core": "7.20.0",
-        "@milkdown/ctx": "7.20.0",
-        "@milkdown/exception": "7.20.0",
-        "@milkdown/prose": "7.20.0",
-        "@milkdown/transformer": "7.20.0",
+        "@milkdown/core": "7.21.1",
+        "@milkdown/ctx": "7.21.1",
+        "@milkdown/exception": "7.21.1",
+        "@milkdown/prose": "7.21.1",
+        "@milkdown/transformer": "7.21.1",
         "nanoid": "^5.0.9"
       }
     },
-    "node_modules/@milkdown/utils/node_modules/nanoid": {
-      "version": "5.1.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.7.tgz",
-      "integrity": "sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.js"
-      },
-      "engines": {
-        "node": "^18 || >=20"
-      }
-    },
     "node_modules/@mistralai/mistralai": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-1.14.1.tgz",
-      "integrity": "sha512-IiLmmZFCCTReQgPAT33r7KQ1nYo5JPdvGkrkZqA8qQ2qB1GHgs5LoP5K2ICyrjnpw2n8oSxMM/VP+liiKcGNlQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.1.tgz",
+      "integrity": "sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "ws": "^8.18.0",
         "zod": "^3.25.0 || ^4.0.0",
-        "zod-to-json-schema": "^3.24.1"
+        "zod-to-json-schema": "^3.25.0"
       }
     },
     "node_modules/@monaco-editor/loader": {
@@ -3366,9 +4446,9 @@
       }
     },
     "node_modules/@napi-rs/canvas": {
-      "version": "0.1.97",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.97.tgz",
-      "integrity": "sha512-8cFniXvrIEnVwuNSRCW9wirRZbHvrD3JVujdS2P5n5xiJZNZMOZcfOvJ1pb66c7jXMKHHglJEDVJGbm8XWFcXQ==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.100.tgz",
+      "integrity": "sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==",
       "license": "MIT",
       "optional": true,
       "workspaces": [
@@ -3382,23 +4462,23 @@
         "url": "https://github.com/sponsors/Brooooooklyn"
       },
       "optionalDependencies": {
-        "@napi-rs/canvas-android-arm64": "0.1.97",
-        "@napi-rs/canvas-darwin-arm64": "0.1.97",
-        "@napi-rs/canvas-darwin-x64": "0.1.97",
-        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.97",
-        "@napi-rs/canvas-linux-arm64-gnu": "0.1.97",
-        "@napi-rs/canvas-linux-arm64-musl": "0.1.97",
-        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.97",
-        "@napi-rs/canvas-linux-x64-gnu": "0.1.97",
-        "@napi-rs/canvas-linux-x64-musl": "0.1.97",
-        "@napi-rs/canvas-win32-arm64-msvc": "0.1.97",
-        "@napi-rs/canvas-win32-x64-msvc": "0.1.97"
+        "@napi-rs/canvas-android-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-x64": "0.1.100",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.100",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.100",
+        "@napi-rs/canvas-win32-arm64-msvc": "0.1.100",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.100"
       }
     },
     "node_modules/@napi-rs/canvas-android-arm64": {
-      "version": "0.1.97",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.97.tgz",
-      "integrity": "sha512-V1c/WVw+NzH8vk7ZK/O8/nyBSCQimU8sfMsB/9qeSvdkGKNU7+mxy/bIF0gTgeBFmHpj30S4E9WHMSrxXGQuVQ==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.100.tgz",
+      "integrity": "sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==",
       "cpu": [
         "arm64"
       ],
@@ -3416,9 +4496,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-darwin-arm64": {
-      "version": "0.1.97",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.97.tgz",
-      "integrity": "sha512-ok+SCEF4YejcxuJ9Rm+WWunHHpf2HmiPxfz6z1a/NFQECGXtsY7A4B8XocK1LmT1D7P174MzwPF9Wy3AUAwEPw==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.100.tgz",
+      "integrity": "sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==",
       "cpu": [
         "arm64"
       ],
@@ -3436,9 +4516,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-darwin-x64": {
-      "version": "0.1.97",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.97.tgz",
-      "integrity": "sha512-PUP6e6/UGlclUvAQNnuXCcnkpdUou6VYZfQOQxExLp86epOylmiwLkqXIvpFmjoTEDmPmXrI+coL/9EFU1gKPA==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.100.tgz",
+      "integrity": "sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==",
       "cpu": [
         "x64"
       ],
@@ -3456,9 +4536,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
-      "version": "0.1.97",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.97.tgz",
-      "integrity": "sha512-XyXH2L/cic8eTNtbrXCcvqHtMX/nEOxN18+7rMrAM2XtLYC/EB5s0wnO1FsLMWmK+04ZSLN9FBGipo7kpIkcOw==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.100.tgz",
+      "integrity": "sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==",
       "cpu": [
         "arm"
       ],
@@ -3476,9 +4556,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
-      "version": "0.1.97",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.97.tgz",
-      "integrity": "sha512-Kuq/M3djq0K8ktgz6nPlK7Ne5d4uWeDxPpyKWOjWDK2RIOhHVtLtyLiJw2fuldw7Vn4mhw05EZXCEr4Q76rs9w==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.100.tgz",
+      "integrity": "sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==",
       "cpu": [
         "arm64"
       ],
@@ -3496,9 +4576,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-arm64-musl": {
-      "version": "0.1.97",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.97.tgz",
-      "integrity": "sha512-kKmSkQVnWeqg7qdsiXvYxKhAFuHz3tkBjW/zyQv5YKUPhotpaVhpBGv5LqCngzyuRV85SXoe+OFj+Tv0a0QXkQ==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.100.tgz",
+      "integrity": "sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==",
       "cpu": [
         "arm64"
       ],
@@ -3516,9 +4596,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
-      "version": "0.1.97",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.97.tgz",
-      "integrity": "sha512-Jc7I3A51jnEOIAXeLsN/M/+Z28LUeakcsXs07FLq9prXc0eYOtVwsDEv913Gr+06IRo34gJJVgT0TXvmz+N2VA==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.100.tgz",
+      "integrity": "sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==",
       "cpu": [
         "riscv64"
       ],
@@ -3536,9 +4616,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-x64-gnu": {
-      "version": "0.1.97",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.97.tgz",
-      "integrity": "sha512-iDUBe7AilfuBSRbSa8/IGX38Mf+iCSBqoVKLSQ5XaY2JLOaqz1TVyPFEyIck7wT6mRQhQt5sN6ogfjIDfi74tg==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.100.tgz",
+      "integrity": "sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==",
       "cpu": [
         "x64"
       ],
@@ -3556,9 +4636,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-x64-musl": {
-      "version": "0.1.97",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.97.tgz",
-      "integrity": "sha512-AKLFd/v0Z5fvgqBDqhvqtAdx+fHMJ5t9JcUNKq4FIZ5WH+iegGm8HPdj00NFlCSnm83Fp3Ln8I2f7uq1aIiWaA==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.100.tgz",
+      "integrity": "sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==",
       "cpu": [
         "x64"
       ],
@@ -3576,9 +4656,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
-      "version": "0.1.97",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.97.tgz",
-      "integrity": "sha512-u883Yr6A6fO7Vpsy9YE4FVCIxzzo5sO+7pIUjjoDLjS3vQaNMkVzx5bdIpEL+ob+gU88WDK4VcxYMZ6nmnoX9A==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.100.tgz",
+      "integrity": "sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==",
       "cpu": [
         "arm64"
       ],
@@ -3596,9 +4676,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-win32-x64-msvc": {
-      "version": "0.1.97",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.97.tgz",
-      "integrity": "sha512-sWtD2EE3fV0IzN+iiQUqr/Q1SwqWhs2O1FKItFlxtdDkikpEj5g7DKQpY3x55H/MAOnL8iomnlk3mcEeGiUMoQ==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.100.tgz",
+      "integrity": "sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==",
       "cpu": [
         "x64"
       ],
@@ -3614,6 +4694,18 @@
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
       }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@ocavue/utils": {
       "version": "1.6.0",
@@ -3680,25 +4772,24 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
+        "@protobufjs/aspromise": "^1.1.1"
       }
     },
     "node_modules/@protobufjs/float": {
@@ -3708,9 +4799,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
@@ -3726,9 +4817,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@rolldown/pluginutils": {
@@ -3739,9 +4830,9 @@
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
-      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
       "cpu": [
         "arm"
       ],
@@ -3753,9 +4844,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
-      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
       "cpu": [
         "arm64"
       ],
@@ -3767,9 +4858,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
-      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
       "cpu": [
         "arm64"
       ],
@@ -3781,9 +4872,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
-      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
       "cpu": [
         "x64"
       ],
@@ -3795,9 +4886,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
-      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
       "cpu": [
         "arm64"
       ],
@@ -3809,9 +4900,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
-      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
       "cpu": [
         "x64"
       ],
@@ -3823,9 +4914,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
-      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
       "cpu": [
         "arm"
       ],
@@ -3837,9 +4928,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
-      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
       "cpu": [
         "arm"
       ],
@@ -3851,9 +4942,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
-      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
       "cpu": [
         "arm64"
       ],
@@ -3865,9 +4956,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
-      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
       "cpu": [
         "arm64"
       ],
@@ -3879,9 +4970,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
-      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
       "cpu": [
         "loong64"
       ],
@@ -3893,9 +4984,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
-      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
       "cpu": [
         "loong64"
       ],
@@ -3907,9 +4998,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
-      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
       "cpu": [
         "ppc64"
       ],
@@ -3921,9 +5012,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
-      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
       "cpu": [
         "ppc64"
       ],
@@ -3935,9 +5026,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
-      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
       "cpu": [
         "riscv64"
       ],
@@ -3949,9 +5040,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
-      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
       "cpu": [
         "riscv64"
       ],
@@ -3963,9 +5054,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
-      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
       "cpu": [
         "s390x"
       ],
@@ -3977,9 +5068,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
-      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
       "cpu": [
         "x64"
       ],
@@ -3991,9 +5082,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
-      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
       "cpu": [
         "x64"
       ],
@@ -4005,9 +5096,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
-      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
       "cpu": [
         "x64"
       ],
@@ -4019,9 +5110,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
-      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
       "cpu": [
         "arm64"
       ],
@@ -4033,9 +5124,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
-      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
       "cpu": [
         "arm64"
       ],
@@ -4047,9 +5138,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
-      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
       "cpu": [
         "ia32"
       ],
@@ -4061,9 +5152,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
-      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
       "cpu": [
         "x64"
       ],
@@ -4075,9 +5166,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
-      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
       "cpu": [
         "x64"
       ],
@@ -4088,50 +5179,14 @@
         "win32"
       ]
     },
-    "node_modules/@silvia-odwyer/photon-node": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
-      "integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@sinclair/typebox": {
-      "version": "0.34.49",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
-      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
-      "license": "MIT"
-    },
-    "node_modules/@smithy/config-resolver": {
-      "version": "4.4.13",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.13.tgz",
-      "integrity": "sha512-iIzMC5NmOUP6WL6o8iPBjFhUhBZ9pPjpUpQYWMUFQqKyXXzOftbfK8zcQCz/jFV1Psmf05BK5ypx4K2r4Tnwdg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-config-provider": "^4.2.2",
-        "@smithy/util-endpoints": "^3.3.3",
-        "@smithy/util-middleware": "^4.2.12",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@smithy/core": {
-      "version": "3.23.13",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.13.tgz",
-      "integrity": "sha512-J+2TT9D6oGsUVXVEMvz8h2EmdVnkBiy2auCie4aSJMvKlzUtO5hqjEzXhoCUkIMo7gAYjbQcN0g/MMSXEhDs1Q==",
+      "version": "3.24.4",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.4.tgz",
+      "integrity": "sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-stream": "^4.5.21",
-        "@smithy/util-utf8": "^4.2.2",
-        "@smithy/uuid": "^1.1.2",
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4139,85 +5194,13 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.12.tgz",
-      "integrity": "sha512-cr2lR792vNZcYMriSIj+Um3x9KWrjcu98kn234xA6reOAFMmbRpQMOv8KPgEmLLtx3eldU6c5wALKFqNOhugmg==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.4.tgz",
+      "integrity": "sha512-vKW0MEFRU4Y3MkVZUkpJm+g9qyPGLCXhc0YLggUdSdBB4g7IaSSsCE75P9rBXyWHrXY1UYSQUl8/DwsTR7QciA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/eventstream-codec": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.12.tgz",
-      "integrity": "sha512-FE3bZdEl62ojmy8x4FHqxq2+BuOHlcxiH5vaZ6aqHJr3AIZzwF5jfx8dEiU/X0a8RboyNDjmXjlbr8AdEyLgiA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-hex-encoding": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/eventstream-serde-browser": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.12.tgz",
-      "integrity": "sha512-XUSuMxlTxV5pp4VpqZf6Sa3vT/Q75FVkLSpSSE3KkWBvAQWeuWt1msTv8fJfgA4/jcJhrbrbMzN1AC/hvPmm5A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/eventstream-serde-universal": "^4.2.12",
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/eventstream-serde-config-resolver": {
-      "version": "4.3.12",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.12.tgz",
-      "integrity": "sha512-7epsAZ3QvfHkngz6RXQYseyZYHlmWXSTPOfPmXkiS+zA6TBNo1awUaMFL9vxyXlGdoELmCZyZe1nQE+imbmV+Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/eventstream-serde-node": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.12.tgz",
-      "integrity": "sha512-D1pFuExo31854eAvg89KMn9Oab/wEeJR6Buy32B49A9Ogdtx5fwZPqBHUlDzaCDpycTFk2+fSQgX689Qsk7UGA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/eventstream-serde-universal": "^4.2.12",
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/eventstream-serde-universal": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.12.tgz",
-      "integrity": "sha512-+yNuTiyBACxOJUTvbsNsSOfH9G9oKbaJE1lNL3YHpGcuucl6rPZMi3nrpehpVOVR2E07YqFFmtwpImtpzlouHQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/eventstream-codec": "^4.2.12",
-        "@smithy/types": "^4.13.1",
+        "@smithy/core": "^3.24.4",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4225,43 +5208,13 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.3.15",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.15.tgz",
-      "integrity": "sha512-T4jFU5N/yiIfrtrsb9uOQn7RdELdM/7HbyLNr6uO/mpkj1ctiVs7CihVr51w4LyQlXWDpXFn4BElf1WmQvZu/A==",
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.4.tgz",
+      "integrity": "sha512-qM7AUKI4G6d7lNgaZD3lA1tWSolh5r6gcixfTZAPstVURfjIbvreVTPz+994M0yC3HbX4YYhDRgr31Xy3XwWOQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/querystring-builder": "^4.2.12",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-base64": "^4.3.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/hash-node": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.12.tgz",
-      "integrity": "sha512-QhBYbGrbxTkZ43QoTPrK72DoYviDeg6YKDrHTMJbbC+A0sml3kSjzFtXP7BtbyJnXojLfTQldGdUR0RGD8dA3w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-buffer-from": "^4.2.2",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/invalid-dependency": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.12.tgz",
-      "integrity": "sha512-/4F1zb7Z8LOu1PalTdESFHR0RbPwHd3FcaG1sI3UEIriQTWakysgJr65lc1jj6QY5ye7aFsisajotH6UhWfm/g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/core": "^3.24.4",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4269,200 +5222,25 @@
       }
     },
     "node_modules/@smithy/is-array-buffer": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
-      "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-content-length": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.12.tgz",
-      "integrity": "sha512-YE58Yz+cvFInWI/wOTrB+DbvUVz/pLn5mC5MvOV4fdRUc6qGwygyngcucRQjAhiCEbmfLOXX0gntSIcgMvAjmA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.4.28",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.28.tgz",
-      "integrity": "sha512-p1gfYpi91CHcs5cBq982UlGlDrxoYUX6XdHSo91cQ2KFuz6QloHosO7Jc60pJiVmkWrKOV8kFYlGFFbQ2WUKKQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.23.13",
-        "@smithy/middleware-serde": "^4.2.16",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-middleware": "^4.2.12",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-retry": {
-      "version": "4.4.46",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.46.tgz",
-      "integrity": "sha512-SpvWNNOPOrKQGUqZbEPO+es+FRXMWvIyzUKUOYdDgdlA6BdZj/R58p4umoQ76c2oJC44PiM7mKizyyex1IJzow==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/service-error-classification": "^4.2.12",
-        "@smithy/smithy-client": "^4.12.8",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-retry": "^4.2.13",
-        "@smithy/uuid": "^1.1.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-serde": {
-      "version": "4.2.16",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.16.tgz",
-      "integrity": "sha512-beqfV+RZ9RSv+sQqor3xroUUYgRFCGRw6niGstPG8zO9LgTl0B0MCucxjmrH/2WwksQN7UUgI7KNANoZv+KALA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.23.13",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-stack": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.12.tgz",
-      "integrity": "sha512-kruC5gRHwsCOuyCd4ouQxYjgRAym2uDlCvQ5acuMtRrcdfg7mFBg6blaxcJ09STpt3ziEkis6bhg1uwrWU7txw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/node-config-provider": {
-      "version": "4.3.12",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.12.tgz",
-      "integrity": "sha512-tr2oKX2xMcO+rBOjobSwVAkV05SIfUKz8iI53rzxEmgW3GOOPOv0UioSDk+J8OpRQnpnhsO3Af6IEBabQBVmiw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.5.1.tgz",
-      "integrity": "sha512-ejjxdAXjkPIs9lyYyVutOGNOraqUE9v/NjGMKwwFrfOM354wfSD8lmlj8hVwUzQmlLLF4+udhfCX9Exnbmvfzw==",
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+      "integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/querystring-builder": "^4.2.12",
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/property-provider": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.12.tgz",
-      "integrity": "sha512-jqve46eYU1v7pZ5BM+fmkbq3DerkSluPr5EhvOcHxygxzD05ByDRppRwRPPpFrsFo5yDtCYLKu+kreHKVrvc7A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/protocol-http": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.12.tgz",
-      "integrity": "sha512-fit0GZK9I1xoRlR4jXmbLhoN0OdEpa96ul8M65XdmXnxXkuMxM0Y8HDT0Fh0Xb4I85MBvBClOzgSrV1X2s1Hxw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/querystring-builder": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.12.tgz",
-      "integrity": "sha512-6wTZjGABQufekycfDGMEB84BgtdOE/rCVTov+EDXQ8NHKTUNIp/j27IliwP7tjIU9LR+sSzyGBOXjeEtVgzCHg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-uri-escape": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/querystring-parser": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.12.tgz",
-      "integrity": "sha512-P2OdvrgiAKpkPNKlKUtWbNZKB1XjPxM086NeVhK+W+wI46pIKdWBe5QyXvhUm3MEcyS/rkLvY8rZzyUdmyDZBw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/service-error-classification": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.12.tgz",
-      "integrity": "sha512-LlP29oSQN0Tw0b6D0Xo6BIikBswuIiGYbRACy5ujw/JgWSzTdYj46U83ssf6Ux0GyNJVivs2uReU8pt7Eu9okQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.13.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.4.7",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.7.tgz",
-      "integrity": "sha512-HrOKWsUb+otTeo1HxVWeEb99t5ER1XrBi/xka2Wv6NVmTbuCUC1dvlrksdvxFtODLBjsC+PHK+fuy2x/7Ynyiw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4470,36 +5248,13 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.12.tgz",
-      "integrity": "sha512-B/FBwO3MVOL00DaRSXfXfa/TRXRheagt/q5A2NM13u7q+sHS59EOVGQNfG7DkmVtdQm5m3vOosoKAXSqn/OEgw==",
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.4.tgz",
+      "integrity": "sha512-e5UtkMvsatzBfbeBZjEOt0k0Z3BEsjTFL/n6fdO5vtBLe67tdy0dX7xw2DU7uZ3acwoHyeCqpU2Fzb7pxwHb6Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.2",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-hex-encoding": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-uri-escape": "^4.2.2",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/smithy-client": {
-      "version": "4.12.8",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.8.tgz",
-      "integrity": "sha512-aJaAX7vHe5i66smoSSID7t4rKY08PbD8EBU7DOloixvhOozfYWdcSYE4l6/tjkZ0vBZhGjheWzB2mh31sLgCMA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.23.13",
-        "@smithy/middleware-endpoint": "^4.4.28",
-        "@smithy/middleware-stack": "^4.2.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-stream": "^4.5.21",
+        "@smithy/core": "^3.24.4",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4507,61 +5262,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
-      "integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/url-parser": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.12.tgz",
-      "integrity": "sha512-wOPKPEpso+doCZGIlr+e1lVI6+9VAKfL4kZWFgzVgGWY2hZxshNKod4l2LXS3PRC9otH/JRSjtEHqQ/7eLciRA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/querystring-parser": "^4.2.12",
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-base64": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
-      "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.2",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-body-length-browser": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
-      "integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-body-length-node": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
-      "integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
+      "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -4571,170 +5274,29 @@
       }
     },
     "node_modules/@smithy/util-buffer-from": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
-      "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/is-array-buffer": "^2.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-config-provider": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
-      "integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.3.44",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.44.tgz",
-      "integrity": "sha512-eZg6XzaCbVr2S5cAErU5eGBDaOVTuTo1I65i4tQcHENRcZ8rMWhQy1DaIYUSLyZjsfXvmCqZrstSMYyGFocvHA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/smithy-client": "^4.12.8",
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.2.48",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.48.tgz",
-      "integrity": "sha512-FqOKTlqSaoV3nzO55pMs5NBnZX8EhoI0DGmn9kbYeXWppgHD6dchyuj2HLqp4INJDJbSrj6OFYJkAh/WhSzZPg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/config-resolver": "^4.4.13",
-        "@smithy/credential-provider-imds": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/smithy-client": "^4.12.8",
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-endpoints": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.3.3.tgz",
-      "integrity": "sha512-VACQVe50j0HZPjpwWcjyT51KUQ4AnsvEaQ2lKHOSL4mNLD0G9BjEniQ+yCt1qqfKfiAHRAts26ud7hBjamrwig==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-hex-encoding": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
-      "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-middleware": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.12.tgz",
-      "integrity": "sha512-Er805uFUOvgc0l8nv0e0su0VFISoxhJ/AwOn3gL2NWNY2LUEldP5WtVcRYSQBcjg0y9NfG8JYrCJaYDpupBHJQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-retry": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.13.tgz",
-      "integrity": "sha512-qQQsIvL0MGIbUjeSrg0/VlQ3jGNKyM3/2iU3FPNgy01z+Sp4OvcaxbgIoFOTvB61ZoohtutuOvOcgmhbD0katQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/service-error-classification": "^4.2.12",
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-stream": {
-      "version": "4.5.21",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.21.tgz",
-      "integrity": "sha512-KzSg+7KKywLnkoKejRtIBXDmwBfjGvg1U1i/etkC7XSWUyFCoLno1IohV2c74IzQqdhX5y3uE44r/8/wuK+A7Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/node-http-handler": "^4.5.1",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-buffer-from": "^4.2.2",
-        "@smithy/util-hex-encoding": "^4.2.2",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-uri-escape": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
-      "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/util-utf8": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
-      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-buffer-from": "^2.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/uuid": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
-      "integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@standard-schema/spec": {
@@ -4745,49 +5307,49 @@
       "license": "MIT"
     },
     "node_modules/@tailwindcss/node": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.2.tgz",
-      "integrity": "sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.0.tgz",
+      "integrity": "sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.5",
-        "enhanced-resolve": "^5.19.0",
+        "enhanced-resolve": "^5.21.0",
         "jiti": "^2.6.1",
         "lightningcss": "1.32.0",
         "magic-string": "^0.30.21",
         "source-map-js": "^1.2.1",
-        "tailwindcss": "4.2.2"
+        "tailwindcss": "4.3.0"
       }
     },
     "node_modules/@tailwindcss/oxide": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.2.tgz",
-      "integrity": "sha512-qEUA07+E5kehxYp9BVMpq9E8vnJuBHfJEC0vPC5e7iL/hw7HR61aDKoVoKzrG+QKp56vhNZe4qwkRmMC0zDLvg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.0.tgz",
+      "integrity": "sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "@tailwindcss/oxide-android-arm64": "4.2.2",
-        "@tailwindcss/oxide-darwin-arm64": "4.2.2",
-        "@tailwindcss/oxide-darwin-x64": "4.2.2",
-        "@tailwindcss/oxide-freebsd-x64": "4.2.2",
-        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.2",
-        "@tailwindcss/oxide-linux-arm64-gnu": "4.2.2",
-        "@tailwindcss/oxide-linux-arm64-musl": "4.2.2",
-        "@tailwindcss/oxide-linux-x64-gnu": "4.2.2",
-        "@tailwindcss/oxide-linux-x64-musl": "4.2.2",
-        "@tailwindcss/oxide-wasm32-wasi": "4.2.2",
-        "@tailwindcss/oxide-win32-arm64-msvc": "4.2.2",
-        "@tailwindcss/oxide-win32-x64-msvc": "4.2.2"
+        "@tailwindcss/oxide-android-arm64": "4.3.0",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.0",
+        "@tailwindcss/oxide-darwin-x64": "4.3.0",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.0",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.0",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.0",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.0",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.0",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.0",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.0",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.0",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.0"
       }
     },
     "node_modules/@tailwindcss/oxide-android-arm64": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.2.tgz",
-      "integrity": "sha512-dXGR1n+P3B6748jZO/SvHZq7qBOqqzQ+yFrXpoOWWALWndF9MoSKAT3Q0fYgAzYzGhxNYOoysRvYlpixRBBoDg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.0.tgz",
+      "integrity": "sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng==",
       "cpu": [
         "arm64"
       ],
@@ -4802,9 +5364,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-arm64": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.2.tgz",
-      "integrity": "sha512-iq9Qjr6knfMpZHj55/37ouZeykwbDqF21gPFtfnhCCKGDcPI/21FKC9XdMO/XyBM7qKORx6UIhGgg6jLl7BZlg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.0.tgz",
+      "integrity": "sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ==",
       "cpu": [
         "arm64"
       ],
@@ -4819,9 +5381,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-x64": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.2.tgz",
-      "integrity": "sha512-BlR+2c3nzc8f2G639LpL89YY4bdcIdUmiOOkv2GQv4/4M0vJlpXEa0JXNHhCHU7VWOKWT/CjqHdTP8aUuDJkuw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.0.tgz",
+      "integrity": "sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA==",
       "cpu": [
         "x64"
       ],
@@ -4836,9 +5398,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-freebsd-x64": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.2.tgz",
-      "integrity": "sha512-YUqUgrGMSu2CDO82hzlQ5qSb5xmx3RUrke/QgnoEx7KvmRJHQuZHZmZTLSuuHwFf0DJPybFMXMYf+WJdxHy/nQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.0.tgz",
+      "integrity": "sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ==",
       "cpu": [
         "x64"
       ],
@@ -4853,9 +5415,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.2.tgz",
-      "integrity": "sha512-FPdhvsW6g06T9BWT0qTwiVZYE2WIFo2dY5aCSpjG/S/u1tby+wXoslXS0kl3/KXnULlLr1E3NPRRw0g7t2kgaQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.0.tgz",
+      "integrity": "sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA==",
       "cpu": [
         "arm"
       ],
@@ -4870,9 +5432,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.2.tgz",
-      "integrity": "sha512-4og1V+ftEPXGttOO7eCmW7VICmzzJWgMx+QXAJRAhjrSjumCwWqMfkDrNu1LXEQzNAwz28NCUpucgQPrR4S2yw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.0.tgz",
+      "integrity": "sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg==",
       "cpu": [
         "arm64"
       ],
@@ -4887,9 +5449,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.2.tgz",
-      "integrity": "sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.0.tgz",
+      "integrity": "sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==",
       "cpu": [
         "arm64"
       ],
@@ -4904,9 +5466,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.2.tgz",
-      "integrity": "sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.0.tgz",
+      "integrity": "sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==",
       "cpu": [
         "x64"
       ],
@@ -4921,9 +5483,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.2.tgz",
-      "integrity": "sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.0.tgz",
+      "integrity": "sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==",
       "cpu": [
         "x64"
       ],
@@ -4938,9 +5500,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.2.tgz",
-      "integrity": "sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.0.tgz",
+      "integrity": "sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==",
       "bundleDependencies": [
         "@napi-rs/wasm-runtime",
         "@emnapi/core",
@@ -4956,10 +5518,10 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "^1.8.1",
-        "@emnapi/runtime": "^1.8.1",
-        "@emnapi/wasi-threads": "^1.1.0",
-        "@napi-rs/wasm-runtime": "^1.1.1",
+        "@emnapi/core": "^1.10.0",
+        "@emnapi/runtime": "^1.10.0",
+        "@emnapi/wasi-threads": "^1.2.1",
+        "@napi-rs/wasm-runtime": "^1.1.4",
         "@tybys/wasm-util": "^0.10.1",
         "tslib": "^2.8.1"
       },
@@ -4968,9 +5530,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.2.tgz",
-      "integrity": "sha512-qPmaQM4iKu5mxpsrWZMOZRgZv1tOZpUm+zdhhQP0VhJfyGGO3aUKdbh3gDZc/dPLQwW4eSqWGrrcWNBZWUWaXQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.0.tgz",
+      "integrity": "sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ==",
       "cpu": [
         "arm64"
       ],
@@ -4985,9 +5547,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.2.tgz",
-      "integrity": "sha512-1T/37VvI7WyH66b+vqHj/cLwnCxt7Qt3WFu5Q8hk65aOvlwAhs7rAp1VkulBJw/N4tMirXjVnylTR72uI0HGcA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.0.tgz",
+      "integrity": "sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA==",
       "cpu": [
         "x64"
       ],
@@ -5002,47 +5564,18 @@
       }
     },
     "node_modules/@tailwindcss/postcss": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.2.2.tgz",
-      "integrity": "sha512-n4goKQbW8RVXIbNKRB/45LzyUqN451deQK0nzIeauVEqjlI49slUlgKYJM2QyUzap/PcpnS7kzSUmPb1sCRvYQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.3.0.tgz",
+      "integrity": "sha512-Jm05Tjx+9yCLGv5qw1c+84Psds8MnyrEQYCB+FFk2lgGiUjlRqdxke4mVTuYrj2xnVZqKim2Apr5ySuQRYAw/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
-        "@tailwindcss/node": "4.2.2",
-        "@tailwindcss/oxide": "4.2.2",
-        "postcss": "^8.5.6",
-        "tailwindcss": "4.2.2"
+        "@tailwindcss/node": "4.3.0",
+        "@tailwindcss/oxide": "4.3.0",
+        "postcss": "^8.5.10",
+        "tailwindcss": "4.3.0"
       }
-    },
-    "node_modules/@tokenizer/inflate": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
-      "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.4.3",
-        "token-types": "^6.1.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
-    "node_modules/@tokenizer/token": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
-      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
-      "license": "MIT"
-    },
-    "node_modules/@tootallnate/quickjs-emscripten": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
-      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
-      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -5431,9 +5964,9 @@
       "license": "MIT"
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -5531,12 +6064,6 @@
         "@types/unist": "*"
       }
     },
-    "node_modules/@types/mime-types": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.4.tgz",
-      "integrity": "sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w==",
-      "license": "MIT"
-    },
     "node_modules/@types/ms": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
@@ -5544,9 +6071,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
-      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -5563,9 +6090,9 @@
       }
     },
     "node_modules/@types/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
       "dev": true,
       "license": "MIT"
     },
@@ -5577,9 +6104,9 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "19.2.14",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
-      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "version": "19.2.15",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
+      "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -5662,16 +6189,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/yauzl": {
-      "version": "2.10.3",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
-      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@upsetjs/venn.js": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
@@ -5704,16 +6221,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
-      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.7.tgz",
+      "integrity": "sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.4",
-        "@vitest/utils": "4.1.4",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -5722,13 +6239,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
-      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.7.tgz",
+      "integrity": "sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.4",
+        "@vitest/spy": "4.1.7",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -5748,20 +6265,10 @@
         }
       }
     },
-    "node_modules/@vitest/mocker/node_modules/estree-walker": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0"
-      }
-    },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
-      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.7.tgz",
+      "integrity": "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5772,13 +6279,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
-      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.7.tgz",
+      "integrity": "sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.4",
+        "@vitest/utils": "4.1.7",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -5786,14 +6293,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
-      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.7.tgz",
+      "integrity": "sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.4",
-        "@vitest/utils": "4.1.4",
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/utils": "4.1.7",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -5802,9 +6309,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
-      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.7.tgz",
+      "integrity": "sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -5812,13 +6319,13 @@
       }
     },
     "node_modules/@vitest/ui": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.1.4.tgz",
-      "integrity": "sha512-EgFR7nlj5iTDYZYCvavjFokNYwr3c3ry0sFiCg+N7B233Nwp+NNx7eoF/XvMWDCKY71xXAG3kFkt97ZHBJVL8A==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.1.7.tgz",
+      "integrity": "sha512-TP6utB2yX6rsJNVRo2qAlsi48i1YwFTrLV2tnTtWqJaYX7m4lRCCLirZBjU6xC5m0RsPHr+L2+N+eIPhgEzFfw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.4",
+        "@vitest/utils": "4.1.7",
         "fflate": "^0.8.2",
         "flatted": "^3.4.2",
         "pathe": "^2.0.3",
@@ -5830,17 +6337,17 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "vitest": "4.1.4"
+        "vitest": "4.1.7"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
-      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.7.tgz",
+      "integrity": "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.4",
+        "@vitest/pretty-format": "4.1.7",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -5849,109 +6356,121 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.32.tgz",
-      "integrity": "sha512-4x74Tbtqnda8s/NSD6e1Dr5p1c8HdMU5RWSjMSUzb8RTcUQqevDCxVAitcLBKT+ie3o0Dl9crc/S/opJM7qBGQ==",
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.34.tgz",
+      "integrity": "sha512-s9cLyK5mLcvZ4Agva5QgRsQyLKvts9WbU9DB6NqiZkkGEdwmcEiylj5Jbwkp680drF/NNCV8OlAJSe+yMLxaJw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.2",
-        "@vue/shared": "3.5.32",
+        "@babel/parser": "^7.29.3",
+        "@vue/shared": "3.5.34",
         "entities": "^7.0.1",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
       }
     },
+    "node_modules/@vue/compiler-core/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.32.tgz",
-      "integrity": "sha512-ybHAu70NtiEI1fvAUz3oXZqkUYEe5J98GjMDpTGl5iHb0T15wQYLR4wE3h9xfuTNA+Cm2f4czfe8B4s+CCH57Q==",
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.34.tgz",
+      "integrity": "sha512-EbF/T++k0e2MMZlJsBhzK8Sgwt0HcIPOhzn1CTB/lv6sQcyk+OWf8YeiLxZp3ro7MbbLcAfAJ6sEvjFWuNgUCw==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-core": "3.5.32",
-        "@vue/shared": "3.5.32"
+        "@vue/compiler-core": "3.5.34",
+        "@vue/shared": "3.5.34"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.32.tgz",
-      "integrity": "sha512-8UYUYo71cP/0YHMO814TRZlPuUUw3oifHuMR7Wp9SNoRSrxRQnhMLNlCeaODNn6kNTJsjFoQ/kqIj4qGvya4Xg==",
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.34.tgz",
+      "integrity": "sha512-D/ihr6uZeIt6r+pVZf46RWT1fAsLFMbUP7k8G1VkiiWexriED9GrX3echHd4Abbt17zjlfiFJ8z7a3BxZOPNjg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.2",
-        "@vue/compiler-core": "3.5.32",
-        "@vue/compiler-dom": "3.5.32",
-        "@vue/compiler-ssr": "3.5.32",
-        "@vue/shared": "3.5.32",
+        "@babel/parser": "^7.29.3",
+        "@vue/compiler-core": "3.5.34",
+        "@vue/compiler-dom": "3.5.34",
+        "@vue/compiler-ssr": "3.5.34",
+        "@vue/shared": "3.5.34",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.30.21",
-        "postcss": "^8.5.8",
+        "postcss": "^8.5.14",
         "source-map-js": "^1.2.1"
       }
     },
+    "node_modules/@vue/compiler-sfc/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.32.tgz",
-      "integrity": "sha512-Gp4gTs22T3DgRotZ8aA/6m2jMR+GMztvBXUBEUOYOcST+giyGWJ4WvFd7QLHBkzTxkfOt8IELKNdpzITLbA2rw==",
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.34.tgz",
+      "integrity": "sha512-cDtTHKibkThKGHH1SP+WdccquNRYQDFH6rRjQCqT9G2ltFAfoR5pUftpab/z+aM5mW9HLLVQW7hfKKQe/1GBeQ==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.32",
-        "@vue/shared": "3.5.32"
+        "@vue/compiler-dom": "3.5.34",
+        "@vue/shared": "3.5.34"
       }
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.32.tgz",
-      "integrity": "sha512-/ORasxSGvZ6MN5gc+uE364SxFdJ0+WqVG0CENXaGW58TOCdrAW76WWaplDtECeS1qphvtBZtR+3/o1g1zL4xPQ==",
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.34.tgz",
+      "integrity": "sha512-y9XDjCEuBp+98k+UL5dbYkh57AHU4o6cxZedOPXw3bmrZZYLQsVHguGurq7hVrPCSrQtrnz1f9dssyFr+dMXfQ==",
       "license": "MIT",
       "dependencies": {
-        "@vue/shared": "3.5.32"
+        "@vue/shared": "3.5.34"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.32.tgz",
-      "integrity": "sha512-pDrXCejn4UpFDFmMd27AcJEbHaLemaE5o4pbb7sLk79SRIhc6/t34BQA7SGNgYtbMnvbF/HHOftYBgFJtUoJUQ==",
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.34.tgz",
+      "integrity": "sha512-mKeBYvu8tcMSLhypAHBmriUFfWXKTCF/23Z4jiCoYK3UtWepkliViNLuR90V9XOyD62mUxs9p1jsrpK3CCGIzw==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.32",
-        "@vue/shared": "3.5.32"
+        "@vue/reactivity": "3.5.34",
+        "@vue/shared": "3.5.34"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.32.tgz",
-      "integrity": "sha512-1CDVv7tv/IV13V8Nip1k/aaObVbWqRlVCVezTwx3K07p7Vxossp5JU1dcPNhJk3w347gonIUT9jQOGutyJrSVQ==",
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.34.tgz",
+      "integrity": "sha512-e8kZzERmCwUnBRVsgSQlAfrfU2rGoy0FFKPBXSlfEjc/O3KfA7QP0t1/2ZylrbchjmIKB4dPTd07A6WPr0eOrg==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.32",
-        "@vue/runtime-core": "3.5.32",
-        "@vue/shared": "3.5.32",
+        "@vue/reactivity": "3.5.34",
+        "@vue/runtime-core": "3.5.34",
+        "@vue/shared": "3.5.34",
         "csstype": "^3.2.3"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.32.tgz",
-      "integrity": "sha512-IOjm2+JQwRFS7W28HNuJeXQle9KdZbODFY7hFGVtnnghF51ta20EWAZJHX+zLGtsHhaU6uC9BGPV52KVpYryMQ==",
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.34.tgz",
+      "integrity": "sha512-nHxmJoTrKsmrkbILRhkC9gY1G3moZbJTqCzDd7DOOzG5KH9oeJ0Unqrff5f9v0pW//jES05ZkJcNtfE8JjOIew==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-ssr": "3.5.32",
-        "@vue/shared": "3.5.32"
+        "@vue/compiler-ssr": "3.5.34",
+        "@vue/shared": "3.5.34"
       },
       "peerDependencies": {
-        "vue": "3.5.32"
+        "vue": "3.5.34"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.32.tgz",
-      "integrity": "sha512-ksNyrmRQzWJJ8n3cRDuSF7zNNontuJg1YHnmWRJd2AMu8Ij2bqwiiri2lH5rHtYPZjj4STkNcgcmiQqlOjiYGg==",
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.34.tgz",
+      "integrity": "sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==",
       "license": "MIT"
     },
     "node_modules/3dmol": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/3dmol/-/3dmol-2.5.4.tgz",
-      "integrity": "sha512-stbHw2c2T12bABmFyBrhJL4tufw+hUjvhmJthOxAxKVDwAtAZSI17Kue8VNxaHewf5oRydPo6W62BlWrbrNa6Q==",
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/3dmol/-/3dmol-2.5.5.tgz",
+      "integrity": "sha512-kqNHouGqq3YfW58174tdERvm0XYTmP0tavQKOqIw1ouc2OJ7epkXEFrtEkVXV0clBZT2Ze2xHRC/qxX0u0qCdw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "iobuffer": "^5.0.0",
@@ -5983,61 +6502,13 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
       "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-formats": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
-      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
+        "node": ">= 14"
       }
     },
     "node_modules/ansi-regex": {
@@ -6063,12 +6534,6 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
-    },
-    "node_modules/any-promise": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
-      "license": "MIT"
     },
     "node_modules/aproba": {
       "version": "2.1.0",
@@ -6106,18 +6571,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/ast-types": {
-      "version": "0.13.4",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
-      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -6125,9 +6578,9 @@
       "license": "MIT"
     },
     "node_modules/autoprefixer": {
-      "version": "10.4.27",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.27.tgz",
-      "integrity": "sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
+      "integrity": "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==",
       "dev": true,
       "funding": [
         {
@@ -6145,8 +6598,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.28.1",
-        "caniuse-lite": "^1.0.30001774",
+        "browserslist": "^4.28.2",
+        "caniuse-lite": "^1.0.30001787",
         "fraction.js": "^5.3.4",
         "picocolors": "^1.1.1",
         "postcss-value-parser": "^4.2.0"
@@ -6162,9 +6615,9 @@
       }
     },
     "node_modules/b4a": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
-      "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "react-native-b4a": "*"
@@ -6192,9 +6645,9 @@
       "license": "MIT"
     },
     "node_modules/bare-events": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
-      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.3.tgz",
+      "integrity": "sha512-HdUm8EMQBLaJvGUdidNNbqpA1kYkwNcb+MYxkxCLAPJGQzlv9J0C24h8V65Z4c5GLd/JEALDvpFCQgpLJqc0zw==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "bare-abort-controller": "*"
@@ -6206,9 +6659,9 @@
       }
     },
     "node_modules/bare-fs": {
-      "version": "4.5.6",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.6.tgz",
-      "integrity": "sha512-1QovqDrR80Pmt5HPAsMsXTCFcDYr+NSUKW6nd6WO5v0JBmnItc/irNRzm2KOQ5oZ69P37y+AMujNyNtG+1Rggw==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
+      "integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-events": "^2.5.4",
@@ -6230,9 +6683,9 @@
       }
     },
     "node_modules/bare-os": {
-      "version": "3.8.6",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.8.6.tgz",
-      "integrity": "sha512-l8xaNWWb/bXuzgsrlF5jaa5QYDJ9S0ddd54cP6CH+081+5iPrbJiCfBWQqrWYzmUhCbsH+WR6qxo9MeHVCr0MQ==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
+      "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
       "license": "Apache-2.0",
       "engines": {
         "bare": ">=1.14.0"
@@ -6248,9 +6701,9 @@
       }
     },
     "node_modules/bare-stream": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.12.0.tgz",
-      "integrity": "sha512-w28i8lkBgREV3rPXGbgK+BO66q+ZpKqRWrZLiCdmmUlLPrQ45CzkvRhN+7lnv00Gpi2zy5naRxnUFAxCECDm9g==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.1.tgz",
+      "integrity": "sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==",
       "license": "Apache-2.0",
       "dependencies": {
         "streamx": "^2.25.0",
@@ -6274,9 +6727,9 @@
       }
     },
     "node_modules/bare-url": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.0.tgz",
-      "integrity": "sha512-NSTU5WN+fy/L0DDenfE8SXQna4voXuW0FHM7wH8i3/q9khUSchfPbPezO4zSFMnDGIf9YE+mt/RWhZgNRKRIXA==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.3.tgz",
+      "integrity": "sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-path": "^3.0.0"
@@ -6303,9 +6756,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.13",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.13.tgz",
-      "integrity": "sha512-BL2sTuHOdy0YT1lYieUxTw/QMtPBC3pmlJC6xk8BBYVv6vcw3SGdKemQ+Xsx9ik2F/lYDO9tqsFQH1r9PFuHKw==",
+      "version": "2.10.32",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.32.tgz",
+      "integrity": "sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -6313,15 +6766,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/basic-ftp": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
-      "integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/bcrypt": {
@@ -6402,6 +6846,22 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/body-parser/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/bowser": {
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
@@ -6409,9 +6869,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -6476,15 +6936,6 @@
         "ieee754": "^1.1.13"
       }
     },
-    "node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
@@ -6530,9 +6981,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001782",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001782.tgz",
-      "integrity": "sha512-dZcaJLJeDMh4rELYFw1tvSn1bhZWYFOt468FcbHHxx/Z/dFidd1I6ciyFdi3iwfQCyOjqo9upF6lGQYtMiJWxw==",
+      "version": "1.0.30001793",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
       "dev": true,
       "funding": [
         {
@@ -6608,95 +7059,10 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/chevrotain": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.1.2.tgz",
-      "integrity": "sha512-opLQzEVriiH1uUQ4Kctsd49bRoFDXGGSC4GUqj7pGyxM3RehRhvTlZJc1FL/Flew2p5uwxa1tUDWKzI4wNM8pg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@chevrotain/cst-dts-gen": "11.1.2",
-        "@chevrotain/gast": "11.1.2",
-        "@chevrotain/regexp-to-ast": "11.1.2",
-        "@chevrotain/types": "11.1.2",
-        "@chevrotain/utils": "11.1.2",
-        "lodash-es": "4.17.23"
-      }
-    },
-    "node_modules/chevrotain-allstar": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.3.1.tgz",
-      "integrity": "sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==",
-      "license": "MIT",
-      "dependencies": {
-        "lodash-es": "^4.17.21"
-      },
-      "peerDependencies": {
-        "chevrotain": "^11.0.0"
-      }
-    },
     "node_modules/chownr": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
       "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/cli-highlight": {
-      "version": "2.1.11",
-      "resolved": "https://registry.npmjs.org/cli-highlight/-/cli-highlight-2.1.11.tgz",
-      "integrity": "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==",
-      "license": "ISC",
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "highlight.js": "^10.7.1",
-        "mz": "^2.4.0",
-        "parse5": "^5.1.1",
-        "parse5-htmlparser2-tree-adapter": "^6.0.0",
-        "yargs": "^16.0.0"
-      },
-      "bin": {
-        "highlight": "bin/highlight"
-      },
-      "engines": {
-        "node": ">=8.0.0",
-        "npm": ">=5.0.0"
-      }
-    },
-    "node_modules/cli-highlight/node_modules/cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      }
-    },
-    "node_modules/cli-highlight/node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/cli-highlight/node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -6781,12 +7147,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
       "license": "MIT",
       "engines": {
-        "node": ">= 10"
+        "node": ">= 12"
       }
     },
     "node_modules/concat-map": {
@@ -6820,12 +7186,6 @@
         "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
       }
     },
-    "node_modules/confbox": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
-      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
-      "license": "MIT"
-    },
     "node_modules/console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
@@ -6833,9 +7193,9 @@
       "license": "ISC"
     },
     "node_modules/content-disposition": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
-      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -6883,20 +7243,11 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/cookie-parser/node_modules/cookie-signature": {
+    "node_modules/cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "license": "MIT"
-    },
-    "node_modules/cookie-signature": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
-      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.6.0"
-      }
     },
     "node_modules/cors": {
       "version": "2.8.6",
@@ -6937,9 +7288,9 @@
       "license": "MIT"
     },
     "node_modules/cytoscape": {
-      "version": "3.33.1",
-      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
-      "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
+      "version": "3.33.4",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.4.tgz",
+      "integrity": "sha512-HIN5Pmd9MrX9BkV7tDwnOcEJCSFvCpc8X97h3f508J6I5FsqAY65wKOCvgH2CuP42CaahWaz4tuh32SOOIH7ww==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10"
@@ -7154,16 +7505,13 @@
         "node": ">=12"
       }
     },
-    "node_modules/d3-dsv/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+    "node_modules/d3-dsv/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
       "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">= 10"
       }
     },
     "node_modules/d3-ease": {
@@ -7448,18 +7796,18 @@
       }
     },
     "node_modules/data-uri-to-buffer": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
-      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
       "license": "MIT",
       "engines": {
-        "node": ">= 14"
+        "node": ">= 12"
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.20",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
-      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -7514,20 +7862,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4.0.0"
-      }
-    },
-    "node_modules/degenerator": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
-      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ast-types": "^0.13.4",
-        "escodegen": "^2.1.0",
-        "esprima": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/delaunator": {
@@ -7594,19 +7928,10 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/diff": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
-      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
     "node_modules/dompurify": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.5.tgz",
+      "integrity": "sha512-OrwIBKsdNSVEeubdJ1HBv/wNENRM9ytAVCv7YXt//A3vPdVMNuACRqK9mXCGCBW2ln7BT/A4X0jXHo2Gu89miA==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -7654,9 +7979,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.329",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.329.tgz",
-      "integrity": "sha512-/4t+AS1l4S3ZC0Ja7PHFIWeBIxGA3QGqV8/yKsP36v7NcyUCl+bIcmw6s5zVuMIECWwBrAK/6QLzTmbJChBboQ==",
+      "version": "1.5.361",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.361.tgz",
+      "integrity": "sha512-Q6Hts7N9FnJc5LeGRINFvLhCI9xZmNtTDe5ZbcVezQz7cU4a8Aua3GH1b8J2XY8Al9PF+OCwYqhgsOOheMdvkA==",
       "dev": true,
       "license": "ISC"
     },
@@ -7685,14 +8010,14 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.20.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
-      "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.22.0.tgz",
+      "integrity": "sha512-xYcDWrpELkFzz9SpZ3PlI6Eu6eD93Yf0WLDRxikGhWJ3MAir2SNZTIVCVZqZ/NUyx8AdMc2gT9C0gPiw18kG+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
-        "tapable": "^2.3.0"
+        "tapable": "^2.3.3"
       },
       "engines": {
         "node": ">=10.13.0"
@@ -7729,16 +8054,16 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
-      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -7762,10 +8087,20 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-toolkit": {
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.47.0.tgz",
+      "integrity": "sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
     "node_modules/esbuild": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
-      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -7776,38 +8111,39 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.4",
-        "@esbuild/android-arm": "0.27.4",
-        "@esbuild/android-arm64": "0.27.4",
-        "@esbuild/android-x64": "0.27.4",
-        "@esbuild/darwin-arm64": "0.27.4",
-        "@esbuild/darwin-x64": "0.27.4",
-        "@esbuild/freebsd-arm64": "0.27.4",
-        "@esbuild/freebsd-x64": "0.27.4",
-        "@esbuild/linux-arm": "0.27.4",
-        "@esbuild/linux-arm64": "0.27.4",
-        "@esbuild/linux-ia32": "0.27.4",
-        "@esbuild/linux-loong64": "0.27.4",
-        "@esbuild/linux-mips64el": "0.27.4",
-        "@esbuild/linux-ppc64": "0.27.4",
-        "@esbuild/linux-riscv64": "0.27.4",
-        "@esbuild/linux-s390x": "0.27.4",
-        "@esbuild/linux-x64": "0.27.4",
-        "@esbuild/netbsd-arm64": "0.27.4",
-        "@esbuild/netbsd-x64": "0.27.4",
-        "@esbuild/openbsd-arm64": "0.27.4",
-        "@esbuild/openbsd-x64": "0.27.4",
-        "@esbuild/openharmony-arm64": "0.27.4",
-        "@esbuild/sunos-x64": "0.27.4",
-        "@esbuild/win32-arm64": "0.27.4",
-        "@esbuild/win32-ia32": "0.27.4",
-        "@esbuild/win32-x64": "0.27.4"
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
       }
     },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -7831,62 +8167,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/escodegen": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
-      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "esprima": "^4.0.1",
-        "estraverse": "^5.2.0",
-        "esutils": "^2.0.2"
-      },
-      "bin": {
-        "escodegen": "bin/escodegen.js",
-        "esgenerate": "bin/esgenerate.js"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "optionalDependencies": {
-        "source-map": "~0.6.1"
-      }
-    },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/estraverse": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
     "node_modules/estree-walker": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "license": "MIT"
-    },
-    "node_modules/esutils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.10.0"
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
       }
     },
     "node_modules/etag": {
@@ -7970,12 +8258,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
-      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -7987,36 +8275,19 @@
         "express": ">= 4.11"
       }
     },
+    "node_modules/express/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "license": "MIT"
-    },
-    "node_modules/extract-zip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "get-stream": "^5.1.0",
-        "yauzl": "^2.10.0"
-      },
-      "bin": {
-        "extract-zip": "cli.js"
-      },
-      "engines": {
-        "node": ">= 10.17.0"
-      },
-      "optionalDependencies": {
-        "@types/yauzl": "^2.9.1"
-      }
-    },
-    "node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
     "node_modules/fast-fifo": {
@@ -8025,26 +8296,10 @@
       "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "license": "MIT"
     },
-    "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -8053,13 +8308,14 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.8",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
-      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
       "funding": [
         {
           "type": "github",
@@ -8068,21 +8324,13 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.2.0",
-        "strnum": "^2.2.0"
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
-      }
-    },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
       }
     },
     "node_modules/fdir": {
@@ -8127,29 +8375,11 @@
       }
     },
     "node_modules/fflate": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
-      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/file-type": {
-      "version": "21.3.4",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
-      "integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
-      "license": "MIT",
-      "dependencies": {
-        "@tokenizer/inflate": "^0.4.1",
-        "strtok3": "^10.3.4",
-        "token-types": "^6.1.1",
-        "uint8array-extras": "^1.4.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
-      }
     },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
@@ -8367,37 +8597,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/gaxios/node_modules/agent-base": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/gaxios/node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/gaxios/node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/gaxios/node_modules/node-fetch": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
@@ -8444,21 +8643,10 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/get-east-asian-width": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
-      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-intrinsic": {
@@ -8496,48 +8684,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/get-tsconfig": {
-      "version": "4.13.7",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
-      "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "resolve-pkg-maps": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
-      }
-    },
-    "node_modules/get-uri": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
-      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
-      "license": "MIT",
-      "dependencies": {
-        "basic-ftp": "^5.0.2",
-        "data-uri-to-buffer": "^6.0.2",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/github-from-package": {
@@ -8609,6 +8755,7 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/hachure-fill": {
@@ -8660,9 +8807,9 @@
       "license": "ISC"
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -8672,42 +8819,15 @@
       }
     },
     "node_modules/helmet": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
-      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.2.0.tgz",
+      "integrity": "sha512-DRgTIUgnWcJ62KyarxxziuqYxKGnR6Rgg19BlbucN/dpmJbl1XOit6qvoOX0ZT+HhWe5OUVhU/a1zpGyc1xA0Q==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/highlight.js": {
-      "version": "10.7.3",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
-      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/hosted-git-info": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
-      "integrity": "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==",
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^11.1.0"
       },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/hosted-git-info/node_modules/lru-cache": {
-      "version": "11.2.7",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
-      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
+      "funding": {
+        "url": "https://github.com/sponsors/EvanHahn"
       }
     },
     "node_modules/hpagent": {
@@ -8752,42 +8872,29 @@
         "node": ">= 14"
       }
     },
-    "node_modules/http-proxy-agent/node_modules/agent-base": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
       "engines": {
         "node": ">= 14"
       }
     },
-    "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/iconv-lite": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ieee754": {
@@ -8817,6 +8924,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/inflight": {
@@ -8858,9 +8975,9 @@
       "license": "MIT"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -8912,19 +9029,18 @@
       }
     },
     "node_modules/jiti": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
-      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "dev": true,
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
     },
     "node_modules/jose": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
-      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -8993,12 +9109,6 @@
         "node": ">=16"
       }
     },
-    "node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
-    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -9053,9 +9163,9 @@
       }
     },
     "node_modules/jsonwebtoken/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -9086,9 +9196,9 @@
       }
     },
     "node_modules/katex": {
-      "version": "0.16.44",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.44.tgz",
-      "integrity": "sha512-EkxoDTk8ufHqHlf9QxGwcxeLkWRR3iOuYfRpfORgYfqc8s13bgb+YtRY59NK5ZpRaCwq1kqA6a5lpX8C/eLphQ==",
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
       "funding": [
         "https://opencollective.com/katex",
         "https://github.com/sponsors/katex"
@@ -9101,47 +9211,10 @@
         "katex": "cli.js"
       }
     },
-    "node_modules/katex/node_modules/commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/khroma": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
       "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
-    },
-    "node_modules/koffi": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/koffi/-/koffi-2.15.2.tgz",
-      "integrity": "sha512-r9tjJLVRSOhCRWdVyQlF3/Ugzeg13jlzS4czS82MAgLff4W+BcYOW7g8Y62t9O5JYjYOLAjAovAZDNlDfZNu+g==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "funding": {
-        "url": "https://liberapay.com/Koromix"
-      }
-    },
-    "node_modules/langium": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/langium/-/langium-4.2.1.tgz",
-      "integrity": "sha512-zu9QWmjpzJcomzdJQAHgDVhLGq5bLosVak1KVa40NzQHXfqr4eAHupvnPOVXEoLkg6Ocefvf/93d//SB7du4YQ==",
-      "license": "MIT",
-      "dependencies": {
-        "chevrotain": "~11.1.1",
-        "chevrotain-allstar": "~0.3.1",
-        "vscode-languageserver": "~9.0.1",
-        "vscode-languageserver-textdocument": "~1.0.11",
-        "vscode-uri": "~3.1.0"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
     },
     "node_modules/layout-base": {
       "version": "1.0.2",
@@ -9192,6 +9265,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9213,6 +9287,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9234,6 +9309,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9255,6 +9331,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9276,6 +9353,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9297,6 +9375,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9318,6 +9397,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9339,6 +9419,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9360,6 +9441,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9381,6 +9463,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9402,6 +9485,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9411,9 +9495,9 @@
       }
     },
     "node_modules/lodash-es": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
     "node_modules/lodash.includes": {
@@ -9793,14 +9877,14 @@
       }
     },
     "node_modules/mermaid": {
-      "version": "11.13.0",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.13.0.tgz",
-      "integrity": "sha512-fEnci+Immw6lKMFI8sqzjlATTyjLkRa6axrEgLV2yHTfv8r+h1wjFbV6xeRtd4rUV1cS4EpR9rwp3Rci7TRWDw==",
+      "version": "11.15.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.15.0.tgz",
+      "integrity": "sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==",
       "license": "MIT",
       "dependencies": {
         "@braintree/sanitize-url": "^7.1.1",
         "@iconify/utils": "^3.0.2",
-        "@mermaid-js/parser": "^1.0.1",
+        "@mermaid-js/parser": "^1.1.1",
         "@types/d3": "^7.4.3",
         "@upsetjs/venn.js": "^2.0.0",
         "cytoscape": "^3.33.1",
@@ -9811,14 +9895,14 @@
         "dagre-d3-es": "7.0.14",
         "dayjs": "^1.11.19",
         "dompurify": "^3.3.1",
+        "es-toolkit": "^1.45.1",
         "katex": "^0.16.25",
         "khroma": "^2.1.0",
-        "lodash-es": "^4.17.23",
         "marked": "^16.3.0",
         "roughjs": "^4.6.6",
         "stylis": "^4.3.6",
         "ts-dedent": "^2.2.0",
-        "uuid": "^11.1.0"
+        "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
       }
     },
     "node_modules/mermaid/node_modules/marked": {
@@ -10531,18 +10615,6 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "license": "MIT"
     },
-    "node_modules/mlly": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
-      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "^8.16.0",
-        "pathe": "^2.0.3",
-        "pkg-types": "^1.3.1",
-        "ufo": "^1.6.3"
-      }
-    },
     "node_modules/monaco-editor": {
       "version": "0.55.1",
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
@@ -10590,21 +10662,10 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
-    "node_modules/mz": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
-      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
-      "license": "MIT",
-      "dependencies": {
-        "any-promise": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "thenify-all": "^1.0.0"
-      }
-    },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.11.tgz",
+      "integrity": "sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==",
       "funding": [
         {
           "type": "github",
@@ -10613,10 +10674,10 @@
       ],
       "license": "MIT",
       "bin": {
-        "nanoid": "bin/nanoid.cjs"
+        "nanoid": "bin/nanoid.js"
       },
       "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+        "node": "^18 || >=20"
       }
     },
     "node_modules/napi-build-utils": {
@@ -10643,19 +10704,10 @@
         "iobuffer": "^5.3.2"
       }
     },
-    "node_modules/netmask": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
-      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/node-abi": {
-      "version": "3.89.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
-      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "version": "3.92.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
       "license": "MIT",
       "dependencies": {
         "semver": "^7.3.5"
@@ -10665,9 +10717,9 @@
       }
     },
     "node_modules/node-abi/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -10722,19 +10774,15 @@
         }
       }
     },
-    "node_modules/node-readable-to-web-readable-stream": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/node-readable-to-web-readable-stream/-/node-readable-to-web-readable-stream-0.4.2.tgz",
-      "integrity": "sha512-/cMZNI34v//jUTrI+UIo4ieHAB5EZRY/+7OmXZgBxaWBMcW2tGdceIw06RFxWxrKZ5Jp3sI2i5TsRo+CBhtVLQ==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/node-releases": {
-      "version": "2.0.36",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
-      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+      "version": "2.0.46",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.46.tgz",
+      "integrity": "sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/nopt": {
       "version": "5.0.0",
@@ -10765,9 +10813,9 @@
       }
     },
     "node_modules/oauth4webapi": {
-      "version": "3.8.5",
-      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.5.tgz",
-      "integrity": "sha512-A8jmyUckVhRJj5lspguklcl90Ydqk61H3dcU0oLhH3Yv13KpAliKTt5hknpGGPZSSfOwGyraNEFmofDYH+1kSg==",
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.6.tgz",
+      "integrity": "sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -10848,13 +10896,13 @@
       }
     },
     "node_modules/openid-client": {
-      "version": "6.8.2",
-      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.8.2.tgz",
-      "integrity": "sha512-uOvTCndr4udZsKihJ68H9bUICrriHdUVJ6Az+4Ns6cW55rwM5h0bjVIzDz2SxgOI84LKjFyjOFvERLzdTUROGA==",
+      "version": "6.8.4",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.8.4.tgz",
+      "integrity": "sha512-QSw0BA08piujetEwfZsHoTrDpMEha7GDZDicQqVwX4u0ChCjefvjDB++TZ8BTg76UpwhzIQgdvvfgfl3HpCSAw==",
       "license": "MIT",
       "dependencies": {
-        "jose": "^6.1.3",
-        "oauth4webapi": "^3.8.4"
+        "jose": "^6.2.2",
+        "oauth4webapi": "^3.8.5"
       },
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -10879,60 +10927,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/pac-proxy-agent": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
-      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
-      "license": "MIT",
-      "dependencies": {
-        "@tootallnate/quickjs-emscripten": "^0.23.0",
-        "agent-base": "^7.1.2",
-        "debug": "^4.3.4",
-        "get-uri": "^6.0.1",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.6",
-        "pac-resolver": "^7.0.1",
-        "socks-proxy-agent": "^8.0.5"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/pac-proxy-agent/node_modules/agent-base": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/pac-proxy-agent/node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/pac-resolver": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
-      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
-      "license": "MIT",
-      "dependencies": {
-        "degenerator": "^5.0.0",
-        "netmask": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/package-manager-detector": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
@@ -10944,27 +10938,6 @@
       "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
       "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
       "license": "(MIT AND Zlib)"
-    },
-    "node_modules/parse5": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
-      "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
-      "license": "MIT"
-    },
-    "node_modules/parse5-htmlparser2-tree-adapter": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
-      "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
-      "license": "MIT",
-      "dependencies": {
-        "parse5": "^6.0.1"
-      }
-    },
-    "node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
-      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
-      "license": "MIT"
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
@@ -10988,9 +10961,9 @@
       "license": "MIT"
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
-      "integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
       "funding": [
         {
           "type": "github",
@@ -11011,44 +10984,10 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/path-scurry": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "11.2.7",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
-      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/path-scurry/node_modules/minipass": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
     "node_modules/path-to-regexp": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.1.tgz",
-      "integrity": "sha512-fvU78fIjZ+SBM9YwCknCvKOUKkLVqtWDVctl0s7xIqfmfb38t2TT4ZU2gHm+Z8xGwgW+QWEU3oQSAzIbo89Ggw==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -11059,26 +10998,20 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/pdfjs-dist": {
-      "version": "5.6.205",
-      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.6.205.tgz",
-      "integrity": "sha512-tlUj+2IDa7G1SbvBNN74UHRLJybZDWYom+k6p5KIZl7huBvsA4APi6mKL+zCxd3tLjN5hOOEE9Tv7VdzO88pfg==",
+      "version": "5.7.284",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.7.284.tgz",
+      "integrity": "sha512-h4EdYQczmGhbOlqc3PPZwxevn7ApdWPbovAuWXOB/DjIyigSnwfy2oze7c6mRcSr9XgLp3eN3EeL4DyySTPMFw==",
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=20.19.0 || >=22.13.0 || >=24"
+        "node": ">=22.13.0 || >=24"
       },
       "optionalDependencies": {
-        "@napi-rs/canvas": "^0.1.96",
-        "node-readable-to-web-readable-stream": "^0.4.2"
+        "@napi-rs/canvas": "^0.1.100"
       }
-    },
-    "node_modules/pend": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -11099,17 +11032,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/pkg-types": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
-      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
-      "license": "MIT",
-      "dependencies": {
-        "confbox": "^0.1.8",
-        "mlly": "^1.7.4",
-        "pathe": "^2.0.1"
-      }
-    },
     "node_modules/points-on-curve": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
@@ -11127,9 +11049,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -11146,7 +11068,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -11160,6 +11082,24 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/prebuild-install": {
       "version": "7.1.3",
@@ -11188,30 +11128,44 @@
         "node": ">=10"
       }
     },
-    "node_modules/proper-lockfile": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
-      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+    "node_modules/prebuild-install/node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/prebuild-install/node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
       "license": "MIT",
       "dependencies": {
-        "graceful-fs": "^4.2.4",
-        "retry": "^0.12.0",
-        "signal-exit": "^3.0.2"
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
       }
     },
-    "node_modules/proper-lockfile/node_modules/retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+    "node_modules/prebuild-install/node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
       "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
       "engines": {
-        "node": ">= 4"
+        "node": ">=6"
       }
     },
     "node_modules/prosemirror-changeset": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/prosemirror-changeset/-/prosemirror-changeset-2.4.0.tgz",
-      "integrity": "sha512-LvqH2v7Q2SF6yxatuPP2e8vSUKS/L+xAU7dPDC4RMyHMhZoGDfBC74mYuyYF4gLqOEG758wajtyhNnsTkuhvng==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-changeset/-/prosemirror-changeset-2.4.1.tgz",
+      "integrity": "sha512-96WBLhOaYhJ+kPhLg3uW359Tz6I/MfcrQfL4EGv4SrcqKEMC1gmoGrXHecPE8eOwTVCJ4IwgfzM8fFad25wNfw==",
       "license": "MIT",
       "dependencies": {
         "prosemirror-transform": "^1.0.0"
@@ -11299,9 +11253,9 @@
       }
     },
     "node_modules/prosemirror-model": {
-      "version": "1.25.4",
-      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
-      "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
+      "version": "1.25.7",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.7.tgz",
+      "integrity": "sha512-A79aN8QEFUwI6cax8Yq4Rpcx1TJZ3Kagn+ii7qLo4/V8H3mMiHrhFyhTyHHvpSnOgMPpWiDGSwM3etwrxE50ug==",
       "license": "MIT",
       "dependencies": {
         "orderedmap": "^2.0.0"
@@ -11401,24 +11355,24 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.1.tgz",
+      "integrity": "sha512-4K0myLaWL5EteuSAro91EGFgcfVgxb64Jx+7oDAY6GOkXD4M69yuSEljNcInGVCA5sOPxmZ/EqDLj2x0Q0+Ygg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/inquire": "^1.1.2",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -11437,62 +11391,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/proxy-agent": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
-      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "^4.3.4",
-        "http-proxy-agent": "^7.0.1",
-        "https-proxy-agent": "^7.0.6",
-        "lru-cache": "^7.14.1",
-        "pac-proxy-agent": "^7.1.0",
-        "proxy-from-env": "^1.1.0",
-        "socks-proxy-agent": "^8.0.5"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/proxy-agent/node_modules/agent-base": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/proxy-agent/node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/proxy-agent/node_modules/lru-cache": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
-    },
     "node_modules/pump": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
@@ -11504,9 +11402,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -11542,6 +11440,22 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -11558,24 +11472,24 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
-      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
-      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
+      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.4"
+        "react": "^19.2.6"
       }
     },
     "node_modules/react-refresh": {
@@ -11589,9 +11503,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.13.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.2.tgz",
-      "integrity": "sha512-tX1Aee+ArlKQP+NIUd7SE6Li+CiGKwQtbS+FfRxPX6Pe4vHOo6nr9d++u5cwg+Z8K/x8tP+7qLmujDtfrAoUJA==",
+      "version": "7.15.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.15.1.tgz",
+      "integrity": "sha512-R8rl9HhgikFYoPJymnUtPXWbnDb3oget6lQnfIoupbt61aT9aOhRkDsY2XRhZRyX1Z/8a5sL74fXmFNm3NRK5A==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -11611,12 +11525,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.13.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.2.tgz",
-      "integrity": "sha512-aR7SUORwTqAW0JDeiWF07e9SBE9qGpByR9I8kJT5h/FrBKxPMS6TiC7rmVO+gC0q52Bx7JnjWe8Z1sR9faN4YA==",
+      "version": "7.15.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.15.1.tgz",
+      "integrity": "sha512-AzF62gjY6U9rkMq4RfP/r2EVtQ7DMfNMjyOp/flLTCrtRylLiK4wT4pSq6O8rOXZ2eXdZYJPEYe+ifomiv+Igg==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.13.2"
+        "react-router": "7.15.1"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -11753,28 +11667,10 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/resolve-pkg-maps": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
-      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
       "dev": true,
       "license": "MIT",
-      "funding": {
-        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/retry": {
@@ -11815,9 +11711,9 @@
       "license": "Unlicense"
     },
     "node_modules/rollup": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
-      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11831,33 +11727,40 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.60.1",
-        "@rollup/rollup-android-arm64": "4.60.1",
-        "@rollup/rollup-darwin-arm64": "4.60.1",
-        "@rollup/rollup-darwin-x64": "4.60.1",
-        "@rollup/rollup-freebsd-arm64": "4.60.1",
-        "@rollup/rollup-freebsd-x64": "4.60.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
-        "@rollup/rollup-linux-arm64-musl": "4.60.1",
-        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
-        "@rollup/rollup-linux-loong64-musl": "4.60.1",
-        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
-        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
-        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
-        "@rollup/rollup-linux-x64-gnu": "4.60.1",
-        "@rollup/rollup-linux-x64-musl": "4.60.1",
-        "@rollup/rollup-openbsd-x64": "4.60.1",
-        "@rollup/rollup-openharmony-arm64": "4.60.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
-        "@rollup/rollup-win32-x64-gnu": "4.60.1",
-        "@rollup/rollup-win32-x64-msvc": "4.60.1",
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/rope-sequence": {
       "version": "1.3.4",
@@ -12046,13 +11949,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -12182,12 +12085,12 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.8.7",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
-      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "^10.0.1",
+        "ip-address": "^10.1.1",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
@@ -12207,25 +12110,6 @@
       },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/socks-proxy-agent/node_modules/agent-base": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/source-map-js": {
@@ -12260,9 +12144,10 @@
       }
     },
     "node_modules/std-env": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/stream-buffers": {
@@ -12330,9 +12215,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
-      "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
       "funding": [
         {
           "type": "github",
@@ -12341,22 +12226,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/strtok3": {
-      "version": "10.3.5",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
-      "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
-      "license": "MIT",
-      "dependencies": {
-        "@tokenizer/token": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
     "node_modules/style-mod": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
@@ -12364,9 +12233,9 @@
       "license": "MIT"
     },
     "node_modules/stylis": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
-      "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
+      "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
       "license": "MIT"
     },
     "node_modules/supports-color": {
@@ -12386,16 +12255,16 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
-      "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
+      "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tapable": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
-      "integrity": "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12425,37 +12294,29 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
+      "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
       "license": "MIT",
       "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
         "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
       }
     },
-    "node_modules/tar-fs/node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "license": "ISC"
-    },
     "node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
       "license": "MIT",
       "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
       }
     },
     "node_modules/tar/node_modules/yallist": {
@@ -12482,27 +12343,6 @@
         "b4a": "^1.6.4"
       }
     },
-    "node_modules/thenify": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
-      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
-      "license": "MIT",
-      "dependencies": {
-        "any-promise": "^1.0.0"
-      }
-    },
-    "node_modules/thenify-all": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
-      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
-      "license": "MIT",
-      "dependencies": {
-        "thenify": ">= 3.1.0 < 4"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -12511,23 +12351,23 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
-      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.2.tgz",
+      "integrity": "sha512-M/Q0B2cp4K7kynaT/vnED1j8TlLY+Pp7C6Wl2bl/7u/F0mUVwdyOpwomQb8JpYLitHUssAJRmLZdMCGsrx7i+g==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -12553,24 +12393,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
-      }
-    },
-    "node_modules/token-types": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
-      "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
-      "license": "MIT",
-      "dependencies": {
-        "@borewit/text-codec": "^0.2.1",
-        "@tokenizer/token": "^0.3.0",
-        "ieee754": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/totalist": {
@@ -12631,14 +12453,13 @@
       "license": "0BSD"
     },
     "node_modules/tsx": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
-      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "version": "4.22.3",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.3.tgz",
+      "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "~0.27.0",
-        "get-tsconfig": "^4.7.5"
+        "esbuild": "~0.28.0"
       },
       "bin": {
         "tsx": "dist/cli.mjs"
@@ -12663,18 +12484,41 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typebox": {
+      "version": "1.1.38",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
+      "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.9.3",
@@ -12688,33 +12532,6 @@
       },
       "engines": {
         "node": ">=14.17"
-      }
-    },
-    "node_modules/ufo": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
-      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
-      "license": "MIT"
-    },
-    "node_modules/uint8array-extras": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
-      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/undici": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.6.tgz",
-      "integrity": "sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -12873,16 +12690,16 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/esm/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/vary": {
@@ -12923,9 +12740,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13482,19 +13299,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
-      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.7.tgz",
+      "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.4",
-        "@vitest/mocker": "4.1.4",
-        "@vitest/pretty-format": "4.1.4",
-        "@vitest/runner": "4.1.4",
-        "@vitest/snapshot": "4.1.4",
-        "@vitest/spy": "4.1.4",
-        "@vitest/utils": "4.1.4",
+        "@vitest/expect": "4.1.7",
+        "@vitest/mocker": "4.1.7",
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/runner": "4.1.7",
+        "@vitest/snapshot": "4.1.7",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -13522,12 +13339,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.4",
-        "@vitest/browser-preview": "4.1.4",
-        "@vitest/browser-webdriverio": "4.1.4",
-        "@vitest/coverage-istanbul": "4.1.4",
-        "@vitest/coverage-v8": "4.1.4",
-        "@vitest/ui": "4.1.4",
+        "@vitest/browser-playwright": "4.1.7",
+        "@vitest/browser-preview": "4.1.7",
+        "@vitest/browser-webdriverio": "4.1.7",
+        "@vitest/coverage-istanbul": "4.1.7",
+        "@vitest/coverage-v8": "4.1.7",
+        "@vitest/ui": "4.1.7",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -13571,73 +13388,17 @@
         }
       }
     },
-    "node_modules/vitest/node_modules/std-env": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
-      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/vscode-jsonrpc": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
-      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/vscode-languageserver": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
-      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
-      "license": "MIT",
-      "dependencies": {
-        "vscode-languageserver-protocol": "3.17.5"
-      },
-      "bin": {
-        "installServerIntoExtension": "bin/installServerIntoExtension"
-      }
-    },
-    "node_modules/vscode-languageserver-protocol": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
-      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
-      "license": "MIT",
-      "dependencies": {
-        "vscode-jsonrpc": "8.2.0",
-        "vscode-languageserver-types": "3.17.5"
-      }
-    },
-    "node_modules/vscode-languageserver-textdocument": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
-      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
-      "license": "MIT"
-    },
-    "node_modules/vscode-languageserver-types": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
-      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
-      "license": "MIT"
-    },
-    "node_modules/vscode-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
-      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
-      "license": "MIT"
-    },
     "node_modules/vue": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.32.tgz",
-      "integrity": "sha512-vM4z4Q9tTafVfMAK7IVzmxg34rSzTFMyIe0UUEijUCkn9+23lj0WRfA83dg7eQZIUlgOSGrkViIaCfqSAUXsMw==",
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.34.tgz",
+      "integrity": "sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.32",
-        "@vue/compiler-sfc": "3.5.32",
-        "@vue/runtime-dom": "3.5.32",
-        "@vue/server-renderer": "3.5.32",
-        "@vue/shared": "3.5.32"
+        "@vue/compiler-dom": "3.5.34",
+        "@vue/compiler-sfc": "3.5.34",
+        "@vue/runtime-dom": "3.5.34",
+        "@vue/server-renderer": "3.5.34",
+        "@vue/shared": "3.5.34"
       },
       "peerDependencies": {
         "typescript": "*"
@@ -13709,6 +13470,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -13729,9 +13491,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -13749,10 +13511,26 @@
         }
       }
     },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -13766,9 +13544,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -13809,32 +13587,10 @@
         "node": ">=12"
       }
     },
-    "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
-      }
-    },
-    "node_modules/yoctocolors": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
-      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -13850,9 +13606,9 @@
       }
     },
     "node_modules/zustand": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.12.tgz",
-      "integrity": "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==",
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.13.tgz",
+      "integrity": "sha512-efI2tVaVQPqtOh114loML/Z80Y4NP3yc+Ff0fYiZJPauNeWZeIp/bRFD7I9bfmCOYBh/PHxlglQ9+wvlwnPikQ==",
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"
@@ -13923,46 +13679,16 @@
       "name": "@goldilocks/runtime",
       "version": "0.1.0",
       "dependencies": {
+        "@earendil-works/pi-agent-core": "^0.75.5",
+        "@earendil-works/pi-coding-agent": "^0.75.5",
         "@goldilocks/config": "file:../config",
         "@goldilocks/data": "file:../data",
         "@kubernetes/client-node": "^1.4.0",
-        "@mariozechner/pi-agent-core": "^0.64.0",
-        "@mariozechner/pi-coding-agent": "^0.64.0",
         "ws": "^8.18.2"
       },
       "devDependencies": {
         "@types/node": "^22.15.3",
         "@types/ws": "^8.18.1",
-        "typescript": "^5.8.3"
-      }
-    },
-    "server": {
-      "name": "goldilocks-server",
-      "version": "0.1.0",
-      "extraneous": true,
-      "dependencies": {
-        "@kubernetes/client-node": "^1.4.0",
-        "@mariozechner/pi-coding-agent": "^0.64.0",
-        "bcrypt": "^5.1.1",
-        "better-sqlite3": "^11.9.1",
-        "cors": "^2.8.5",
-        "dotenv": "^16.5.0",
-        "express": "^5.1.0",
-        "express-rate-limit": "^8.3.2",
-        "jsonwebtoken": "^9.0.2",
-        "uuid": "^11.1.0",
-        "ws": "^8.18.2"
-      },
-      "devDependencies": {
-        "@types/bcrypt": "^5.0.2",
-        "@types/better-sqlite3": "^7.6.12",
-        "@types/cors": "^2.8.17",
-        "@types/express": "^5.0.2",
-        "@types/jsonwebtoken": "^9.0.10",
-        "@types/node": "^22.15.3",
-        "@types/uuid": "^10.0.0",
-        "@types/ws": "^8.18.1",
-        "tsx": "^4.19.4",
         "typescript": "^5.8.3"
       }
     }

--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -5,6 +5,7 @@ config();
 
 const defaultStateDir = resolve(process.cwd(), '.dev');
 const dataDir = process.env.DATA_DIR ?? (process.env.GOLDILOCKS_STATE_DIR ? resolve(process.env.GOLDILOCKS_STATE_DIR) : defaultStateDir);
+const sessionCookieMaxAgeMs = parseInt(process.env.SESSION_COOKIE_MAX_AGE_MS ?? '28800000', 10);
 
 function requireEnv(name: 'JWT_SECRET' | 'ENCRYPTION_KEY' | 'AGENT_SERVICE_SHARED_SECRET'): string {
   const value = process.env[name]?.trim();
@@ -26,9 +27,28 @@ export const CONFIG = {
   get jwtSecret(): string {
     return requireEnv('JWT_SECRET');
   },
-  jwtExpiresIn: '7d',
+  jwtExpiresIn: process.env.JWT_EXPIRES_IN ?? '8h',
+  jwtIssuer: 'goldilocks-gateway',
+  jwtAudience: 'goldilocks-api',
+  sessionCookieName: process.env.SESSION_COOKIE_NAME ?? 'goldilocks-session',
+  sessionCookieMaxAgeMs,
   get encryptionKey(): string {
     return requireEnv('ENCRYPTION_KEY');
+  },
+
+  get frontendUrl(): string {
+    return process.env.FRONTEND_URL ?? (this.isProd ? `http://localhost:${this.port}` : 'http://localhost:5173');
+  },
+
+  get allowedWebSocketOrigins(): string[] {
+    const origins = new Set<string>([this.frontendUrl]);
+
+    if (!this.isProd) {
+      origins.add('http://localhost:5173');
+      origins.add('http://127.0.0.1:5173');
+    }
+
+    return [...origins];
   },
 
   // k8s

--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -6,31 +6,31 @@ config();
 const defaultStateDir = resolve(process.cwd(), '.dev');
 const dataDir = process.env.DATA_DIR ?? (process.env.GOLDILOCKS_STATE_DIR ? resolve(process.env.GOLDILOCKS_STATE_DIR) : defaultStateDir);
 
+function requireEnv(name: 'JWT_SECRET' | 'ENCRYPTION_KEY' | 'AGENT_SERVICE_SHARED_SECRET'): string {
+  const value = process.env[name]?.trim();
+  if (!value) {
+    throw new Error(`FATAL: ${name} environment variable is required. Set it before starting the server.`);
+  }
+  return value;
+}
+
 export const CONFIG = {
   port: parseInt(process.env.PORT ?? '3000', 10),
   nodeEnv: process.env.NODE_ENV ?? 'development',
-  
+
   // Paths
   dataDir,
   workspaceRoot: process.env.WORKSPACE_ROOT ?? resolve(dataDir, 'workspaces'),
-  
+
   // Auth
   get jwtSecret(): string {
-    const secret = process.env.JWT_SECRET;
-    if (!secret && process.env.NODE_ENV === 'production') {
-      throw new Error('JWT_SECRET must be set in production');
-    }
-    return secret ?? 'dev-secret-change-in-production';
+    return requireEnv('JWT_SECRET');
   },
   jwtExpiresIn: '7d',
   get encryptionKey(): string {
-    const key = process.env.ENCRYPTION_KEY;
-    if (!key && process.env.NODE_ENV === 'production') {
-      throw new Error('ENCRYPTION_KEY must be set in production');
-    }
-    return key ?? 'dev-encryption-key-32-bytes!!!';
+    return requireEnv('ENCRYPTION_KEY');
   },
-  
+
   // k8s
   k8sNamespace: process.env.K8S_NAMESPACE ?? 'goldilocks',
   agentImage: process.env.AGENT_IMAGE ?? 'goldilocks-agent:latest',
@@ -38,21 +38,23 @@ export const CONFIG = {
   agentServiceUrl: process.env.AGENT_SERVICE_URL ?? 'http://agent-service:3001',
   agentServiceWsUrl: process.env.AGENT_SERVICE_WS_URL ?? 'ws://agent-service:3001/ws',
   get agentServiceSharedSecret(): string {
-    const secret = process.env.AGENT_SERVICE_SHARED_SECRET;
-    if (!secret && process.env.NODE_ENV === 'production') {
-      throw new Error('AGENT_SERVICE_SHARED_SECRET must be set in production');
-    }
-    return secret ?? 'dev-agent-service-secret';
+    return requireEnv('AGENT_SERVICE_SHARED_SECRET');
+  },
+
+  validateRequiredSecrets(): void {
+    void this.jwtSecret;
+    void this.encryptionKey;
+    void this.agentServiceSharedSecret;
   },
 
   get isDev() {
     return this.nodeEnv === 'development';
   },
-  
+
   get isProd() {
     return this.nodeEnv === 'production';
   },
-  
+
   get dbPath() {
     return resolve(this.dataDir, 'goldilocks.db');
   }

--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -6,6 +6,7 @@ config();
 const defaultStateDir = resolve(process.cwd(), '.dev');
 const dataDir = process.env.DATA_DIR ?? (process.env.GOLDILOCKS_STATE_DIR ? resolve(process.env.GOLDILOCKS_STATE_DIR) : defaultStateDir);
 const sessionCookieMaxAgeMs = parseInt(process.env.SESSION_COOKIE_MAX_AGE_MS ?? '28800000', 10);
+const defaultFileUploadMaxBytes = 50 * 1024 * 1024;
 
 function requireEnv(name: 'JWT_SECRET' | 'ENCRYPTION_KEY' | 'AGENT_SERVICE_SHARED_SECRET'): string {
   const value = process.env[name]?.trim();
@@ -38,6 +39,15 @@ export const CONFIG = {
 
   get frontendUrl(): string {
     return process.env.FRONTEND_URL ?? (this.isProd ? `http://localhost:${this.port}` : 'http://localhost:5173');
+  },
+
+  get fileUploadMaxBytes(): number {
+    const parsed = parseInt(process.env.FILE_UPLOAD_MAX_BYTES ?? `${defaultFileUploadMaxBytes}`, 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : defaultFileUploadMaxBytes;
+  },
+
+  get fileUploadBodyLimit(): string {
+    return `${this.fileUploadMaxBytes}b`;
   },
 
   get allowedWebSocketOrigins(): string[] {

--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -16,6 +16,10 @@ function requireEnv(name: 'JWT_SECRET' | 'ENCRYPTION_KEY' | 'AGENT_SERVICE_SHARE
   return value;
 }
 
+// as const prevents reassignment but preserves getter semantics.
+// Using a direct object literal (no `as const` on the entire object) because
+// `as const` on an object with getters can lose `this` binding in some
+// module bundlers and test runners.
 export const CONFIG = {
   port: parseInt(process.env.PORT ?? '3000', 10),
   nodeEnv: process.env.NODE_ENV ?? 'development',
@@ -85,7 +89,12 @@ export const CONFIG = {
     return this.nodeEnv === 'production';
   },
 
+  get adminEmails(): string[] {
+    if (!process.env.ADMIN_EMAILS) return [];
+    return process.env.ADMIN_EMAILS.split(',').map(e => e.trim().toLowerCase()).filter(Boolean);
+  },
+
   get dbPath() {
     return resolve(this.dataDir, 'goldilocks.db');
   }
-} as const;
+};

--- a/packages/config/src/crypto.ts
+++ b/packages/config/src/crypto.ts
@@ -4,20 +4,80 @@ import { CONFIG } from './config.js';
 const ALGORITHM = 'aes-256-gcm';
 const IV_LENGTH = 16;
 const AUTH_TAG_LENGTH = 16;
+const HKDF_INFO = 'goldilocks-api-keys';
+const HKDF_KEY_LENGTH = 32;
 
 /**
- * Derive a proper 32-byte key from the config encryption key using SHA-256.
+ * Derive the global V1 key from the config encryption key using SHA-256.
+ * Used as fallback when decrypting keys encrypted before per-user derivation.
  */
-function getKey(): Buffer {
+function getV1Key(): Buffer {
   return crypto.createHash('sha256').update(CONFIG.encryptionKey).digest();
 }
 
 /**
- * Encrypt a plaintext string using AES-256-GCM.
- * @returns iv:authTag:ciphertext (all hex encoded)
+ * Derive a per-user encryption subkey from the master key + user salt via HKDF.
  */
-export function encrypt(plaintext: string): string {
-  const key = getKey();
+export function deriveUserKey(keySalt: string): Buffer {
+  return Buffer.from(crypto.hkdfSync(
+    'sha256',
+    CONFIG.encryptionKey,
+    Buffer.from(keySalt, 'hex'),
+    HKDF_INFO,
+    HKDF_KEY_LENGTH,
+  ));
+}
+
+/**
+ * Derive a per-user key from the V1 (legacy) master key + user salt.
+ * Used when re-encrypting V1 keys that were originally encrypted with global key.
+ */
+function deriveV1UserKey(keySalt: string): Buffer {
+  const v1MasterKey = getV1Key();
+  return Buffer.from(crypto.hkdfSync(
+    'sha256',
+    v1MasterKey,
+    Buffer.from(keySalt, 'hex'),
+    HKDF_INFO,
+    HKDF_KEY_LENGTH,
+  ));
+}
+
+/**
+ * Get the appropriate decryption key based on the key version.
+ * - V1 (key_version = 1): Global SHA-256 derived key (legacy, no per-user isolation)
+ * - V2 (key_version = 2): Per-user HKDF-derived key
+ *
+ * When an optional ENCRYPTION_KEY_V1 is set and key_version is 1, the V1 fallback
+ * key is derived from ENCRYPTION_KEY_V1 instead of ENCRYPTION_KEY. This supports
+ * rotation: the current ENCRYPTION_KEY is V2, ENCRYPTION_KEY_V1 is the previous key.
+ */
+function getDecryptKey(keyVersion: number, keySalt?: string): Buffer {
+  if (keyVersion >= 2 && keySalt) {
+    // V2 or later: per-user derived key
+    return deriveUserKey(keySalt);
+  }
+
+  // V1: global key. If ENCRYPTION_KEY_V1 is set (rotation in progress),
+  // derive from the previous master key. Otherwise derive from current.
+  if (process.env.ENCRYPTION_KEY_V1) {
+    return crypto.createHash('sha256').update(process.env.ENCRYPTION_KEY_V1).digest();
+  }
+
+  return getV1Key();
+}
+
+export interface EncryptedValue {
+  encrypted: string;
+  keyVersion: number;
+}
+
+/**
+ * Encrypt a plaintext string using AES-256-GCM with a per-user derived key.
+ * @returns iv:authTag:ciphertext (all hex encoded), always at key_version 2.
+ */
+export function encrypt(plaintext: string, keySalt: string): EncryptedValue {
+  const key = deriveUserKey(keySalt);
   const iv = crypto.randomBytes(IV_LENGTH);
   const cipher = crypto.createCipheriv(ALGORITHM, key, iv, {
     authTagLength: AUTH_TAG_LENGTH,
@@ -27,20 +87,31 @@ export function encrypt(plaintext: string): string {
   ciphertext += cipher.final('hex');
   const authTag = cipher.getAuthTag().toString('hex');
 
-  return `${iv.toString('hex')}:${authTag}:${ciphertext}`;
+  return {
+    encrypted: `${iv.toString('hex')}:${authTag}:${ciphertext}`,
+    keyVersion: 2,
+  };
 }
 
 /**
  * Decrypt an encrypted string (iv:authTag:ciphertext, all hex encoded).
+ * Supports both V1 (global key) and V2 (per-user derived key) decryption.
+ *
+ * If decrypting a V1 key and keySalt is provided, the key is automatically
+ * re-encrypted with the per-user V2 key and the new EncryptedValue is returned
+ * alongside the plaintext for eager rotation.
  */
-export function decrypt(encrypted: string): string {
+export function decrypt(
+  encrypted: string,
+  options: { keyVersion: number; keySalt?: string },
+): { plaintext: string; reEncrypt?: EncryptedValue } {
   const parts = encrypted.split(':');
   if (parts.length !== 3) {
     throw new Error('Invalid encrypted format: expected iv:authTag:ciphertext');
   }
 
   const [ivHex, authTagHex, ciphertext] = parts;
-  const key = getKey();
+  const key = getDecryptKey(options.keyVersion, options.keySalt);
   const iv = Buffer.from(ivHex, 'hex');
   const authTag = Buffer.from(authTagHex, 'hex');
 
@@ -52,5 +123,19 @@ export function decrypt(encrypted: string): string {
   let plaintext = decipher.update(ciphertext, 'hex', 'utf8');
   plaintext += decipher.final('utf8');
 
-  return plaintext;
+  // Eager rotation: if we decrypted a V1 key and have a key_salt, re-encrypt as V2
+  if (options.keyVersion < 2 && options.keySalt) {
+    const reEncrypted = encrypt(plaintext, options.keySalt);
+    return { plaintext, reEncrypt: reEncrypted };
+  }
+
+  return { plaintext };
+}
+
+/**
+ * Generate a 32-byte random salt for a user's key derivation.
+ * Returns a hex string suitable for storage in the key_salt column.
+ */
+export function generateKeySalt(): string {
+  return crypto.randomBytes(32).toString('hex');
 }

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,2 +1,2 @@
 export { CONFIG } from './config.js';
-export { encrypt, decrypt } from './crypto.js';
+export { encrypt, decrypt, deriveUserKey, generateKeySalt } from './crypto.js';

--- a/packages/config/test/config.test.ts
+++ b/packages/config/test/config.test.ts
@@ -53,3 +53,31 @@ describe('CONFIG required secrets', () => {
     expect(() => CONFIG.validateRequiredSecrets()).not.toThrow();
   });
 });
+
+describe('CONFIG auth defaults', () => {
+  it('uses cookie-session auth defaults tuned for wave 2', async () => {
+    process.env.NODE_ENV = 'test';
+    process.env.JWT_SECRET = 'test-jwt-not-for-prod';
+    process.env.ENCRYPTION_KEY = 'test-encryption-key-32bytes!!';
+    process.env.AGENT_SERVICE_SHARED_SECRET = 'test-agent-shared-secret';
+
+    const { CONFIG } = await loadConfig();
+    expect(CONFIG.jwtExpiresIn).toBe('8h');
+    expect(CONFIG.sessionCookieName).toBe('goldilocks-session');
+    expect(CONFIG.jwtIssuer).toBe('goldilocks-gateway');
+    expect(CONFIG.jwtAudience).toBe('goldilocks-api');
+    expect(CONFIG.sessionCookieMaxAgeMs).toBe(28_800_000);
+  });
+
+  it('builds websocket origin allowlist from frontendUrl plus localhost dev origin', async () => {
+    process.env.NODE_ENV = 'development';
+    process.env.FRONTEND_URL = 'https://goldilocks.example';
+    process.env.JWT_SECRET = 'test-jwt-not-for-prod';
+    process.env.ENCRYPTION_KEY = 'test-encryption-key-32bytes!!';
+    process.env.AGENT_SERVICE_SHARED_SECRET = 'test-agent-shared-secret';
+
+    const { CONFIG } = await loadConfig();
+    expect(CONFIG.allowedWebSocketOrigins).toContain('https://goldilocks.example');
+    expect(CONFIG.allowedWebSocketOrigins).toContain('http://localhost:5173');
+  });
+});

--- a/packages/config/test/config.test.ts
+++ b/packages/config/test/config.test.ts
@@ -80,4 +80,16 @@ describe('CONFIG auth defaults', () => {
     expect(CONFIG.allowedWebSocketOrigins).toContain('https://goldilocks.example');
     expect(CONFIG.allowedWebSocketOrigins).toContain('http://localhost:5173');
   });
+
+  it('exposes configurable file upload limits', async () => {
+    process.env.NODE_ENV = 'test';
+    process.env.FILE_UPLOAD_MAX_BYTES = '1234';
+    process.env.JWT_SECRET = 'test-jwt-not-for-prod';
+    process.env.ENCRYPTION_KEY = 'test-encryption-key-32bytes!!';
+    process.env.AGENT_SERVICE_SHARED_SECRET = 'test-agent-shared-secret';
+
+    const { CONFIG } = await loadConfig();
+    expect(CONFIG.fileUploadMaxBytes).toBe(1234);
+    expect(CONFIG.fileUploadBodyLimit).toBe('1234b');
+  });
 });

--- a/packages/config/test/config.test.ts
+++ b/packages/config/test/config.test.ts
@@ -2,25 +2,54 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const originalEnv = { ...process.env };
 
+async function loadConfig() {
+  vi.resetModules();
+  return import('../src/index');
+}
+
 afterEach(() => {
   process.env = { ...originalEnv };
   vi.resetModules();
 });
 
-describe('CONFIG.agentServiceSharedSecret', () => {
-  it('uses the dev default outside production', async () => {
-    delete process.env.AGENT_SERVICE_SHARED_SECRET;
+describe('CONFIG required secrets', () => {
+  it('throws when JWT_SECRET is unset', async () => {
     process.env.NODE_ENV = 'development';
+    delete process.env.JWT_SECRET;
+    process.env.ENCRYPTION_KEY = 'test-encryption-key-32bytes!!';
+    process.env.AGENT_SERVICE_SHARED_SECRET = 'test-agent-shared-secret';
 
-    const { CONFIG } = await import('../src/index');
-    expect(CONFIG.agentServiceSharedSecret).toBe('dev-agent-service-secret');
+    const { CONFIG } = await loadConfig();
+    expect(() => CONFIG.jwtSecret).toThrow('FATAL: JWT_SECRET environment variable is required. Set it before starting the server.');
   });
 
-  it('throws in production when unset', async () => {
-    delete process.env.AGENT_SERVICE_SHARED_SECRET;
-    process.env.NODE_ENV = 'production';
+  it('throws when ENCRYPTION_KEY is unset', async () => {
+    process.env.NODE_ENV = 'development';
+    process.env.JWT_SECRET = 'test-jwt-not-for-prod';
+    delete process.env.ENCRYPTION_KEY;
+    process.env.AGENT_SERVICE_SHARED_SECRET = 'test-agent-shared-secret';
 
-    const { CONFIG } = await import('../src/index');
-    expect(() => CONFIG.agentServiceSharedSecret).toThrow('AGENT_SERVICE_SHARED_SECRET must be set in production');
+    const { CONFIG } = await loadConfig();
+    expect(() => CONFIG.encryptionKey).toThrow('FATAL: ENCRYPTION_KEY environment variable is required. Set it before starting the server.');
+  });
+
+  it('throws when AGENT_SERVICE_SHARED_SECRET is unset', async () => {
+    process.env.NODE_ENV = 'development';
+    process.env.JWT_SECRET = 'test-jwt-not-for-prod';
+    process.env.ENCRYPTION_KEY = 'test-encryption-key-32bytes!!';
+    delete process.env.AGENT_SERVICE_SHARED_SECRET;
+
+    const { CONFIG } = await loadConfig();
+    expect(() => CONFIG.agentServiceSharedSecret).toThrow('FATAL: AGENT_SERVICE_SHARED_SECRET environment variable is required. Set it before starting the server.');
+  });
+
+  it('validates all required secrets together', async () => {
+    process.env.NODE_ENV = 'test';
+    process.env.JWT_SECRET = 'test-jwt-not-for-prod';
+    process.env.ENCRYPTION_KEY = 'test-encryption-key-32bytes!!';
+    process.env.AGENT_SERVICE_SHARED_SECRET = 'test-agent-shared-secret';
+
+    const { CONFIG } = await loadConfig();
+    expect(() => CONFIG.validateRequiredSecrets()).not.toThrow();
   });
 });

--- a/packages/config/test/crypto.test.ts
+++ b/packages/config/test/crypto.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import crypto from 'crypto';
+
+const originalEnv = { ...process.env };
+
+// Set up env for config to load
+beforeEach(() => {
+  process.env.NODE_ENV = 'test';
+  process.env.JWT_SECRET = 'test-jwt-not-for-prod';
+  process.env.ENCRYPTION_KEY = 'test-encryption-key-32bytes!!';
+  process.env.AGENT_SERVICE_SHARED_SECRET = 'test-agent-shared-secret';
+});
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+  delete process.env.ENCRYPTION_KEY_V1;
+});
+
+describe('P8: Crypto key derivation', () => {
+  it('deriveUserKey produces different keys for different salts', async () => {
+    const { deriveUserKey, generateKeySalt } = await import('../src/crypto.js');
+    const salt1 = generateKeySalt();
+    const salt2 = generateKeySalt();
+    const key1 = deriveUserKey(salt1);
+    const key2 = deriveUserKey(salt2);
+    expect(key1.equals(key2)).toBe(false);
+  });
+
+  it('deriveUserKey produces the same key for the same salt', async () => {
+    const { deriveUserKey, generateKeySalt } = await import('../src/crypto.js');
+    const salt = generateKeySalt();
+    const key1 = deriveUserKey(salt);
+    const key2 = deriveUserKey(salt);
+    expect(key1.equals(key2)).toBe(true);
+  });
+
+  it('generateKeySalt returns 32-byte hex strings', async () => {
+    const { generateKeySalt } = await import('../src/crypto.js');
+    const salt = generateKeySalt();
+    expect(salt).toMatch(/^[0-9a-f]{64}$/);
+    expect(Buffer.from(salt, 'hex').length).toBe(32);
+  });
+
+  it('encrypt returns V2 encrypted value with keyVersion 2', async () => {
+    const { encrypt, generateKeySalt } = await import('../src/crypto.js');
+    const salt = generateKeySalt();
+    const result = encrypt('secret-api-key', salt);
+    expect(result.keyVersion).toBe(2);
+    expect(result.encrypted).toMatch(/^[0-9a-f]+:[0-9a-f]+:[0-9a-f]+$/);
+  });
+
+  it('decrypt can roundtrip V2 encrypted values', async () => {
+    const { encrypt, decrypt, generateKeySalt } = await import('../src/crypto.js');
+    const salt = generateKeySalt();
+    const plaintext = 'sk-test-roundtrip-key-12345';
+    const { encrypted } = encrypt(plaintext, salt);
+    const { plaintext: decrypted } = decrypt(encrypted, { keyVersion: 2, keySalt: salt });
+    expect(decrypted).toBe(plaintext);
+  });
+
+  it('decrypt rejects cross-salt decryption (user isolation)', async () => {
+    const { encrypt, decrypt, generateKeySalt } = await import('../src/crypto.js');
+    const salt1 = generateKeySalt();
+    const salt2 = generateKeySalt();
+    const { encrypted } = encrypt('secret', salt1);
+
+    expect(() => decrypt(encrypted, { keyVersion: 2, keySalt: salt2 })).toThrow();
+  });
+
+  it('decrypt supports V1 fallback without ENCRYPTION_KEY_V1', async () => {
+    const { decrypt } = await import('../src/crypto.js');
+    // V1 encryption uses global SHA-256 of ENCRYPTION_KEY
+    const masterKey = crypto.createHash('sha256').update(process.env.ENCRYPTION_KEY!).digest();
+    const iv = crypto.randomBytes(16);
+    const cipher = crypto.createCipheriv('aes-256-gcm', masterKey, iv, { authTagLength: 16 });
+    let ct = cipher.update('v1-secret', 'utf8', 'hex');
+    ct += cipher.final('hex');
+    const tag = cipher.getAuthTag().toString('hex');
+    const v1Encrypted = `${iv.toString('hex')}:${tag}:${ct}`;
+
+    const { plaintext } = decrypt(v1Encrypted, { keyVersion: 1 });
+    expect(plaintext).toBe('v1-secret');
+  });
+
+  it('decrypt eagerly re-encrypts V1 keys as V2 when keySalt is provided', async () => {
+    const { decrypt, generateKeySalt } = await import('../src/crypto.js');
+    // Create a V1 encrypted value
+    const masterKey = crypto.createHash('sha256').update(process.env.ENCRYPTION_KEY!).digest();
+    const iv = crypto.randomBytes(16);
+    const cipher = crypto.createCipheriv('aes-256-gcm', masterKey, iv, { authTagLength: 16 });
+    let ct = cipher.update('v1-to-v2-key', 'utf8', 'hex');
+    ct += cipher.final('hex');
+    const tag = cipher.getAuthTag().toString('hex');
+    const v1Encrypted = `${iv.toString('hex')}:${tag}:${ct}`;
+
+    const salt = generateKeySalt();
+    const { plaintext, reEncrypt } = decrypt(v1Encrypted, { keyVersion: 1, keySalt: salt });
+
+    expect(plaintext).toBe('v1-to-v2-key');
+    expect(reEncrypt).toBeTruthy();
+    expect(reEncrypt!.keyVersion).toBe(2);
+    expect(reEncrypt!.encrypted).toBeTruthy();
+
+    // Verify the re-encrypted value can be decrypted as V2
+    const { plaintext: decrypted2 } = decrypt(reEncrypt!.encrypted, { keyVersion: 2, keySalt: salt });
+    expect(decrypted2).toBe('v1-to-v2-key');
+  });
+
+  it('supports ENCRYPTION_KEY_V1 for key rotation fallback', async () => {
+    const { decrypt, generateKeySalt } = await import('../src/crypto.js');
+    // Encrypt with a different key (simulating the old master key)
+    const oldKey = 'old-master-key-for-rotation-test!';
+    process.env.ENCRYPTION_KEY_V1 = oldKey;
+    const v1MasterKey = crypto.createHash('sha256').update(oldKey).digest();
+    const iv = crypto.randomBytes(16);
+    const cipher = crypto.createCipheriv('aes-256-gcm', v1MasterKey, iv, { authTagLength: 16 });
+    let ct = cipher.update('rotated-secret', 'utf8', 'hex');
+    ct += cipher.final('hex');
+    const tag = cipher.getAuthTag().toString('hex');
+    const v1Encrypted = `${iv.toString('hex')}:${tag}:${ct}`;
+
+    // Decrypt with V1 using ENCRYPTION_KEY_V1 as the fallback
+    const { plaintext } = decrypt(v1Encrypted, { keyVersion: 1 });
+    expect(plaintext).toBe('rotated-secret');
+  });
+});

--- a/packages/contracts/src/websocket.ts
+++ b/packages/contracts/src/websocket.ts
@@ -1,9 +1,9 @@
 /**
- * Shared WebSocket message types used by both the frontend client and backend server.
+ * Shared browser WebSocket message types used by both the frontend client and gateway.
  *
- * Client → Server: auth, open, prompt, abort
- * Server → Client: auth_ok, auth_fail, ready, text_delta, thinking_delta,
- *                   tool_start, tool_update, tool_end, message_end, agent_end, error
+ * Client → Server: open, prompt, abort
+ * Server → Client: ready, text_delta, thinking_delta, tool_start,
+ *                   tool_update, tool_end, message_end, agent_end, error
  */
 
 // ---------------------------------------------------------------------------
@@ -11,7 +11,6 @@
 // ---------------------------------------------------------------------------
 
 export type ClientMessage =
-  | { type: 'auth'; token: string }
   | { type: 'open'; conversationId: string }
   | { type: 'prompt'; text: string; files?: string[] }
   | { type: 'abort' };
@@ -21,8 +20,6 @@ export type ClientMessage =
 // ---------------------------------------------------------------------------
 
 export type ServerMessage =
-  | { type: 'auth_ok'; userId: string }
-  | { type: 'auth_fail'; error: string }
   | { type: 'ready'; conversationId: string; messages?: HistoryMessage[] }
   | { type: 'text_delta'; delta: string }
   | { type: 'thinking_delta'; delta: string }

--- a/packages/data/src/migrations/003_revoked_tokens.sql
+++ b/packages/data/src/migrations/003_revoked_tokens.sql
@@ -1,0 +1,9 @@
+-- Wave 2 auth hardening: JWT revocation denylist
+
+CREATE TABLE IF NOT EXISTS revoked_tokens (
+  jti TEXT PRIMARY KEY,
+  expires_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_revoked_tokens_expires_at
+ON revoked_tokens (expires_at);

--- a/packages/data/src/migrations/004_failed_auth_attempts.sql
+++ b/packages/data/src/migrations/004_failed_auth_attempts.sql
@@ -1,0 +1,11 @@
+-- Wave 3 auth hardening: account lockout tracking
+
+CREATE TABLE IF NOT EXISTS failed_auth_attempts (
+  email TEXT PRIMARY KEY,
+  attempts INTEGER NOT NULL DEFAULT 0,
+  locked_until INTEGER,
+  last_attempt INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_failed_auth_attempts_locked_until
+ON failed_auth_attempts (locked_until);

--- a/packages/data/src/migrations/005_admin_role.sql
+++ b/packages/data/src/migrations/005_admin_role.sql
@@ -1,0 +1,4 @@
+-- Wave 4 P7: Admin role column
+
+ALTER TABLE users ADD COLUMN role TEXT NOT NULL DEFAULT 'user'
+  CHECK (role IN ('user', 'admin'));

--- a/packages/data/src/migrations/006_key_derivation.sql
+++ b/packages/data/src/migrations/006_key_derivation.sql
@@ -1,0 +1,5 @@
+-- Wave 4 P8: Per-user key derivation salt and key versioning
+
+ALTER TABLE users ADD COLUMN key_salt TEXT;
+
+ALTER TABLE api_keys ADD COLUMN key_version INTEGER NOT NULL DEFAULT 1;

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -20,8 +20,8 @@
     "@goldilocks/config": "file:../config",
     "@goldilocks/data": "file:../data",
     "@kubernetes/client-node": "^1.4.0",
-    "@mariozechner/pi-agent-core": "^0.64.0",
-    "@mariozechner/pi-coding-agent": "^0.64.0",
+    "@earendil-works/pi-agent-core": "^0.75.5",
+    "@earendil-works/pi-coding-agent": "^0.75.5",
     "ws": "^8.18.2"
   },
   "devDependencies": {

--- a/packages/runtime/src/pod-manager.ts
+++ b/packages/runtime/src/pod-manager.ts
@@ -109,6 +109,10 @@ export class PodManager {
   private ensuring = new Map<string, Promise<string>>();
   private idleTimer: ReturnType<typeof setInterval> | null = null;
 
+  getUserHomeHostPath(userId: string): string {
+    return resolve(HOMES_HOST_PATH, userId);
+  }
+
   constructor() {
     // Check for idle pods every 60s
     this.idleTimer = setInterval(() => this.evictIdle(), 60_000);
@@ -475,7 +479,7 @@ export class PodManager {
           {
             name: 'home',
             hostPath: {
-              path: `${HOMES_HOST_PATH}/${userId}`,
+              path: this.getUserHomeHostPath(userId),
               type: 'DirectoryOrCreate',
             },
           },

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -1,16 +1,16 @@
 import {
   AuthStorage,
   createAgentSession,
-  createBashTool,
-  createEditTool,
-  createReadTool,
-  createWriteTool,
+  createBashToolDefinition,
+  createEditToolDefinition,
+  createReadToolDefinition,
+  createWriteToolDefinition,
+  defineTool,
   getAgentDir,
   ModelRegistry,
   SessionManager as PiSessionManager,
   type AgentSession,
-} from '@mariozechner/pi-coding-agent';
-import type { AgentTool } from '@mariozechner/pi-agent-core';
+} from '@earendil-works/pi-coding-agent';
 import { resolve } from 'path';
 import { getDb } from '@goldilocks/data';
 import { decrypt } from '@goldilocks/config';
@@ -46,11 +46,6 @@ interface ApiKeyRow {
   provider: string;
   encrypted_key: string;
   key_version: number;
-}
-
-interface AgentSessionWithToolOverride {
-  _baseToolsOverride?: Record<string, AgentTool<any>>;
-  _buildRuntime?: (options?: { activeToolNames?: string[]; includeAllExtensionTools?: boolean }) => void;
 }
 
 class SessionManager {
@@ -245,12 +240,12 @@ class SessionManager {
       ? PiSessionManager.open(resolve(requestedSessionPath), sessionDir)
       : PiSessionManager.create(getRemoteWorkspaceCwd(), sessionDir);
 
-    const baseTools = {
-      read: createReadTool(getRemoteWorkspaceCwd(), { operations: operations.read }),
-      bash: createBashTool(getRemoteWorkspaceCwd(), { operations: operations.bash }),
-      edit: createEditTool(getRemoteWorkspaceCwd(), { operations: operations.edit }),
-      write: createWriteTool(getRemoteWorkspaceCwd(), { operations: operations.write }),
-    };
+    const baseToolDefinitions = [
+      defineTool(createReadToolDefinition(getRemoteWorkspaceCwd(), { operations: operations.read })),
+      defineTool(createBashToolDefinition(getRemoteWorkspaceCwd(), { operations: operations.bash })),
+      defineTool(createEditToolDefinition(getRemoteWorkspaceCwd(), { operations: operations.edit })),
+      defineTool(createWriteToolDefinition(getRemoteWorkspaceCwd(), { operations: operations.write })),
+    ];
     const activeToolNames = ['read', 'bash', 'edit', 'write'] as const;
 
     const { session } = await createAgentSession({
@@ -259,18 +254,9 @@ class SessionManager {
       authStorage,
       modelRegistry,
       sessionManager,
-      tools: activeToolNames.map((name) => baseTools[name]),
-    });
-
-    // pi SDK 0.64.0 only uses options.tools to pick active tool names; it still
-    // builds the default local tool runtime internally. Force the runtime to use
-    // our pod-backed tools instead, then rebuild the runtime so all executions go
-    // through k8s exec against the user's sandbox pod.
-    const sessionWithOverride = session as unknown as AgentSessionWithToolOverride;
-    sessionWithOverride._baseToolsOverride = baseTools;
-    sessionWithOverride._buildRuntime?.({
-      activeToolNames: [...activeToolNames],
-      includeAllExtensionTools: true,
+      noTools: 'builtin',
+      tools: [...activeToolNames],
+      customTools: baseToolDefinitions,
     });
 
     const context: UserSessionContext = {

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -45,6 +45,7 @@ interface UserSessionContext {
 interface ApiKeyRow {
   provider: string;
   encrypted_key: string;
+  key_version: number;
 }
 
 interface AgentSessionWithToolOverride {
@@ -321,17 +322,31 @@ class SessionManager {
   private getUserApiKeys(userId: string): ApiKeyRow[] {
     const db = getDb();
     return db.prepare(
-      'SELECT provider, encrypted_key FROM api_keys WHERE user_id = ? ORDER BY provider ASC'
+      'SELECT provider, encrypted_key, key_version FROM api_keys WHERE user_id = ? ORDER BY provider ASC'
     ).all(userId) as ApiKeyRow[];
   }
 
   private syncAuthStorage(authStorage: AuthStorage, rows: ApiKeyRow[], userId: string): void {
+    const db = getDb();
+    const userRow = db.prepare('SELECT key_salt FROM users WHERE id = ?').get(userId) as { key_salt: string | null } | undefined;
+    const keySalt = userRow?.key_salt ?? undefined;
     const providers = new Set<string>();
 
     for (const row of rows) {
       try {
-        authStorage.setRuntimeApiKey(row.provider, decrypt(row.encrypted_key));
+        const { plaintext, reEncrypt } = decrypt(row.encrypted_key, {
+          keyVersion: row.key_version ?? 1,
+          keySalt,
+        });
+        authStorage.setRuntimeApiKey(row.provider, plaintext);
         providers.add(row.provider);
+
+        // Eager rotation: V1 keys auto-upgraded to V2
+        if (reEncrypt) {
+          db.prepare(
+            'UPDATE api_keys SET encrypted_key = ?, key_version = ? WHERE user_id = ? AND provider = ?'
+          ).run(reEncrypt.encrypted, reEncrypt.keyVersion, userId, row.provider);
+        }
       } catch (err) {
         console.error(`Failed to decrypt ${row.provider} key for user ${userId}:`, err);
       }

--- a/packages/runtime/test/pod-tool-operations.test.ts
+++ b/packages/runtime/test/pod-tool-operations.test.ts
@@ -1,6 +1,6 @@
 import { PassThrough } from 'stream';
 import { describe, expect, it, vi } from 'vitest';
-import { createEditTool, createWriteTool } from '@mariozechner/pi-coding-agent';
+import { createEditTool, createWriteTool } from '@earendil-works/pi-coding-agent';
 import { createPodToolOperations } from '../src/pod-tool-operations';
 
 interface ExecStep {

--- a/packages/runtime/test/session-manager.test.ts
+++ b/packages/runtime/test/session-manager.test.ts
@@ -76,6 +76,8 @@ vi.mock('@goldilocks/data', () => ({
   getDb: () => ({
     prepare: () => ({
       all: () => [],
+      get: () => undefined,
+      run: () => ({ changes: 0 }),
     }),
   }),
 }));
@@ -83,6 +85,8 @@ vi.mock('@goldilocks/data', () => ({
 vi.mock('@goldilocks/config', () => ({
   CONFIG: { dataDir: '/tmp/goldilocks-test' },
   decrypt: (value: string) => value,
+  encrypt: (value: string, _salt: string) => ({ encrypted: value, keyVersion: 2 }),
+  generateKeySalt: () => 'a'.repeat(64),
 }));
 vi.mock('../src/pod-manager.js', () => ({
   PodManager: class PodManager {

--- a/packages/runtime/test/session-manager.test.ts
+++ b/packages/runtime/test/session-manager.test.ts
@@ -51,7 +51,7 @@ const createPodToolOperationsMock = vi.fn(() => ({
   write: { transport: 'write' },
 }));
 
-vi.mock('@mariozechner/pi-coding-agent', () => {
+vi.mock('@earendil-works/pi-coding-agent', () => {
   return {
     AuthStorage: {
       inMemory: () => ({ setRuntimeApiKey: vi.fn(), removeRuntimeApiKey: vi.fn(), list: () => [] }),

--- a/scripts/promote-admin.js
+++ b/scripts/promote-admin.js
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+/**
+ * Promote or demote a user's admin role.
+ *
+ * Usage:
+ *   node scripts/promote-admin.js admin@example.com        # promote to admin
+ *   node scripts/promote-admin.js admin@example.com --user   # demote to user
+ *
+ * Requires DATA_DIR (or GOLDILOCKS_STATE_DIR) and ENCRYPTION_KEY env vars to
+ * load the database config. JWT_SECRET and AGENT_SERVICE_SHARED_SECRET are
+ * also required by config validation but not used by this script.
+ */
+
+import { config } from 'dotenv';
+import { resolve } from 'path';
+import Database from 'better-sqlite3';
+
+config();
+
+// Load the same config resolution as the app (needed for db path)
+const dataDir = process.env.DATA_DIR ?? (process.env.GOLDILOCKS_STATE_DIR ? resolve(process.env.GOLDILOCKS_STATE_DIR) : resolve(process.cwd(), '.dev'));
+
+// Ensure required secrets exist so config doesn't throw
+for (const key of ['JWT_SECRET', 'ENCRYPTION_KEY', 'AGENT_SERVICE_SHARED_SECRET']) {
+  if (!process.env[key]) {
+    process.env[key] = 'placeholder-for-promote-script';
+  }
+}
+
+const dbPath = resolve(dataDir, 'goldilocks.db');
+
+const email = process.argv[2];
+const targetRole = process.argv.includes('--user') ? 'user' : 'admin';
+
+if (!email) {
+  console.error('Usage: node scripts/promote-admin.js <email> [--user]');
+  console.error('  Promotes to admin by default. Use --user to demote back to regular user.');
+  process.exit(1);
+}
+
+try {
+  const db = new Database(dbPath);
+
+  const user = db.prepare('SELECT id, email, role FROM users WHERE email = ?').get(email) as
+    | { id: string; email: string; role: string }
+    | undefined;
+
+  if (!user) {
+    console.error(`No user found with email: ${email}`);
+    process.exit(1);
+  }
+
+  if (user.role === targetRole) {
+    console.log(`User ${email} is already '${targetRole}'. No change needed.`);
+    process.exit(0);
+  }
+
+  db.prepare('UPDATE users SET role = ? WHERE id = ?').run(targetRole, user.id);
+  console.log(`User ${email} role changed: '${user.role}' → '${targetRole}'`);
+  console.log('Note: The user must log in again to get a JWT with the updated role.');
+
+  db.close();
+} catch (err) {
+  console.error('Failed to update role:', err);
+  process.exit(1);
+}

--- a/scripts/rotate-encryption-keys.js
+++ b/scripts/rotate-encryption-keys.js
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+/**
+ * Eagerly rotate all API key encryption from V1 (global key) to V2 (per-user derived keys).
+ *
+ * This script is idempotent — keys already at V2 are skipped.
+ *
+ * Prerequisites:
+ *   - ENCRYPTION_KEY set to the NEW (V2) master key
+ *   - ENCRYPTION_KEY_V1 set to the OLD (V1) master key (if a rotation happened)
+ *   - If no master key rotation happened, set ENCRYPTION_KEY_V1 = ENCRYPTION_KEY
+ *   - DATA_DIR or GOLDILOCKS_STATE_DIR pointing to the data directory
+ *   - JWT_SECRET and AGENT_SERVICE_SHARED_SECRET set (config validation)
+ *
+ * Usage:
+ *   ENCRYPTION_KEY=new_key ENCRYPTION_KEY_V1=old_key node scripts/rotate-encryption-keys.js
+ */
+
+import { config } from 'dotenv';
+import { resolve } from 'path';
+import crypto from 'crypto';
+import Database from 'better-sqlite3';
+
+config();
+
+const dataDir = process.env.DATA_DIR ?? (process.env.GOLDILOCKS_STATE_DIR ? resolve(process.env.GOLDILOCKS_STATE_DIR) : resolve(process.cwd(), '.dev'));
+
+// Ensure required secrets exist so config doesn't throw
+for (const key of ['JWT_SECRET', 'AGENT_SERVICE_SHARED_SECRET']) {
+  if (!process.env[key]) {
+    process.env[key] = 'placeholder-for-rotation-script';
+  }
+}
+
+const ALGORITHM = 'aes-256-gcm';
+const IV_LENGTH = 16;
+const AUTH_TAG_LENGTH = 16;
+const HKDF_INFO = 'goldilocks-api-keys';
+const HKDF_KEY_LENGTH = 32;
+
+function getV1Key(): Buffer {
+  const v1EnvKey = process.env.ENCRYPTION_KEY_V1;
+  const masterKey = v1EnvKey || process.env.ENCRYPTION_KEY;
+  if (!masterKey) {
+    throw new Error('ENCRYPTION_KEY (and optionally ENCRYPTION_KEY_V1) must be set');
+  }
+  return crypto.createHash('sha256').update(masterKey).digest();
+}
+
+function getV2Key(): Buffer {
+  if (!process.env.ENCRYPTION_KEY) {
+    throw new Error('ENCRYPTION_KEY must be set');
+  }
+  return crypto.createHash('sha256').update(process.env.ENCRYPTION_KEY).digest();
+}
+
+function deriveV2UserKey(keySalt: string): Buffer {
+  const v2MasterKey = getV2Key();
+  return crypto.hkdfSync('sha256', v2MasterKey, Buffer.from(keySalt, 'hex'), HKDF_INFO, HKDF_KEY_LENGTH);
+}
+
+function decryptV1(encrypted: string): string {
+  const parts = encrypted.split(':');
+  if (parts.length !== 3) throw new Error('Invalid encrypted format');
+
+  const [ivHex, authTagHex, ciphertext] = parts;
+  const key = getV1Key();
+  const iv = Buffer.from(ivHex, 'hex');
+  const authTag = Buffer.from(authTagHex, 'hex');
+
+  const decipher = crypto.createDecipheriv(ALGORITHM, key, iv, { authTagLength: AUTH_TAG_LENGTH });
+  decipher.setAuthTag(authTag);
+
+  let plaintext = decipher.update(ciphertext, 'hex', 'utf8');
+  plaintext += decipher.final('utf8');
+  return plaintext;
+}
+
+function encryptV2(plaintext: string, keySalt: string): string {
+  const key = deriveV2UserKey(keySalt);
+  const iv = crypto.randomBytes(IV_LENGTH);
+  const cipher = crypto.createCipheriv(ALGORITHM, key, iv, { authTagLength: AUTH_TAG_LENGTH });
+
+  let ciphertext = cipher.update(plaintext, 'utf8', 'hex');
+  ciphertext += cipher.final('hex');
+  const authTag = cipher.getAuthTag().toString('hex');
+
+  return `${iv.toString('hex')}:${authTag}:${ciphertext}`;
+}
+
+function generateKeySalt(): string {
+  return crypto.randomBytes(32).toString('hex');
+}
+
+// Main
+try {
+  if (!process.env.ENCRYPTION_KEY) {
+    console.error('ERROR: ENCRYPTION_KEY must be set (the current/new master key)');
+    process.exit(1);
+  }
+
+  const dbPath = resolve(dataDir, 'goldilocks.db');
+  const db = new Database(dbPath);
+
+  // Find all V1 keys
+  const v1Keys = db.prepare(
+    `SELECT ak.user_id, ak.provider, ak.encrypted_key, u.key_salt
+     FROM api_keys ak
+     JOIN users u ON ak.user_id = u.id
+     WHERE ak.key_version = 1`
+  ).all() as { user_id: string; provider: string; encrypted_key: string; key_salt: string | null }[];
+
+  if (v1Keys.length === 0) {
+    console.log('No V1 keys found. All keys are already at V2 or the table is empty.');
+    db.close();
+    process.exit(0);
+  }
+
+  console.log(`Found ${v1Keys.length} V1 key(s) to rotate.`);
+
+  let rotated = 0;
+  let failed = 0;
+  const ensureSalt = db.prepare('UPDATE users SET key_salt = ? WHERE id = ? AND key_salt IS NULL');
+  const rotateKey = db.prepare(
+    'UPDATE api_keys SET encrypted_key = ?, key_version = 2 WHERE user_id = ? AND provider = ?'
+  );
+
+  const tx = db.transaction(() => {
+    for (const row of v1Keys) {
+      try {
+        // Ensure user has a key_salt
+        let keySalt = row.key_salt;
+        if (!keySalt) {
+          keySalt = generateKeySalt();
+          ensureSalt.run(keySalt, row.user_id);
+        }
+
+        const plaintext = decryptV1(row.encrypted_key);
+        const newEncrypted = encryptV2(plaintext, keySalt);
+        rotateKey.run(newEncrypted, row.user_id, row.provider);
+        rotated++;
+        console.log(`  ✓ Rotated ${row.provider} for user ${row.user_id.slice(0, 8)}...`);
+      } catch (err) {
+        failed++;
+        console.error(`  ✗ Failed to rotate ${row.provider} for user ${row.user_id.slice(0, 8)}...:`, err);
+      }
+    }
+  });
+
+  tx();
+
+  console.log(`\nRotation complete: ${rotated} rotated, ${failed} failed.`);
+
+  if (failed > 0) {
+    console.error('\nWARNING: Some keys failed to rotate. Ensure ENCRYPTION_KEY_V1 is set correctly.');
+  }
+
+  // Verify no V1 keys remain
+  const remaining = db.prepare('SELECT COUNT(*) as count FROM api_keys WHERE key_version = 1').get() as { count: number };
+  if (remaining.count > 0) {
+    console.error(`\nWARNING: ${remaining.count} V1 key(s) still remain in the database.`);
+  } else {
+    console.log('All keys are now at V2. You may remove ENCRYPTION_KEY_V1 from the environment.');
+  }
+
+  db.close();
+} catch (err) {
+  console.error('Rotation failed:', err);
+  process.exit(1);
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,8 @@ export default defineConfig({
       'apps/frontend/src/**/*.test.ts',
     ],
     exclude: ['node_modules/**'],
+    fileParallelism: false,
+    hookTimeout: 30_000,
     reporters: process.env.CI ? ['verbose'] : ['default'],
   },
 });


### PR DESCRIPTION
## Wave 4: Infrastructure Hardening (P7, P8, P9)

Implements the next phase of the security hardening roadmap, branched off Wave 3.

### P7: Admin role & metrics protection
- **Schema**: `role TEXT NOT NULL DEFAULT 'user' CHECK (role IN ('user', 'admin'))` on users table (migration 005)
- **JWT**: `role` claim included in all tokens; `AuthUser` type extended
- **Middleware**: `requireAdmin` guard applied to `/api/metrics` (was previously unauthenticated — Finding #7)
- **Auto-promotion**: `ADMIN_EMAILS` env var grants admin on register/login
- **CLI**: `scripts/promote-admin.js` for one-off role changes

### P8: API key encryption rotation
- **Per-user key derivation**: HKDF(master key + user-specific salt) produces unique encryption subkeys per user (migration 006 adds `key_salt` to users, `key_version` to api_keys)
- **Key versioning**: V1 = global SHA-256 key, V2 = per-user HKDF key. New keys always store as V2.
- **Eager rotation**: Decrypting a V1 key with a user's salt available automatically re-encrypts as V2
- **ENCRYPTION_KEY_V1 fallback**: Supports rotation where current key is V2, previous key is V1
- **Rotation script**: `scripts/rotate-encryption-keys.js` for batch V1→V2 migration
- **Session manager**: Updated decrypt calls to use versioned keys; V1 keys are lazily upgraded on access

### P9: Audit trail & structured logging
- **audit-logger.ts**: JSON lines to stdout (Kubernetes-native pattern)
- **Instrumented events**: `auth.login.success`, `auth.login.failure`, `auth.logout`, `auth.register.success`, `settings.api-key.store`, `settings.api-key.delete`, `settings.update`, `admin.action`
- **Never logs key values** — only metadata (provider name, changed settings keys)
- **Lockout helpers**: `pruneExpiredLockouts()` called on login; `getActiveLockouts()` for monitoring dashboards

### Bug fix (pre-existing)
Removed `as const` from CONFIG object — `allowedWebSocketOrigins` getter was not iterable under vitest module transforms.

### Tests
- 16 new integration tests for P7/P8/P9
- 9 new crypto unit tests for key derivation and rotation
- Total: 157 tests passing

### Depends on
- #17 (Wave 1) — secret startup guards
- #18 (Wave 2) — auth refactor (P7 builds on `verifyToken`/JWT changes)
- #19 (Wave 3) — rate limiting (P9 builds on lockout infrastructure)